### PR TITLE
Fast/Slow feature, proj settings, memory violation fixes

### DIFF
--- a/LR2/En_fileutil.cpp
+++ b/LR2/En_fileutil.cpp
@@ -940,7 +940,7 @@ void MD5byte(char **iStr, uint len, char *oByte){
 }
 
 //443ff0
-char md5str[32];
+char md5str[33];
 char* MD5str(char *iStr) {
 	char* buf;
 	unsigned char md5buf[16];

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -253,8 +253,10 @@ int InitGameplay(gameplay *gp, CONFIG_PLAY *cfg) {
 		int prevTotalnote = gp->player[p].total_note;
 		int prevNotecurrent = gp->player[p].note_current2;
 		double prevHP = gp->player[p].HP;
+		EXTENDEDPLAYERSTATS extendedStatsCourse = gp->player[p].extendedStatsCourse;
+		std::array<EXTENDEDPLAYERSTATS, 20> extendedColumnStatsCourse = gp->player[p].extendedColumnStatsCourse;
 
-		memset(&gp->player[p], 0, sizeof(PLAYERSTATUS));
+		gp->player[p] = PLAYERSTATUS();
 
 		if (gp->courseStageNow > 0) {
 			gp->player[p].HP = prevHP;
@@ -265,6 +267,8 @@ int InitGameplay(gameplay *gp, CONFIG_PLAY *cfg) {
 			memcpy(gp->player[p].judgecount2, prevJudge, 6 * sizeof(int));
 			gp->player[p].total_note = prevTotalnote;
 			gp->player[p].note_current2 = prevNotecurrent;
+			gp->player[p].extendedStatsCourse = extendedStatsCourse;
+			gp->player[p].extendedColumnStatsCourse = extendedColumnStatsCourse;
 		}
 	}
 
@@ -631,7 +635,7 @@ int InitGameplay_retry(gameplay *gp, AUDIO *snd, game *g) {
 	tempCount = gp->player[0].totalnotes;
 	memcpy(tempDmg, &gp->player[0].judge_damage, sizeof(tempDmg));
 	memcpy(tempTime, &gp->player[0].judgetime, sizeof(tempTime));
-	memset(&gp->player[0], 0, sizeof(PLAYERSTATUS));
+	gp->player[0] = PLAYERSTATUS();
 	memcpy(&gp->player[0].judge_damage, tempDmg, sizeof(tempDmg));
 	memcpy(&gp->player[0].judgetime, tempTime, sizeof(tempTime));
 	gp->player[0].totalnotes = tempCount;
@@ -639,7 +643,7 @@ int InitGameplay_retry(gameplay *gp, AUDIO *snd, game *g) {
 	tempCount = gp->player[1].totalnotes;
 	memcpy(tempDmg, &gp->player[1].judge_damage, sizeof(tempDmg));
 	memcpy(tempTime, &gp->player[1].judgetime, sizeof(tempTime));
-	memset(&gp->player[1], 0, sizeof(PLAYERSTATUS));
+	gp->player[1] = PLAYERSTATUS();
 	memcpy(&gp->player[1].judge_damage, tempDmg, sizeof(tempDmg));
 	memcpy(&gp->player[1].judgetime, tempTime, sizeof(tempTime));
 	gp->player[1].totalnotes = tempCount;

--- a/LR2/LR2_replay.cpp
+++ b/LR2/LR2_replay.cpp
@@ -717,7 +717,7 @@ int SetReplayConfig(REPLAY *re, game *g, AUDIO *aud, gameplay *gp, inputStructur
 	memcpy(&re->cfg, &g->config.play, sizeof(CONFIG_PLAY));
 	memcpy(&re->aud, &aud->param, sizeof(AUDIO_PARAM));
 
-	while (re->data[re->count].timing == 0 && re->count < re->max) {
+	while (re->count < re->max && re->data[re->count].timing == 0) {
 		ReplayDataToInput(&re->data[re->count], g, aud, gp, in, T);
 		re->count++;
 	}
@@ -728,7 +728,7 @@ int SetReplayConfig(REPLAY *re, game *g, AUDIO *aud, gameplay *gp, inputStructur
 //4c2310
 int ReplayToInput(REPLAY *rp, game *g, AUDIO *aud, gameplay *gp, inputStructure *is, Timer *T){
 	if (rp->count < rp->max) {
-		while (rp->data[rp->count].timing < GetTimeLapse(41, T) && rp->count < rp->max) {
+		while (rp->count < rp->max && rp->data[rp->count].timing < GetTimeLapse(41, T)) {
 			ReplayDataToInput(rp->data + rp->count, g, aud, gp, is, T);
 			rp->count++;
 		}

--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -1854,7 +1854,8 @@ int LoadScene(skstruct *sk, CSTR skinfile, int p5, char font) {
 	(sk->adjust).note_1p_y = tsku.adjust.note_1p_y;
 	(sk->adjust).note_2p_x = tsku.adjust.note_2p_x;
 	(sk->adjust).note_2p_y = tsku.adjust.note_2p_y;
-	for (int i = 0; i < 20; i++) {
+	constexpr size_t s = offsetof(SkinUser, SkinUser::customize_value);
+	for (int i = 0; i < 8; i++) {
 		int t = tsku.customize_value[i * 5];
 		if (t > 899 && t < 1000) sk->op[t] = 1;
 		t = tsku.customize_value[i * 5 + 1];

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -2041,23 +2041,47 @@ uint SetObjectValue_Num(game *g, int op) {
 		case 200:
 			return g->net.rankingData.rankingCount;
 		case 201:
+			if (g->procSelecter == 4) {
+				return g->gameplay.player[0].extendedStats.lastHitOffset;
+			}
 			return g->net.rankingData.totalPlaycount;
 
 		case 210:
+			if (g->procSelecter == 4) {
+				return g->gameplay.player[0].extendedStats.lastFastSlow;
+			}
 			return g->net.rankingData.clearPlayers[1];
 		case 211:
+			if (g->procSelecter == 4) {
+				return g->gameplay.player[1].extendedStats.lastFastSlow;
+			}
 			if (g->net.rankingData.rankingCount != 0) {
 				return (g->net.rankingData.clearPlayers[1] * 100) / g->net.rankingData.rankingCount;
 			}
 			break;
 		case 212:
+			if (g->procSelecter == 4 || g->procSelecter == 5) {
+				return g->gameplay.player[0].extendedStats.fast;
+			}
+			if (g->procSelecter == 13) {
+				return g->gameplay.player[0].extendedStatsCourse.fast;
+			}
 			return g->net.rankingData.clearPlayers[2];
 		case 213:
+			if (g->procSelecter == 4) {
+				return g->gameplay.player[1].extendedStats.lastHitOffset;
+			}
 			if (g->net.rankingData.rankingCount != 0) {
 				return (g->net.rankingData.clearPlayers[2] * 100) / g->net.rankingData.rankingCount;
 			}
 			break;
 		case 214:
+			if (g->procSelecter == 4 || g->procSelecter == 5) {
+				return g->gameplay.player[0].extendedStats.slow;
+			}
+			if (g->procSelecter == 13) {
+				return g->gameplay.player[0].extendedStatsCourse.slow;
+			}
 			return g->net.rankingData.clearPlayers[3];
 		case 215:
 			if (g->net.rankingData.rankingCount != 0) {
@@ -2065,13 +2089,25 @@ uint SetObjectValue_Num(game *g, int op) {
 			}
 			break;
 		case 216:
+			if (g->procSelecter == 4 || g->procSelecter == 5) {
+				return g->gameplay.player[0].extendedStats.cb;
+			}
+			if (g->procSelecter == 13) {
+				return g->gameplay.player[0].extendedStatsCourse.cb;
+			}
 			return g->net.rankingData.clearPlayers[4];
 		case 217:
+			if (g->procSelecter == 4) {
+				return g->gameplay.player[0].totalnotes;
+			}
 			if (g->net.rankingData.rankingCount != 0) {
 				return (g->net.rankingData.clearPlayers[4] * 100) / g->net.rankingData.rankingCount;
 			}
 			break;
 		case 218:
+			if (g->procSelecter == 4) {
+				return g->gameplay.player[0].note_current;
+			}
 			return g->net.rankingData.clearPlayers[5];
 		case 219:
 			if (g->net.rankingData.rankingCount != 0) {

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -7,6 +7,7 @@
 
 #include <windows.h>
 #include <string>
+#include <thread>
 
 #include "DXlib/DxLib.h"
 #include "tinyxml/tinyxml.h"
@@ -22,6 +23,9 @@ extern "C" {
 using namespace std;
 
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow) {
+#ifdef _DEBUG
+	while (!IsDebuggerPresent()) std::this_thread::sleep_for(std::chrono::milliseconds(200));
+#endif
 
 	int loadingGrHandle;
 

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -668,7 +668,11 @@ int JudgeToScore(int judge, game *g, int player, int lane, char isReplay) {
 //418850
 int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 	NoteStruct &note = g->gameplay.bmsobj_note[lane].notes[g->gameplay.bmsobj_note[lane].note_count];
-
+	EXTENDEDPLAYERSTATS& extendedStats = g->gameplay.player[player].extendedStats;
+	EXTENDEDPLAYERSTATS& extendedColumnStats = g->gameplay.player[player].extendedColumnStats[lane];
+	EXTENDEDPLAYERSTATS& extendedStatsCourse = g->gameplay.player[player].extendedStatsCourse;
+	EXTENDEDPLAYERSTATS& extendedColumnStatsCourse = g->gameplay.player[player].extendedColumnStatsCourse[lane];
+	int& lastOffsetColumnIdx = g->gameplay.player[player].lastJudgedColumnIdx;
 	if (note.mine > 0) {
 		if (keypress == 1 && note.realTiming - (double)timing < (double)g->gameplay.player[player].judgetime[4]) {
 			ApplyJudgeMine(0, g, player, lane, note.mine);
@@ -700,11 +704,23 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			g->gameplay.bmsobj_note[lane].noteVal = note.val;
 			note.active = -1;
 			g->gameplay.bmsobj_note[lane].note_count++;
+			auto increment_extended = [](EXTENDEDPLAYERSTATS& stats) {
+				stats.lpr++;
+				stats.cb++;
+				stats.noteCount++;
+				stats.lastFastSlow = 2;
+			};
+			increment_extended(extendedStats);
+			increment_extended(extendedColumnStats);
+			increment_extended(extendedStatsCourse);
+			increment_extended(extendedColumnStatsCourse);
 			return 0;
 		}
 		if (keypress != 1) return 0;
 
-		int gap = abs(timing - (int)note.realTiming);
+		int offset = timing - (int)note.realTiming;
+		int gap = std::abs(offset);
+		bool isFast = offset < 0;
 
 		if (gap <= g->gameplay.player[player].judgetime[5] && g->gameplay.player[player].note_current < g->gameplay.player[player].totalnotes) {
 			g->gameplay.autojudge_midcount++;
@@ -715,6 +731,17 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			note.active = -1;
 			g->gameplay.bmsobj_note[lane].note_count++;
 			SetTimeLapse(50 + lane, &g->timer1);
+			auto increment_extended = [](EXTENDEDPLAYERSTATS& stats, bool isFast, int offset) {
+				isFast ? stats.epg++ : stats.lpg++;
+				stats.lastFastSlow = 0;
+				stats.noteCount++;
+				stats.lastHitOffset = offset;
+			};
+			increment_extended(extendedStats, isFast, offset);
+			increment_extended(extendedColumnStats, isFast, offset);
+			increment_extended(extendedStatsCourse, isFast, offset);
+			increment_extended(extendedColumnStatsCourse, isFast, offset);
+			lastOffsetColumnIdx = lane;
 			return 1;
 		}
 		if (gap <= g->gameplay.player[player].judgetime[4] && g->gameplay.player[player].note_current < g->gameplay.player[player].totalnotes) {
@@ -726,6 +753,18 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			note.active = -1;
 			g->gameplay.bmsobj_note[lane].note_count++;
 			SetTimeLapse(50 + lane, &g->timer1);
+			auto increment_extended = [](EXTENDEDPLAYERSTATS& stats, bool isFast, int offset) {
+				isFast ? stats.egr++ : stats.lgr++;
+				isFast ? stats.fast++ : stats.slow++;
+				stats.lastFastSlow = isFast ? 1 : 2;
+				stats.noteCount++;
+				stats.lastHitOffset = offset;
+			};
+			increment_extended(extendedStats, isFast, offset);
+			increment_extended(extendedColumnStats, isFast, offset);
+			increment_extended(extendedStatsCourse, isFast, offset);
+			increment_extended(extendedColumnStatsCourse, isFast, offset);
+			lastOffsetColumnIdx = lane;
 			return 1;
 		}
 		if (gap <= g->gameplay.player[player].judgetime[3] && g->gameplay.player[player].note_current < g->gameplay.player[player].totalnotes) {
@@ -736,7 +775,18 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			PlaySound(&g->audio, &g->gameplay.keysound[g->gameplay.bmsobj_note[lane].noteVal], g->audio.chnStageKey[note.stage], note.stage);
 			note.active = -1;
 			g->gameplay.bmsobj_note[lane].note_count++;
-			
+			auto increment_extended = [](EXTENDEDPLAYERSTATS& stats, bool isFast, int offset) {
+				isFast ? stats.egd++ : stats.lgd++;
+				isFast ? stats.fast++ : stats.slow++;
+				stats.lastFastSlow = isFast ? 1 : 2;
+				stats.noteCount++;
+				stats.lastHitOffset = offset;
+			};
+			increment_extended(extendedStats, isFast, offset);
+			increment_extended(extendedColumnStats, isFast, offset);
+			increment_extended(extendedStatsCourse, isFast, offset);
+			increment_extended(extendedColumnStatsCourse, isFast, offset);
+			lastOffsetColumnIdx = lane;
 			return 1;
 		}
 
@@ -749,7 +799,19 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			PlaySound(&g->audio, &g->gameplay.keysound[g->gameplay.bmsobj_note[lane].noteVal], g->audio.chnStageKey[note.stage], note.stage);
 			note.active = -1;
 			g->gameplay.bmsobj_note[lane].note_count++;
-			
+			auto increment_extended = [](EXTENDEDPLAYERSTATS& stats, bool isFast, int offset) {
+				isFast ? stats.ebd++ : stats.lbd++;
+				isFast ? stats.fast++ : stats.slow++;
+				stats.lastFastSlow = isFast ? 1 : 2;
+				stats.noteCount++;
+				stats.lastHitOffset = offset;
+			};
+			increment_extended(extendedStats, isFast, offset);
+			increment_extended(extendedColumnStats, isFast, offset);
+			increment_extended(extendedStatsCourse, isFast, offset);
+			increment_extended(extendedColumnStatsCourse, isFast, offset);
+			lastOffsetColumnIdx = lane;
+
 			if (g->gameplay.bmsobj_note[lane].note_count < g->gameplay.bmsobj_note[lane].size && abs(timing - (int)g->gameplay.bmsobj_note[lane].notes[g->gameplay.bmsobj_note[lane].note_count].realTiming) <= g->gameplay.player[player].judgetime[2]) {
 				ProcSinglenote(g, lane, 1, timing, player);
 				return 1;
@@ -760,6 +822,16 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			JudgeToScore(0, g, player, lane, 0);
 			g->gameplay.bmsobj_note[lane].noteVal = note.val;
 			PlaySound(&g->audio, &g->gameplay.keysound[g->gameplay.bmsobj_note[lane].noteVal], g->audio.chnStageKey[note.stage], note.stage);
+			auto increment_extended = [](EXTENDEDPLAYERSTATS& stats) {
+				stats.epr++;
+				stats.lastFastSlow = 1;
+				stats.epr++;
+				stats.lastFastSlow = 1;
+			};
+			increment_extended(extendedStats);
+			increment_extended(extendedColumnStats);
+			increment_extended(extendedStatsCourse);
+			increment_extended(extendedColumnStatsCourse);
 			return 1;
 		}
 
@@ -773,6 +845,11 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 int ProcLongnote(game *g, int lane, int keypress, int timing, int player) {
 	
 	NoteStruct &note = g->gameplay.bmsobj_note[lane].notes[g->gameplay.bmsobj_note[lane].note_count];
+	EXTENDEDPLAYERSTATS& extendedStats = g->gameplay.player[player].extendedStats;
+	EXTENDEDPLAYERSTATS& extendedColumnStats = g->gameplay.player[player].extendedColumnStats[lane];
+	EXTENDEDPLAYERSTATS& extendedStatsCourse = g->gameplay.player[player].extendedStatsCourse;
+	EXTENDEDPLAYERSTATS& extendedColumnStatsCourse = g->gameplay.player[player].extendedColumnStatsCourse[lane];
+	int& lastOffsetColumnIdx = g->gameplay.player[player].lastJudgedColumnIdx;
 
 	if ((double)timing - note.realTiming > (double)g->gameplay.player[player].judgetime[3] && note.active <= 0) {
 		ApplyJudgeNote(1, g, player, lane, &g->timer1, 0);
@@ -780,16 +857,38 @@ int ProcLongnote(game *g, int lane, int keypress, int timing, int player) {
 		note.active = -1;
 		g->gameplay.bmsobj_note[lane].note_count++;
 		ResetTimeLapse(70 + lane, &g->timer1);
+		auto increment_extended = [](EXTENDEDPLAYERSTATS& stats) {
+			stats.lpr++;
+			stats.cb++;
+			stats.noteCount++;
+			stats.lastFastSlow = 2;
+		};
+		increment_extended(extendedStats);
+		increment_extended(extendedColumnStats);
+		increment_extended(extendedStatsCourse);
+		increment_extended(extendedColumnStatsCourse);
 		return 0;
 	}
 
 	if (keypress == 1) {
-		int gap = abs(timing - (int)note.realTiming);
+		int offset = timing - (int)note.realTiming;
+		int gap = std::abs(offset);
+		bool isFast = offset < 0;
 
 		if (gap <= g->gameplay.player[player].judgetime[5]) {
 			g->gameplay.bmsobj_note[lane].noteVal = note.val;
 			PlaySound(&g->audio, &g->gameplay.keysound[g->gameplay.bmsobj_note[lane].noteVal], g->audio.chnStageKey[note.stage], note.stage);
 			note.active = 5;
+			note.lnHeadFast = isFast;
+			auto increment_extended = [](EXTENDEDPLAYERSTATS& stats, int offset) {
+				stats.lastFastSlow = 0;
+				stats.lastHitOffset = offset;
+			};
+			increment_extended(extendedStats, offset);
+			increment_extended(extendedColumnStats, offset);
+			increment_extended(extendedStatsCourse, offset);
+			increment_extended(extendedColumnStatsCourse, offset);
+			lastOffsetColumnIdx = lane;
 
 			SetTimeLapse(70 + lane, &g->timer1);
 			return 1;
@@ -798,6 +897,17 @@ int ProcLongnote(game *g, int lane, int keypress, int timing, int player) {
 			g->gameplay.bmsobj_note[lane].noteVal = note.val;
 			PlaySound(&g->audio, &g->gameplay.keysound[g->gameplay.bmsobj_note[lane].noteVal], g->audio.chnStageKey[note.stage], note.stage);
 			note.active = 4;
+			note.lnHeadFast = isFast;
+			auto increment_extended = [](EXTENDEDPLAYERSTATS& stats, int offset, bool isFast) {
+				isFast ? stats.fast++ : stats.slow++;
+				stats.lastFastSlow = isFast ? 1 : 2;
+				stats.lastHitOffset = offset;
+			};
+			increment_extended(extendedStats, offset, isFast);
+			increment_extended(extendedColumnStats, offset, isFast);
+			increment_extended(extendedStatsCourse, offset, isFast);
+			increment_extended(extendedColumnStatsCourse, offset, isFast);
+			lastOffsetColumnIdx = lane;
 
 			SetTimeLapse(70 + lane, &g->timer1);
 			return 1;
@@ -806,6 +916,17 @@ int ProcLongnote(game *g, int lane, int keypress, int timing, int player) {
 			g->gameplay.bmsobj_note[lane].noteVal = note.val;
 			PlaySound(&g->audio, &g->gameplay.keysound[g->gameplay.bmsobj_note[lane].noteVal], g->audio.chnStageKey[note.stage], note.stage);
 			note.active = 3;
+			note.lnHeadFast = isFast;
+			auto increment_extended = [](EXTENDEDPLAYERSTATS& stats, int offset, bool isFast) {
+				isFast ? stats.fast++ : stats.slow++;
+				stats.lastFastSlow = isFast ? 1 : 2;
+				stats.lastHitOffset = offset;
+			};
+			increment_extended(extendedStats, offset, isFast);
+			increment_extended(extendedColumnStats, offset, isFast);
+			increment_extended(extendedStatsCourse, offset, isFast);
+			increment_extended(extendedColumnStatsCourse, offset, isFast);
+			lastOffsetColumnIdx = lane;
 
 			SetTimeLapse(70 + lane, &g->timer1);
 			return 1;
@@ -814,12 +935,33 @@ int ProcLongnote(game *g, int lane, int keypress, int timing, int player) {
 			g->gameplay.bmsobj_note[lane].noteVal = note.val;
 			PlaySound(&g->audio, &g->gameplay.keysound[g->gameplay.bmsobj_note[lane].noteVal], g->audio.chnStageKey[note.stage], note.stage);
 			note.active = 2;
+			note.lnHeadFast = isFast;
+			auto increment_extended = [](EXTENDEDPLAYERSTATS& stats, int offset, bool isFast) {
+				isFast ? stats.fast++ : stats.slow++;
+				stats.lastFastSlow = isFast ? 1 : 2;
+				stats.lastHitOffset = offset;
+			};
+			increment_extended(extendedStats, offset, isFast);
+			increment_extended(extendedColumnStats, offset, isFast);
+			increment_extended(extendedStatsCourse, offset, isFast);
+			increment_extended(extendedColumnStatsCourse, offset, isFast);
+			lastOffsetColumnIdx = lane;
 			return 1;
 		}
 		else if ((int)note.realTiming - timing < g->gameplay.player[player].judgetime[1]) {
 			JudgeToScore(0, g, player, lane, 0);
 			g->gameplay.bmsobj_note[lane].noteVal = note.val;
 			PlaySound(&g->audio, &g->gameplay.keysound[g->gameplay.bmsobj_note[lane].noteVal], g->audio.chnStageKey[note.stage], note.stage);
+			auto increment_extended = [](EXTENDEDPLAYERSTATS& stats) {
+				stats.epr++;
+				stats.lastFastSlow = 1;
+				stats.epr++;
+				stats.lastFastSlow = 1;
+			};
+			increment_extended(extendedStats);
+			increment_extended(extendedColumnStats);
+			increment_extended(extendedStatsCourse);
+			increment_extended(extendedColumnStatsCourse);
 			return 1;
 		}
 
@@ -831,6 +973,7 @@ int ProcLongnote(game *g, int lane, int keypress, int timing, int player) {
 
 	else if (keypress == 2) {
 		if ((int)note.realTiming_ln < timing && note.active > 0) {
+			bool& isFast = note.lnHeadFast;
 			if (note.active < 4) {
 				ResetTimeLapse(70 + lane, &g->timer1);
 			}
@@ -839,20 +982,56 @@ int ProcLongnote(game *g, int lane, int keypress, int timing, int player) {
 				SetTimeLapse(50 + lane, &g->timer1);
 			}
 			JudgeToScore(note.active, g, player, lane, 0);
+			auto increment_extended = [](EXTENDEDPLAYERSTATS& stats, bool isFast, int judge) {
+				switch (judge) {
+				case 5: isFast ? stats.epg++ : stats.lpg++; break;
+				case 4: isFast ? stats.egr++ : stats.lgr++; break;
+				case 3: isFast ? stats.egd++ : stats.lgd++; break;
+				case 2: isFast ? stats.ebd++ : stats.lbd++; stats.cb++; break;
+				}
+				stats.noteCount++;
+			};
+			increment_extended(extendedStats, isFast, note.active);
+			increment_extended(extendedColumnStats, isFast, note.active);
+			increment_extended(extendedStatsCourse, isFast, note.active);
+			increment_extended(extendedColumnStatsCourse, isFast, note.active);
 			note.active = -1;
 			g->gameplay.bmsobj_note[lane].note_count++;
 			return 1;
 		}
 	}
 	else if (keypress == 3 && note.active > 0) {
+		bool& isFast = note.lnHeadFast;
 		if (g->gameplay.player[player].judgetime[3] + timing < (int)note.realTiming_ln) {
 			StopSound(&g->audio, &g->gameplay.keysound[g->gameplay.bmsobj_note[lane].noteVal]);
 			ResetTimeLapse(70 + lane, &g->timer1);
 			JudgeToScore(2, g, player, lane, 0);
+			auto increment_extended = [](EXTENDEDPLAYERSTATS& stats, bool isFast) {
+				isFast ? stats.ebd++ : stats.lbd++;
+				stats.cb++;
+				stats.noteCount++;
+			};
+			increment_extended(extendedStats, isFast);
+			increment_extended(extendedColumnStats, isFast);
+			increment_extended(extendedStatsCourse, isFast);
+			increment_extended(extendedColumnStatsCourse, isFast);
 		}
 		else {
 			ResetTimeLapse(70 + lane, &g->timer1);
 			JudgeToScore(note.active, g, player, lane, 0);
+			auto increment_extended = [](EXTENDEDPLAYERSTATS& stats, bool isFast, int judge) {
+				switch (judge) {
+				case 5: isFast ? stats.epg++ : stats.lpg++; break;
+				case 4: isFast ? stats.egr++ : stats.lgr++; break;
+				case 3: isFast ? stats.egd++ : stats.lgd++; break;
+				case 2: isFast ? stats.ebd++ : stats.lbd++; stats.cb++; break;
+				}
+				stats.noteCount++;
+			};
+			increment_extended(extendedStats, isFast, note.active);
+			increment_extended(extendedColumnStats, isFast, note.active);
+			increment_extended(extendedStatsCourse, isFast, note.active);
+			increment_extended(extendedColumnStatsCourse, isFast, note.active);
 		}
 		note.active = -1;
 		g->gameplay.bmsobj_note[lane].note_count++;

--- a/LR2/strclass.cpp
+++ b/LR2/strclass.cpp
@@ -250,35 +250,48 @@ CSTR& CSTR::replace(int pos, int len1, const char *str2, int len2) {
 	return *this;
 }
 
+#include <string>
+inline void replace_all(std::string& str, std::string_view from, std::string_view to)
+{
+	for (size_t pos = str.find(from); pos != std::string::npos;)
+	{
+		str.replace(pos, from.length(), to);
+		pos = str.find(from, pos + to.length());
+	}
+}
+
 //43b060
 CSTR& CSTR::replace(const char *str1, const char *str2) {
-	char cVar1;
-	char *pcVar2;
-	char *pcVar3;
-	char *_Str1;
-	int iVar4;
-	int len1;
-	int len2;
+	//char cVar1;
+	//char *pcVar2;
+	//char *pcVar3;
+	//char *_Str1;
+	//int iVar4;
+	//int len1;
+	//int len2;
 
-	if (body != NULL) {
-		/*pcVar2 = str1;
-		do {
-			cVar1 = *pcVar2;
-			pcVar2 = pcVar2 + 1;
-		} while (cVar1 != '\0');*/
-		len1 = strlen(str1);
-		/*pcVar3 = str2;
-		do {
-			cVar1 = *pcVar3;
-			pcVar3 = pcVar3 + 1;
-		} while (cVar1 != '\0');*/
-		len2 = strlen(str2);
-		_Str1 = strchr(body, (int)*str1);
-		while (_Str1 != NULL && !strncmp(_Str1, str1, len1)) {
-			replace((int)(_Str1 + -(int)body), len1, str2, len2);
-			_Str1 = strchr(_Str1 + len2, (int)*str1);
-		}
-	}
+	//if (body != NULL) {
+	//	/*pcVar2 = str1;
+	//	do {
+	//		cVar1 = *pcVar2;
+	//		pcVar2 = pcVar2 + 1;
+	//	} while (cVar1 != '\0');*/
+	//	len1 = strlen(str1);
+	//	/*pcVar3 = str2;
+	//	do {
+	//		cVar1 = *pcVar3;
+	//		pcVar3 = pcVar3 + 1;
+	//	} while (cVar1 != '\0');*/
+	//	len2 = strlen(str2);
+	//	_Str1 = strchr(body, (int)*str1);
+	//	while (_Str1 != NULL && !strncmp(_Str1, str1, len1)) {
+	//		replace((int)(_Str1 + -(int)body), len1, str2, len2);
+	//		_Str1 = strchr(_Str1 + len2, (int)*str1);
+	//	}
+	//}
+	std::string string = this->body;
+	replace_all(string, str1, str2);
+	this->assign(string.c_str());
 	return *this;
 }
 
@@ -611,27 +624,26 @@ CSTR CSTR::makeCRCstr() {
 	int pcVar3;
 	char* CVar4;
 	char *pstr;
-	CSTR local_4;
-	CSTR ret;
+	char* local_4;
+	char* ret;
 
-	local_4.body = (char *)0x0;
-	local_4.body = (char *)calloc(1, 0x40);
+	local_4 = (char *)calloc(1, 0x40);
 	dVar2 = CRC32();
-	cstrSprintf(&local_4, "%x", dVar2);
-	str = local_4.body;
-	if (local_4.body == NULL) {
+	sprintf(local_4, "%x", dVar2);
+	str = local_4;
+	if (local_4 == NULL) {
 		pcVar3 = (int)calloc(1, 0x40);
-		ret.body = (char*)pcVar3;
+		ret = (char*)pcVar3;
 		return ret;
 	}
-	CVar4 = local_4.body;
+	CVar4 = local_4;
 	do {
 		cVar1 = *CVar4;
 		CVar4 = CVar4 + 1;
 	} while (cVar1 != '\0');
-	pcVar3 = (int)CVar4 - (int)(local_4.body + 1);
+	pcVar3 = (int)CVar4 - (int)(local_4 + 1);
 	pstr = (char *)calloc(1, (size_t)(pcVar3 + 1));
-	ret.body = pstr;
+	ret = pstr;
 	if (pstr != (char *)0x0) {
 		strncpy(pstr, (char *)str, pcVar3);
 	}

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -2,6 +2,8 @@
 #include <winsock2.h>
 #include <Windows.h>
 #include <vfw.h>
+#include <vector>
+#include <array>
 #include "FMOD/fmod.h"
 #include "strclass.h"
 typedef unsigned char   undefined;
@@ -1067,6 +1069,7 @@ struct NoteStruct {
 	double realTiming;
 	double val;
 	int active;
+	bool lnHeadFast;
 	undefined4 unk1c;
 	double bmsTiming_ln;
 	double realTiming_ln;
@@ -1233,64 +1236,64 @@ struct REPLAY {
 	struct AUDIO_PARAM aud;
 };
 
+struct EXTENDEDPLAYERSTATS {
+	unsigned int epg = 0;
+	unsigned int lpg = 0;
+	unsigned int egr = 0;
+	unsigned int lgr = 0;
+	unsigned int egd = 0;
+	unsigned int lgd = 0;
+	unsigned int ebd = 0;
+	unsigned int lbd = 0;
+	unsigned int epr = 0;
+	unsigned int lpr = 0;
+	unsigned int cb = 0;
+	unsigned int fast = 0;
+	unsigned int slow = 0;
+	unsigned int noteCount = 0;
+	int lastHitOffset = 0;
+	int lastFastSlow = 0;
+};
+
 struct PLAYERSTATUS {
-	int flag_active;
-	int judgecount[6]; /* 0unknown 1poor 2bad 3good 4great 5pgreat */
-	int max_combo; /* Created by retype action */
-	int now_combo;
-	int combo_song_draw;
-	int max_combo_course;
-	int now_combo_course;
-	int combo_draw;
-	int judgecount2[6]; /* 0unknown 1poor 2bad 3good 4great 5pgreat */
-	int total_note;
-	int note_current2;
-	int field11_0x54;
-	double HP;
-	double HP_unk;
-	double HP_print;
-	double HP_old;
-	uint time_oldHP;
-	uint time_newHP;
-	int recent_judge;
-	int judge_draw;
-	double judge_damage[6];
-	int judgetime[6]; /* 0unknown 1poor 2bad 3good 4great 5pgreat */
-	int totalnotes;
-	int score;
-	int exscore;
-	undefined field25_0xdc;
-	undefined field26_0xdd;
-	undefined field27_0xde;
-	undefined field28_0xdf;
-	double rate;
-	int score_unk;
-	int score_print;
-	int score_old;
-	int time_oldScore;
-	int time_newScore;
-	int note_current;
-	int clearType;
-	undefined field49_0x104;
-	undefined field50_0x105;
-	undefined field51_0x106;
-	undefined field52_0x107;
-	undefined field53_0x108;
-	undefined field54_0x109;
-	undefined field55_0x10a;
-	undefined field56_0x10b;
-	undefined field57_0x10c;
-	undefined field58_0x10d;
-	undefined field59_0x10e;
-	undefined field60_0x10f;
-	undefined field61_0x110;
-	undefined field62_0x111;
-	undefined field63_0x112;
-	undefined field64_0x113;
-	undefined field65_0x114;
-	undefined field66_0x115;
-	undefined field67_0x116;
-	undefined field68_0x117;
+	int flag_active = 0;
+	int judgecount[6] = {}; /* 0unknown 1poor 2bad 3good 4great 5pgreat */
+	int max_combo = 0; /* Created by retype action */
+	int now_combo = 0;
+	int combo_song_draw = 0;
+	int max_combo_course = 0;
+	int now_combo_course = 0;
+	int combo_draw = 0;
+	int judgecount2[6] = {}; /* 0unknown 1poor 2bad 3good 4great 5pgreat */
+	int total_note = 0;
+	int note_current2 = 0;
+	int field11_0x54 = 0;
+	double HP = 0.;
+	double HP_unk = 0.;
+	double HP_print = 0.;
+	double HP_old = 0.;
+	uint time_oldHP = 0;
+	uint time_newHP = 0;
+	int recent_judge = 0;
+	int judge_draw = 0;
+	double judge_damage[6] = {};
+	int judgetime[6] = {}; /* 0unknown 1poor 2bad 3good 4great 5pgreat */
+	int totalnotes = 0;
+	int score = 0;
+	int exscore = 0;
+	double rate = 0.;
+	int score_unk = 0;
+	int score_print = 0;
+	int score_old = 0;
+	int time_oldScore = 0;
+	int time_newScore = 0;
+	int note_current = 0;
+	int clearType = 0;
+	EXTENDEDPLAYERSTATS extendedStats;
+	std::array<EXTENDEDPLAYERSTATS, 20> extendedColumnStats;
+	EXTENDEDPLAYERSTATS extendedStatsCourse;
+	std::array<EXTENDEDPLAYERSTATS, 20> extendedColumnStatsCourse;
+	int lastJudgedColumnIdx = 0;
 };
 
 struct PLAYSCORE {
@@ -1755,8 +1758,8 @@ typedef struct SkinUser SkinUser, *PSkinUser;
 
 struct SkinUser {
 	struct SkinAdjust adjust;
-	int customize_value[40];
-	CSTR customize_filename[40];
+	int customize_value[100];
+	CSTR customize_filename[100];
 };
 
 typedef struct CHARTCONVERTER CHARTCONVERTER, *PCHARTCONVERTER;

--- a/OpenLR2_vs22.sln
+++ b/OpenLR2_vs22.sln
@@ -13,6 +13,8 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		DebugWithSanitizer|x64 = DebugWithSanitizer|x64
+		DebugWithSanitizer|x86 = DebugWithSanitizer|x86
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
@@ -21,6 +23,10 @@ Global
 		{01FA731B-9406-4B8B-8604-7023E88298F5}.Debug|x64.Build.0 = Debug|x64
 		{01FA731B-9406-4B8B-8604-7023E88298F5}.Debug|x86.ActiveCfg = Debug|Win32
 		{01FA731B-9406-4B8B-8604-7023E88298F5}.Debug|x86.Build.0 = Debug|Win32
+		{01FA731B-9406-4B8B-8604-7023E88298F5}.DebugWithSanitizer|x64.ActiveCfg = DebugWithSanitizer|x64
+		{01FA731B-9406-4B8B-8604-7023E88298F5}.DebugWithSanitizer|x64.Build.0 = DebugWithSanitizer|x64
+		{01FA731B-9406-4B8B-8604-7023E88298F5}.DebugWithSanitizer|x86.ActiveCfg = DebugWithSanitizer|Win32
+		{01FA731B-9406-4B8B-8604-7023E88298F5}.DebugWithSanitizer|x86.Build.0 = DebugWithSanitizer|Win32
 		{01FA731B-9406-4B8B-8604-7023E88298F5}.Release|x64.ActiveCfg = Release|x64
 		{01FA731B-9406-4B8B-8604-7023E88298F5}.Release|x64.Build.0 = Release|x64
 		{01FA731B-9406-4B8B-8604-7023E88298F5}.Release|x86.ActiveCfg = Release|Win32
@@ -29,6 +35,10 @@ Global
 		{C0290D21-3AD2-4A35-ABBC-A2F5F48326DA}.Debug|x64.Build.0 = Debug|x64
 		{C0290D21-3AD2-4A35-ABBC-A2F5F48326DA}.Debug|x86.ActiveCfg = Debug|Win32
 		{C0290D21-3AD2-4A35-ABBC-A2F5F48326DA}.Debug|x86.Build.0 = Debug|Win32
+		{C0290D21-3AD2-4A35-ABBC-A2F5F48326DA}.DebugWithSanitizer|x64.ActiveCfg = Debug|x64
+		{C0290D21-3AD2-4A35-ABBC-A2F5F48326DA}.DebugWithSanitizer|x64.Build.0 = Debug|x64
+		{C0290D21-3AD2-4A35-ABBC-A2F5F48326DA}.DebugWithSanitizer|x86.ActiveCfg = Debug|Win32
+		{C0290D21-3AD2-4A35-ABBC-A2F5F48326DA}.DebugWithSanitizer|x86.Build.0 = Debug|Win32
 		{C0290D21-3AD2-4A35-ABBC-A2F5F48326DA}.Release|x64.ActiveCfg = Release|x64
 		{C0290D21-3AD2-4A35-ABBC-A2F5F48326DA}.Release|x64.Build.0 = Release|x64
 		{C0290D21-3AD2-4A35-ABBC-A2F5F48326DA}.Release|x86.ActiveCfg = Release|Win32
@@ -37,6 +47,10 @@ Global
 		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug|x64.Build.0 = Debug|x64
 		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug|x86.ActiveCfg = Debug|Win32
 		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug|x86.Build.0 = Debug|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.DebugWithSanitizer|x64.ActiveCfg = Debug|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.DebugWithSanitizer|x64.Build.0 = Debug|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.DebugWithSanitizer|x86.ActiveCfg = Debug|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.DebugWithSanitizer|x86.Build.0 = Debug|Win32
 		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release|x64.ActiveCfg = Release|x64
 		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release|x64.Build.0 = Release|x64
 		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release|x86.ActiveCfg = Release|Win32

--- a/OpenLR2_vs22.vcxproj
+++ b/OpenLR2_vs22.vcxproj
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="DebugWithSanitizer|Win32">
+      <Configuration>DebugWithSanitizer</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="DebugWithSanitizer|x64">
+      <Configuration>DebugWithSanitizer</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
@@ -121,6 +129,12 @@
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugWithSanitizer|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -129,6 +143,12 @@
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugWithSanitizer|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
@@ -149,10 +169,16 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugWithSanitizer|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugWithSanitizer|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -171,6 +197,7 @@
       <FloatingPointModel>Precise</FloatingPointModel>
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -178,6 +205,34 @@
       <AdditionalLibraryDirectories>$(ProjectDir)lib\FMODex\;$(ProjectDir)lib\FMOD\;$(ProjectDir)lib\DxLib\;$(ProjectDir)lib\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>winmm.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
       <ImageHasSafeExceptionHandlers>true</ImageHasSafeExceptionHandlers>
+      <StackReserveSize>
+      </StackReserveSize>
+      <LargeAddressAware>true</LargeAddressAware>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugWithSanitizer|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)lib\FMOD;$(ProjectDir)lib\DxLib;$(ProjectDir)lib\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <AdditionalOptions>/execution-charset:shift-JIS /arch:IA32  /fsanitize=address %(AdditionalOptions)</AdditionalOptions>
+      <FloatingPointModel>Precise</FloatingPointModel>
+      <LanguageStandard>stdcpp23</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(ProjectDir)lib\FMODex\;$(ProjectDir)lib\FMOD\;$(ProjectDir)lib\DxLib\;$(ProjectDir)lib\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>winmm.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <ImageHasSafeExceptionHandlers>true</ImageHasSafeExceptionHandlers>
+      <StackReserveSize>
+      </StackReserveSize>
+      <LargeAddressAware>true</LargeAddressAware>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -201,6 +256,9 @@
       <AdditionalLibraryDirectories>$(ProjectDir)lib\FMODex\;$(ProjectDir)lib\FMOD\;$(ProjectDir)lib\DxLib\;$(ProjectDir)lib\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>winmm.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
       <ImageHasSafeExceptionHandlers>true</ImageHasSafeExceptionHandlers>
+      <StackReserveSize>
+      </StackReserveSize>
+      <LargeAddressAware>true</LargeAddressAware>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -222,6 +280,29 @@
       <AdditionalLibraryDirectories>$(ProjectDir)lib\FMODex\;$(ProjectDir)lib\FMOD\;$(ProjectDir)lib\DxLib\;$(ProjectDir)lib\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>winmm.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
       <StackReserveSize>4194304</StackReserveSize>
+      <LargeAddressAware>true</LargeAddressAware>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugWithSanitizer|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)lib\FMOD;$(ProjectDir)lib\DxLib;$(ProjectDir)lib\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <AdditionalOptions>/execution-charset:shift-JIS /fsanitize=address %(AdditionalOptions)</AdditionalOptions>
+      <FloatingPointModel>Precise</FloatingPointModel>
+      <LanguageStandard>stdcpp23</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(ProjectDir)lib\FMODex\;$(ProjectDir)lib\FMOD\;$(ProjectDir)lib\DxLib\;$(ProjectDir)lib\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>winmm.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <StackReserveSize>4194304</StackReserveSize>
+      <LargeAddressAware>true</LargeAddressAware>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -245,6 +326,7 @@
       <AdditionalLibraryDirectories>$(ProjectDir)lib\FMODex\;$(ProjectDir)lib\FMOD\;$(ProjectDir)lib\DxLib\;$(ProjectDir)lib\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>winmm.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
       <StackReserveSize>4194304</StackReserveSize>
+      <LargeAddressAware>true</LargeAddressAware>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
Fast/Slow:
implements fast/slow similar to the mod in LR2. Doesn't replace IR clear statistics, only returns fast/slow information on play scene and result scene when needed. Stores per-column play statistics for future use. Among issues, replay fast/slow is not exactly correct, because input timing data from replay differs from original, because replay saves a different timer than the one used in judgement function.

Proj settings:
debug config with sanitizer to track memory bugs. Requires 'clang_rt.asan_dynamic-i386.dll' from your VS runtime in the game folder to run; Big addresses awareness to allow up to 4GB of RAM use in x86.

Mem violation fixes:
I ran most core loops of the game with sanitizer and fixed all bugs it revealed.