### PR TITLE
Gauge Auto Shift

### DIFF
--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -252,15 +252,22 @@ int InitGameplay(gameplay *gp, CONFIG_PLAY *cfg) {
 		int prevCombodraw = gp->player[p].combo_draw;
 		int prevTotalnote = gp->player[p].total_note;
 		int prevNotecurrent = gp->player[p].note_current2;
-		double prevHP = gp->player[p].HP;
+		int prevGaugeType = gp->player[p].gaugeType;
+		int prevLastCourseGaugeType = gp->player[p].lastCourseGaugeType;
+		auto prevHP = gp->player[p].HP;
+		double prevHP_print = gp->player[p].HP[prevGaugeType];
 		EXTENDEDPLAYERSTATS extendedStatsCourse = gp->player[p].extendedStatsCourse;
 		std::array<EXTENDEDPLAYERSTATS, 20> extendedColumnStatsCourse = gp->player[p].extendedColumnStatsCourse;
 
 		gp->player[p] = PLAYERSTATUS();
+		gp->player[p].gaugeType = cfg->gaugeOption[p];
+		gp->statgraph[p] = GRAPHDATA();
 
 		if (gp->courseStageNow > 0) {
+			gp->player[p].gaugeType = prevGaugeType;
+			gp->player[p].lastCourseGaugeType = prevLastCourseGaugeType;
 			gp->player[p].HP = prevHP;
-			gp->player[p].HP_print = prevHP;
+			gp->player[p].HP_print = prevHP_print;
 			gp->player[p].now_combo_course = prevNowcombo;
 			gp->player[p].max_combo_course = prevMaxcombo;
 			gp->player[p].combo_draw = prevCombodraw;
@@ -271,25 +278,28 @@ int InitGameplay(gameplay *gp, CONFIG_PLAY *cfg) {
 			gp->player[p].extendedColumnStatsCourse = extendedColumnStatsCourse;
 		}
 	}
-
 	gp->player[0].flag_active = 1;
 	gp->player[1].flag_active = 0;
-	memset(&gp->statgraph[0], 0, sizeof(GRAPHDATA));
-	memset(&gp->statgraph[1], 0, sizeof(GRAPHDATA));
 
 	for (int p = 0; p < 2; p++) {
 		if (gp->courseStageNow < 1) {
-			if (gp->isCourse == 0 && (cfg->gaugeOption[p] == 0 || cfg->gaugeOption[p] == 3)) {
-				gp->player[p].HP = 20.0;
-				gp->player[p].HP_old = 20.0;
-				gp->player[p].HP_print = 20.0;
+			if (gp->isCourse == 0) {
+				gp->player[p].HP[0] = 20.;
+				gp->player[p].HP[3] = 20.;
 			}
 			else {
-				gp->player[p].HP = 100.0;
-				gp->player[p].HP_old = 100.0;
-				gp->player[p].HP_print = 100.0;
+				gp->player[p].HP[0] = 100.;
+				gp->player[p].HP[3] = 100.;
 			}
-			gp->statgraph[p].hp[0] = gp->player[p].HP;
+			gp->player[p].HP[1] = 100.;
+			gp->player[p].HP[2] = 100.;
+			gp->player[p].HP[4] = 100.;
+			gp->player[p].HP[5] = 100.;
+			gp->player[p].HP_old = gp->player[p].HP[gp->player[p].gaugeType];
+			gp->player[p].HP_print = gp->player[p].HP[gp->player[p].gaugeType];
+			for (int i = 0; i < 6; i++) {
+				gp->statgraph[p].hp[i][0] = gp->player[p].HP[i];
+			}
 		}
 	}
 	for (int i = 0; i < 6480; i++) {
@@ -630,47 +640,39 @@ int InitGameplay_retry(gameplay *gp, AUDIO *snd, game *g) {
 	gp->delayDetectedCount = 0;
 	gp->delayCheckCount = 0;
 
-	double tempDmg[6];
-	int tempTime[6], tempCount;
-	tempCount = gp->player[0].totalnotes;
-	memcpy(tempDmg, &gp->player[0].judge_damage, sizeof(tempDmg));
-	memcpy(tempTime, &gp->player[0].judgetime, sizeof(tempTime));
-	gp->player[0] = PLAYERSTATUS();
-	memcpy(&gp->player[0].judge_damage, tempDmg, sizeof(tempDmg));
-	memcpy(&gp->player[0].judgetime, tempTime, sizeof(tempTime));
-	gp->player[0].totalnotes = tempCount;
-
-	tempCount = gp->player[1].totalnotes;
-	memcpy(tempDmg, &gp->player[1].judge_damage, sizeof(tempDmg));
-	memcpy(tempTime, &gp->player[1].judgetime, sizeof(tempTime));
-	gp->player[1] = PLAYERSTATUS();
-	memcpy(&gp->player[1].judge_damage, tempDmg, sizeof(tempDmg));
-	memcpy(&gp->player[1].judgetime, tempTime, sizeof(tempTime));
-	gp->player[1].totalnotes = tempCount;
-
-	memset(&gp->statgraph[0], 0, sizeof(GRAPHDATA));
-	memset(&gp->statgraph[1], 0, sizeof(GRAPHDATA));
-	
+	for (int p = 0; p < 2; p++) {
+		int tempTime[6], tempCount;
+		tempCount = gp->player[p].totalnotes;
+		auto tempDmg = gp->player[p].judge_damage;
+		memcpy(tempTime, &gp->player[p].judgetime, sizeof(tempTime));
+		gp->player[p] = PLAYERSTATUS();
+		gp->player[p].gaugeType = g->config.play.gaugeOption[p];
+		gp->player[p].judge_damage = tempDmg;
+		memcpy(&gp->player[p].judgetime, tempTime, sizeof(tempTime));
+		gp->player[p].totalnotes = tempCount;
+		gp->statgraph[p] = GRAPHDATA();
+	}
 	gp->player[0].flag_active = 1;
 	gp->player[1].flag_active = 0;
 
 	for (int p = 0; p < 2; p++) {
-		if (gp->isCourse) {
-			gp->player[p].HP = 100.0;
-			gp->player[p].HP_old = 100.0;
-			gp->player[p].HP_print = 100.0;
+		if (gp->isCourse == 0) {
+			gp->player[p].HP[0] = 20.;
+			gp->player[p].HP[3] = 20.;
 		}
-		else if (g->config.play.gaugeOption[p] == 0 || g->config.play.gaugeOption[p] == 3) {
-			gp->player[p].HP = 20.0;
-			gp->player[p].HP_old = 20.0;
-			gp->player[p].HP_print = 20.0;
+		else {
+			gp->player[p].HP[0] = 100.;
+			gp->player[p].HP[3] = 100.;
 		}
-		else{
-			gp->player[p].HP = 100.0;
-			gp->player[p].HP_old = 100.0;
-			gp->player[p].HP_print = 100.0;
+		gp->player[p].HP[1] = 100.;
+		gp->player[p].HP[2] = 100.;
+		gp->player[p].HP[4] = 100.;
+		gp->player[p].HP[5] = 100.;
+		gp->player[p].HP_old = gp->player[p].HP[gp->player[p].gaugeType];
+		gp->player[p].HP_print = gp->player[p].HP[gp->player[p].gaugeType];
+		for (int i = 0; i < 6; i++) {
+			gp->statgraph[p].hp[i][0] = gp->player[p].HP[i];
 		}
-		gp->statgraph->hp[p] = gp->player[p].HP;
 	}
 
 	for (int i = 0; i < 1296; i++) {
@@ -3768,152 +3770,133 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 			double dmg = max(dmg_notebase * 10, dmg_totalbase) / 10.0;
 
 			if (!gp->isCourse) {
-				switch (cfg->play.gaugeOption[p]) {
-				default:
-					gp->player[p].judge_damage[5] = total[p] / (float)notes;
-					gp->player[p].judge_damage[4] = total[p] / (float)notes;
-					gp->player[p].judge_damage[3] = total[p] / (float)(notes + notes);
-					gp->player[p].judge_damage[2] = -4.0;
-					gp->player[p].judge_damage[1] = -6.0;
-					gp->player[p].judge_damage[0] = -2.0;
-					break;
-				case 1:
-					gp->player[p].judge_damage[5] = 0.1;
-					gp->player[p].judge_damage[4] = 0.1;
-					gp->player[p].judge_damage[3] = 0.05;
-					gp->player[p].judge_damage[2] = dmg * (-6.0);
-					gp->player[p].judge_damage[1] = dmg * (-10.0);
-					gp->player[p].judge_damage[0] = dmg * (-2.0);
-					break;
-				case 2:
-					gp->player[p].judge_damage[5] = 0.0;
-					gp->player[p].judge_damage[4] = 0.0;
-					gp->player[p].judge_damage[3] = 0.0;
-					gp->player[p].judge_damage[2] = -100.0;
-					gp->player[p].judge_damage[1] = -100.0;
-					gp->player[p].judge_damage[0] = 0.0;
-					break;
-				case 3:
-					gp->player[p].judge_damage[5] = (total[p] / (float)notes) * 1.2;
-					gp->player[p].judge_damage[4] = (total[p] / (float)notes) * 1.2;
-					gp->player[p].judge_damage[3] = (total[p] / (float)(notes + notes)) * 1.2;
-					gp->player[p].judge_damage[2] = -3.2;
-					gp->player[p].judge_damage[1] = -4.800000000000001;
-					gp->player[p].judge_damage[0] = -1.6;
-					break;
-				case 4:
-					gp->player[p].judge_damage[5] = 0.1;
-					gp->player[p].judge_damage[4] = -1.0;
-					gp->player[p].judge_damage[3] = -100.0;
-					gp->player[p].judge_damage[2] = -100.0;
-					gp->player[p].judge_damage[1] = -100.0;
-					gp->player[p].judge_damage[0] = -100.0;
-					break;
-				case 5:
-					gp->player[p].judge_damage[5] = dmg * (-10.0);
-					gp->player[p].judge_damage[4] = -1.0;
-					gp->player[p].judge_damage[3] = 0.1;
-					gp->player[p].judge_damage[2] = -6.0;
-					gp->player[p].judge_damage[1] = dmg * (-10.0);
-					gp->player[p].judge_damage[0] = dmg * (-2.0);
-					break;
-				}
+				gp->player[p].judge_damage[0][5] = total[p] / (float)notes;
+				gp->player[p].judge_damage[0][4] = total[p] / (float)notes;
+				gp->player[p].judge_damage[0][3] = total[p] / (float)(notes + notes);
+				gp->player[p].judge_damage[0][2] = -4.0;
+				gp->player[p].judge_damage[0][1] = -6.0;
+				gp->player[p].judge_damage[0][0] = -2.0;
+
+				gp->player[p].judge_damage[1][5] = 0.1;
+				gp->player[p].judge_damage[1][4] = 0.1;
+				gp->player[p].judge_damage[1][3] = 0.05;
+				gp->player[p].judge_damage[1][2] = dmg * (-6.0);
+				gp->player[p].judge_damage[1][1] = dmg * (-10.0);
+				gp->player[p].judge_damage[1][0] = dmg * (-2.0);
+
+				gp->player[p].judge_damage[2][5] = 0.0;
+				gp->player[p].judge_damage[2][4] = 0.0;
+				gp->player[p].judge_damage[2][3] = 0.0;
+				gp->player[p].judge_damage[2][2] = -100.0;
+				gp->player[p].judge_damage[2][1] = -100.0;
+				gp->player[p].judge_damage[2][0] = 0.0;
+
+				gp->player[p].judge_damage[3][5] = (total[p] / (float)notes) * 1.2;
+				gp->player[p].judge_damage[3][4] = (total[p] / (float)notes) * 1.2;
+				gp->player[p].judge_damage[3][3] = (total[p] / (float)(notes + notes)) * 1.2;
+				gp->player[p].judge_damage[3][2] = -3.2;
+				gp->player[p].judge_damage[3][1] = -4.800000000000001;
+				gp->player[p].judge_damage[3][0] = -1.6;
+
+				gp->player[p].judge_damage[4][5] = 0.1;
+				gp->player[p].judge_damage[4][4] = -1.0;
+				gp->player[p].judge_damage[4][3] = -100.0;
+				gp->player[p].judge_damage[4][2] = -100.0;
+				gp->player[p].judge_damage[4][1] = -100.0;
+				gp->player[p].judge_damage[4][0] = -100.0;
+
+				gp->player[p].judge_damage[5][5] = dmg * (-10.0);
+				gp->player[p].judge_damage[5][4] = -1.0;
+				gp->player[p].judge_damage[5][3] = 0.1;
+				gp->player[p].judge_damage[5][2] = -6.0;
+				gp->player[p].judge_damage[5][1] = dmg * (-10.0);
+				gp->player[p].judge_damage[5][0] = dmg * (-2.0);
 			}
 			else if (gp->courseType == 2) {
-				switch (cfg->play.gaugeOption[p]) {
-				default:
-					gp->player[p].judge_damage[5] = 0.1;
-					gp->player[p].judge_damage[4] = 0.1;
-					gp->player[p].judge_damage[3] = 0.04;
-					gp->player[p].judge_damage[2] = -2.0;
-					gp->player[p].judge_damage[1] = -3.0;
-					gp->player[p].judge_damage[0] = -2.0;
-					break;
-				case 1:
-					gp->player[p].judge_damage[5] = 0.1;
-					gp->player[p].judge_damage[4] = 0.1;
-					gp->player[p].judge_damage[3] = 0.04;
-					gp->player[p].judge_damage[2] = dmg * (-6.0);
-					gp->player[p].judge_damage[1] = dmg * (-10.0);
-					gp->player[p].judge_damage[0] = dmg * (-2.0);
-					break;
-				case 2:
-					gp->player[p].judge_damage[5] = 0.0;
-					gp->player[p].judge_damage[4] = 0.0;
-					gp->player[p].judge_damage[3] = 0.0;
-					gp->player[p].judge_damage[2] = -100.0;
-					gp->player[p].judge_damage[1] = -100.0;
-					gp->player[p].judge_damage[0] = 0.0;
-					break;
-				case 4:
-					gp->player[p].judge_damage[5] = 0.1;
-					gp->player[p].judge_damage[4] = -1.0;
-					gp->player[p].judge_damage[3] = -100.0;
-					gp->player[p].judge_damage[2] = -100.0;
-					gp->player[p].judge_damage[1] = -100.0;
-					gp->player[p].judge_damage[0] = -100.0;
-					break;
-				case 5:
-					gp->player[p].judge_damage[5] = dmg * (-10.0);
-					gp->player[p].judge_damage[4] = -1.0;
-					gp->player[p].judge_damage[3] = 0.1;
-					gp->player[p].judge_damage[2] = -6.0;
-					gp->player[p].judge_damage[1] = dmg * (-10.0);
-					gp->player[p].judge_damage[0] = dmg * (-2.0);
-					break;
-				}
+				gp->player[p].judge_damage[0][5] = 0.1;
+				gp->player[p].judge_damage[0][4] = 0.1;
+				gp->player[p].judge_damage[0][3] = 0.04;
+				gp->player[p].judge_damage[0][2] = -2.0;
+				gp->player[p].judge_damage[0][1] = -3.0;
+				gp->player[p].judge_damage[0][0] = -2.0;
+
+				gp->player[p].judge_damage[1][5] = 0.1;
+				gp->player[p].judge_damage[1][4] = 0.1;
+				gp->player[p].judge_damage[1][3] = 0.04;
+				gp->player[p].judge_damage[1][2] = dmg * (-6.0);
+				gp->player[p].judge_damage[1][1] = dmg * (-10.0);
+				gp->player[p].judge_damage[1][0] = dmg * (-2.0);
+
+				gp->player[p].judge_damage[2][5] = 0.0;
+				gp->player[p].judge_damage[2][4] = 0.0;
+				gp->player[p].judge_damage[2][3] = 0.0;
+				gp->player[p].judge_damage[2][2] = -100.0;
+				gp->player[p].judge_damage[2][1] = -100.0;
+				gp->player[p].judge_damage[2][0] = 0.0;
+
+				gp->player[p].judge_damage[3][5] = 0.1;
+				gp->player[p].judge_damage[3][4] = 0.1;
+				gp->player[p].judge_damage[3][3] = 0.04;
+				gp->player[p].judge_damage[3][2] = -2.0;
+				gp->player[p].judge_damage[3][1] = -3.0;
+				gp->player[p].judge_damage[3][0] = -2.0;
+
+				gp->player[p].judge_damage[4][5] = 0.1;
+				gp->player[p].judge_damage[4][4] = -1.0;
+				gp->player[p].judge_damage[4][3] = -100.0;
+				gp->player[p].judge_damage[4][2] = -100.0;
+				gp->player[p].judge_damage[4][1] = -100.0;
+				gp->player[p].judge_damage[4][0] = -100.0;
+
+				gp->player[p].judge_damage[5][5] = dmg * (-10.0);
+				gp->player[p].judge_damage[5][4] = -1.0;
+				gp->player[p].judge_damage[5][3] = 0.1;
+				gp->player[p].judge_damage[5][2] = -6.0;
+				gp->player[p].judge_damage[5][1] = dmg * (-10.0);
+				gp->player[p].judge_damage[5][0] = dmg * (-2.0);
 			}
 			else {
-				switch (cfg->play.gaugeOption[p]) {
-				default:
-					gp->player[p].judge_damage[5] = 0.1;
-					gp->player[p].judge_damage[4] = 0.1;
-					gp->player[p].judge_damage[3] = 0.04;
-					gp->player[p].judge_damage[2] = -1.5;
-					gp->player[p].judge_damage[1] = -2.0;
-					gp->player[p].judge_damage[0] = -1.5;
-					break;
-				case 1:
-					gp->player[p].judge_damage[5] = 0.1;
-					gp->player[p].judge_damage[4] = 0.1;
-					gp->player[p].judge_damage[3] = 0.05;
-					gp->player[p].judge_damage[2] = dmg * (-6.0);
-					gp->player[p].judge_damage[1] = dmg * (-10.0);
-					gp->player[p].judge_damage[0] = dmg * (-2.0);
-					break;
-				case 2:
-					gp->player[p].judge_damage[5] = 0.0;
-					gp->player[p].judge_damage[4] = 0.0;
-					gp->player[p].judge_damage[3] = 0.0;
-					gp->player[p].judge_damage[2] = -100.0;
-					gp->player[p].judge_damage[1] = -100.0;
-					gp->player[p].judge_damage[0] = 0.0;
-					break;
-				case 3:
-					gp->player[p].judge_damage[5] = 0.12;
-					gp->player[p].judge_damage[4] = 0.12;
-					gp->player[p].judge_damage[3] = 0.048;
-					gp->player[p].judge_damage[2] = -1.2;
-					gp->player[p].judge_damage[1] = -1.6;
-					gp->player[p].judge_damage[0] = -1.2;
-					break;
-				case 4:
-					gp->player[p].judge_damage[5] = 0.1;
-					gp->player[p].judge_damage[4] = -1.0;
-					gp->player[p].judge_damage[3] = -100.0;
-					gp->player[p].judge_damage[2] = -100.0;
-					gp->player[p].judge_damage[1] = -100.0;
-					gp->player[p].judge_damage[0] = -100.0;
-					break;
-				case 5:
-					gp->player[p].judge_damage[5] = dmg * (-10.0);
-					gp->player[p].judge_damage[4] = -1.0;
-					gp->player[p].judge_damage[3] = 0.1;
-					gp->player[p].judge_damage[2] = -6.0;
-					gp->player[p].judge_damage[1] = dmg * (-10.0);
-					gp->player[p].judge_damage[0] = dmg * (-2.0);
-					break;
-				}
+				gp->player[p].judge_damage[0][5] = 0.1;
+				gp->player[p].judge_damage[0][4] = 0.1;
+				gp->player[p].judge_damage[0][3] = 0.04;
+				gp->player[p].judge_damage[0][2] = -1.5;
+				gp->player[p].judge_damage[0][1] = -2.0;
+				gp->player[p].judge_damage[0][0] = -1.5;
+
+				gp->player[p].judge_damage[1][5] = 0.1;
+				gp->player[p].judge_damage[1][4] = 0.1;
+				gp->player[p].judge_damage[1][3] = 0.05;
+				gp->player[p].judge_damage[1][2] = dmg * (-6.0);
+				gp->player[p].judge_damage[1][1] = dmg * (-10.0);
+				gp->player[p].judge_damage[1][0] = dmg * (-2.0);
+
+				gp->player[p].judge_damage[2][5] = 0.0;
+				gp->player[p].judge_damage[2][4] = 0.0;
+				gp->player[p].judge_damage[2][3] = 0.0;
+				gp->player[p].judge_damage[2][2] = -100.0;
+				gp->player[p].judge_damage[2][1] = -100.0;
+				gp->player[p].judge_damage[2][0] = 0.0;
+
+				gp->player[p].judge_damage[3][5] = 0.12;
+				gp->player[p].judge_damage[3][4] = 0.12;
+				gp->player[p].judge_damage[3][3] = 0.048;
+				gp->player[p].judge_damage[3][2] = -1.2;
+				gp->player[p].judge_damage[3][1] = -1.6;
+				gp->player[p].judge_damage[3][0] = -1.2;
+
+				gp->player[p].judge_damage[4][5] = 0.1;
+				gp->player[p].judge_damage[4][4] = -1.0;
+				gp->player[p].judge_damage[4][3] = -100.0;
+				gp->player[p].judge_damage[4][2] = -100.0;
+				gp->player[p].judge_damage[4][1] = -100.0;
+				gp->player[p].judge_damage[4][0] = -100.0;
+
+				gp->player[p].judge_damage[5][5] = dmg * (-10.0);
+				gp->player[p].judge_damage[5][4] = -1.0;
+				gp->player[p].judge_damage[5][3] = 0.1;
+				gp->player[p].judge_damage[5][2] = -6.0;
+				gp->player[p].judge_damage[5][1] = dmg * (-10.0);
+				gp->player[p].judge_damage[5][0] = dmg * (-2.0);
 			}
 		}
 	}

--- a/LR2/LR2_configsave.cpp
+++ b/LR2/LR2_configsave.cpp
@@ -299,6 +299,9 @@ int WriteConfigXml(game *g, const char *filename){
 
 	sprintf(buf, "\t\t<%s>%d</%s>\n", "disablecurspeedchange", (g->config).play.disablecurspeedchange, "disablecurspeedchange");
 	fputs(buf, pFile);
+
+	sprintf(buf, "\t\t<%s>%d</%s>\n", "gaugeautoshift", (g->config).play.m_gas, "gaugeautoshift");
+	fputs(buf, pFile);
 	fputs("\t</play>\n", pFile);
 
 	fputs("\t<sound>\n", pFile);
@@ -1019,13 +1022,13 @@ int WriteSkinCustomizeXml(SkinUser *sku, char *filepath) {
 }
 
 //441d30
-int ReadConfig(game *g, const char *filepath){
-	int *piVar1;
+int ReadConfig(game* g, const char* filepath) {
+	int* piVar1;
 	bool bVar2;
-	TiXmlDocument *hXml;
-	TiXmlDocument *pTVar7;
+	TiXmlDocument* hXml;
+	TiXmlDocument* pTVar7;
 	uint uStack32;
-	int *local_c;
+	int* local_c;
 
 	memset(&g->config.play, 0, sizeof(g->config.play));
 	g->config.play.hiSpeed[0] = 200;
@@ -1090,7 +1093,7 @@ int ReadConfig(game *g, const char *filepath){
 	ReadXml_Int("config", "select", "ignorekeydouble", 0, &g->config.select.ignorekeydouble, hXml);
 	ReadXml_Int("config", "select", "ignoredp", 0, &g->config.select.ignoredp, hXml);
 	ReadXml_Int("config", "select", "ignorepms", 0, &g->config.select.ignorepms, hXml);
-	ReadXml_Int("config", "select", "ignoredifficultyall", 0, &g->config.select.ignoredifficultyall,	hXml);
+	ReadXml_Int("config", "select", "ignoredifficultyall", 0, &g->config.select.ignoredifficultyall, hXml);
 	ReadXml_Int("config", "select", "ignore5key", 0, &g->config.select.ignore5key, hXml);
 	ReadXml_Int("config", "select", "levelbarflash_7", 12, &g->config.select.levelbarflash_7, hXml);
 	ReadXml_Int("config", "select", "levelbarflash_5", 9, &g->config.select.levelbarflash_5, hXml);
@@ -1136,7 +1139,7 @@ int ReadConfig(game *g, const char *filepath){
 	ReadXml_Int("config", "sound", "fxp2_2", 0, &g->config.sound.fxp2_2, hXml);
 	ReadXml_Int("config", "sound", "fxtarget_2", 0, &g->config.sound.fxtarget_2, hXml);
 	ReadXml_Int("config", "sound", "fxtype_2", 0, &g->config.sound.fxtype_2, hXml);
-	
+
 	g->config.sound.disabledsp = (uint)(g->config.sound.output != 2);
 	if (g->config.sound.bufferlength == 0) g->config.sound.bufferlength = 256;
 	if (g->config.sound.bufferlength < 16) g->config.sound.bufferlength = 16;
@@ -1171,7 +1174,12 @@ int ReadConfig(game *g, const char *filepath){
 	ReadXml_Int("config", "play", "basespeed", 100, &g->config.play.basespeed, hXml);
 	ReadXml_Int("config", "play", "gomiscore", 0, &g->config.play.gomiscore, hXml);
 	ReadXml_Int("config", "play", "disableleftclickexit", 0, &g->config.play.disableleftclickexit, hXml);
-	ReadXml_Int("config", "play", "disablecurspeedchange", 0, &g->config.play.disablecurspeedchange,	hXml);
+	ReadXml_Int("config", "play", "disablecurspeedchange", 0, &g->config.play.disablecurspeedchange, hXml);
+	{
+		int gasInt = 0;
+		ReadXml_Int("config", "play", "gaugeautoshift", 0, &gasInt, hXml);
+		g->config.play.m_gas = gasInt > 0 ? true : false;
+	}
 	ReadXml_Str("config", "skin", "play_7", "", &g->config.skin.skinFilePath[0], hXml);
 	ReadXml_Str("config", "skin", "play_5", "", &g->config.skin.skinFilePath[1], hXml);
 	ReadXml_Str("config", "skin", "play_14", "", &g->config.skin.skinFilePath[2], hXml);

--- a/LR2/LR2_replay.cpp
+++ b/LR2/LR2_replay.cpp
@@ -329,26 +329,27 @@ int REPLAY_ApplyJudgeNote(gameplay *gp, Timer *T, game *g, uint judge, int playe
 		gp->player[player].judgecount2[judge]++;
 	}
 
-	int hp = ((int)gp->player[player].HP / 2) * 2;
+	int gauge = gp->player[player].gaugeType;
+	int hp = ((int)gp->player[player].HP[gauge] / 2) * 2;
 	double damage;
-	if (hp <= 30 && (!(g->config.play.gaugeOption[player] == 0 || g->config.play.gaugeOption[player] == 3) || gp->isCourse != 0) && judge <= 2) {
-		damage = gp->player[player].judge_damage[judge] * 0.6;
+	if (hp <= 30 && (!(gauge == 0 || gauge == 3) || gp->isCourse != 0) && judge <= 2) {
+		damage = gp->player[player].judge_damage[gauge][judge] * 0.6;
 	}
 	else {
-		damage = gp->player[player].judge_damage[judge];
+		damage = gp->player[player].judge_damage[gauge][judge];
 	}
-	gp->player[player].HP += damage;
+	gp->player[player].HP[gauge] += damage;
 
-	if (gp->isCourse == 0 && gp->player[player].HP <= 2.0 && (g->config.play.gaugeOption[player] == 0 || g->config.play.gaugeOption[player] == 3)) {
-		gp->player[player].HP = 2.0;
+	if (gp->isCourse == 0 && gp->player[player].HP[gauge] <= 2.0 && (gauge == 0 || gauge == 3)) {
+		gp->player[player].HP[gauge] = 2.0;
 	}
 
-	if (gp->player[player].HP >= 100.0) gp->player[player].HP = 100.0;
-	if (gp->player[player].HP < 0.0) gp->player[player].HP = 0.0;
+	if (gp->player[player].HP[gauge] >= 100.0) gp->player[player].HP[gauge] = 100.0;
+	if (gp->player[player].HP[gauge] < 0.0) gp->player[player].HP[gauge] = 0.0;
 
-	int newhp = ((int)gp->player[player].HP / 2) * 2;
+	int newhp = ((int)gp->player[player].HP[gauge] / 2) * 2;
 	if (hp <= 0) {
-		gp->player[player].HP = 0; //?
+		gp->player[player].HP[gauge] = 0; //?
 		newhp = 0;
 		ResetTimeLapse(44 + player, T);
 	}
@@ -422,19 +423,20 @@ int REPLAY_ApplyJudgeMine(gameplay *gp, Timer *T, game *g, int dmg, int player, 
 
 	gp->player[player].judgecount[1]++;
 	gp->player[player].recent_judge = 0;
-	gp->player[player].HP -= dmg;
+	int gauge = gp->player[player].gaugeType;
+	gp->player[player].HP[gauge] -= dmg;
 
-	if (gp->player[player].HP <= 2.0 && (g->config.play.gaugeOption[player] == 0 || g->config.play.gaugeOption[player] == 3)) {
-		gp->player[player].HP = 2.0;
+	if (gp->player[player].HP[gauge] <= 2.0 && (gauge == 0 || gauge == 3)) {
+		gp->player[player].HP[gauge] = 2.0;
 	}
-	if (gp->player[player].HP >= 100.0) {
-		gp->player[player].HP = 100.0;
+	if (gp->player[player].HP[gauge] >= 100.0) {
+		gp->player[player].HP[gauge] = 100.0;
 	}
-	if (gp->player[player].HP < 0.0) {
-		gp->player[player].HP = 0.0;
+	if (gp->player[player].HP[gauge] < 0.0) {
+		gp->player[player].HP[gauge] = 0.0;
 	}
 
-	if ((int)gp->player[player].HP / 2 != 50) ResetTimeLapse(44 + player, T); //this may be different
+	if ((int)gp->player[player].HP[gauge] / 2 != 50) ResetTimeLapse(44 + player, T); //this may be different
 
 	if (dp == 1) {
 		if (player == 0) {

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -144,19 +144,19 @@ bool GetOptionFlag_dst(game *gs, int option) {
 			break;
 
 		case 42:
-			if (gs->config.play.gaugeOption[0] != 0 && gs->config.play.gaugeOption[0] != 3) return !ret;
+			if (gs->gameplay.player[0].gaugeType != 0 && gs->gameplay.player[0].gaugeType != 3) return !ret;
 			if (gs->gameplay.isCourse == 0) return ret;
 			break;
 		case 43:
-			if (gs->config.play.gaugeOption[0] != 0 && gs->config.play.gaugeOption[0] != 3) return ret;
+			if (gs->gameplay.player[0].gaugeType != 0 && gs->gameplay.player[0].gaugeType != 3) return ret;
 			if (gs->gameplay.isCourse == 0) return !ret;
 			return ret;
 		case 44:
-			if (gs->config.play.gaugeOption[1] != 0 && gs->config.play.gaugeOption[1] != 3) return !ret;
+			if (gs->gameplay.player[1].gaugeType != 0 && gs->gameplay.player[1].gaugeType != 3) return !ret;
 			if (gs->gameplay.isCourse == 0) return ret;
 			break;
 		case 45:
-			if (gs->config.play.gaugeOption[1] != 0 && gs->config.play.gaugeOption[1] != 3) return ret;
+			if (gs->gameplay.player[1].gaugeType != 0 && gs->gameplay.player[1].gaugeType != 3) return ret;
 			if (gs->gameplay.isCourse == 0) return !ret;
 			return ret;
 
@@ -785,47 +785,47 @@ bool GetOptionFlag_dst(game *gs, int option) {
 			return ret;
 
 		case 230:
-			if (gs->gameplay.player[0].HP < 0.0) return !ret;
-			if (gs->gameplay.player[0].HP < 10.0) return ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] < 0.0) return !ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] < 10.0) return ret;
 			break;
 		case 231:
-			if (gs->gameplay.player[0].HP < 10.0) return !ret;
-			if (gs->gameplay.player[0].HP < 20.0) return ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] < 10.0) return !ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] < 20.0) return ret;
 			break;
 		case 232:
-			if (gs->gameplay.player[0].HP < 20.0) return !ret;
-			if (gs->gameplay.player[0].HP < 30.0) return ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] < 20.0) return !ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] < 30.0) return ret;
 			break;
 		case 233:
-			if (gs->gameplay.player[0].HP < 30.0) return !ret;
-			if (gs->gameplay.player[0].HP < 40.0) return ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] < 30.0) return !ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] < 40.0) return ret;
 			break;
 		case 234:
-			if (gs->gameplay.player[0].HP < 40.0) return !ret;
-			if (gs->gameplay.player[0].HP < 50.0) return ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] < 40.0) return !ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] < 50.0) return ret;
 			break;
 		case 235:
-			if (gs->gameplay.player[0].HP < 50.0) return !ret;
-			if (gs->gameplay.player[0].HP < 60.0) return ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] < 50.0) return !ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] < 60.0) return ret;
 			break;
 		case 236:
-			if (gs->gameplay.player[0].HP < 60.0) return !ret;
-			if (gs->gameplay.player[0].HP < 70.0) return ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] < 60.0) return !ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] < 70.0) return ret;
 			break;
 		case 237:
-			if (gs->gameplay.player[0].HP < 70.0) return !ret;
-			if (gs->gameplay.player[0].HP < 80.0) return ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] < 70.0) return !ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] < 80.0) return ret;
 			break;
 		case 238:
-			if (gs->gameplay.player[0].HP < 80.0) return !ret;
-			if (gs->gameplay.player[0].HP < 90.0) return ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] < 80.0) return !ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] < 90.0) return ret;
 			break;
 		case 239:
-			if (gs->gameplay.player[0].HP < 90.0) return !ret;
-			if (gs->gameplay.player[0].HP < 100.0) return ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] < 90.0) return !ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] < 100.0) return ret;
 			break;
 		case 240:
-			if (gs->gameplay.player[0].HP >= 100.0) return ret;
+			if (gs->gameplay.player[0].HP[gs->gameplay.player[0].gaugeType] >= 100.0) return ret;
 			break;
 		case 241:
 			if (gs->gameplay.player[0].judge_draw == 5) return ret;
@@ -853,47 +853,47 @@ bool GetOptionFlag_dst(game *gs, int option) {
 			break;
 
 		case 250:
-			if (gs->gameplay.player[1].HP < 0.0) return !ret;
-			if (gs->gameplay.player[1].HP < 10.0) return ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] < 0.0) return !ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] < 10.0) return ret;
 			break;
 		case 251:
-			if (gs->gameplay.player[1].HP < 10.0) return !ret;
-			if (gs->gameplay.player[1].HP < 20.0) return ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] < 10.0) return !ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] < 20.0) return ret;
 			break;
 		case 252:
-			if (gs->gameplay.player[1].HP < 20.0) return !ret;
-			if (gs->gameplay.player[1].HP < 30.0) return ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] < 20.0) return !ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] < 30.0) return ret;
 			break;
 		case 253:
-			if (gs->gameplay.player[1].HP < 30.0) return !ret;
-			if (gs->gameplay.player[1].HP < 40.0) return ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] < 30.0) return !ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] < 40.0) return ret;
 			break;
 		case 254:
-			if (gs->gameplay.player[1].HP < 40.0) return !ret;
-			if (gs->gameplay.player[1].HP < 50.0) return ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] < 40.0) return !ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] < 50.0) return ret;
 			break;
 		case 255:
-			if (gs->gameplay.player[1].HP < 50.0) return !ret;
-			if (gs->gameplay.player[1].HP < 60.0) return ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] < 50.0) return !ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] < 60.0) return ret;
 			break;
 		case 256:
-			if (gs->gameplay.player[1].HP < 60.0) return !ret;
-			if (gs->gameplay.player[1].HP < 70.0) return ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] < 60.0) return !ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] < 70.0) return ret;
 			break;
 		case 257:
-			if (gs->gameplay.player[1].HP < 70.0) return !ret;
-			if (gs->gameplay.player[1].HP < 80.0) return ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] < 70.0) return !ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] < 80.0) return ret;
 			break;
 		case 258:
-			if (gs->gameplay.player[1].HP < 80.0) return !ret;
-			if (gs->gameplay.player[1].HP < 90.0) return ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] < 80.0) return !ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] < 90.0) return ret;
 			break;
 		case 259:
-			if (gs->gameplay.player[1].HP < 90.0) return !ret;
-			if (gs->gameplay.player[1].HP < 100.0) return ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] < 90.0) return !ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] < 100.0) return ret;
 			break;
 		case 260:
-			if (gs->gameplay.player[1].HP >= 100.0) return ret;
+			if (gs->gameplay.player[1].HP[gs->gameplay.player[1].gaugeType] >= 100.0) return ret;
 			break;
 		case 261:
 			if (gs->gameplay.player[1].judge_draw == 5) return ret;
@@ -3228,7 +3228,9 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 
 			//Option Play
 			case 40:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.gaugeOption[0], 0, 5, g->sSelect.panel);
+				isClickSuccess = g->procSelecter == 4 || g->procSelecter == 5 || g->procSelecter == 13 ?
+					ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->gameplay.player[0].gaugeType, 0, 5, g->sSelect.panel) :
+					ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.gaugeOption[0], 0, 5, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetObjectStrings_SongSelect(g);
@@ -3237,7 +3239,9 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 
 			case 41:
 				if (g->config.play.battle == 1) {
-					isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.gaugeOption[1], 0, 5, g->sSelect.panel);
+					isClickSuccess = g->procSelecter == 4 || g->procSelecter == 5 || g->procSelecter == 13 ?
+						ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->gameplay.player[0].gaugeType, 0, 5, g->sSelect.panel) :
+						ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.gaugeOption[0], 0, 5, g->sSelect.panel);
 					if (isClickSuccess == 2) {
 						PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 						SetObjectStrings_SongSelect(g);

--- a/LR2/LR2_statplay.cpp
+++ b/LR2/LR2_statplay.cpp
@@ -32,7 +32,7 @@ int CheckClearLampChallenge(game *g){ //TOFIX : p2_assist == 1 but no battle, do
 		&& g->config.play.autokey == 0 && (g->config.play.unknown_1 == 0 || g->sSelect.metaSelected.keymode < 10) 
 		&& g->config.play.p1_assist == 0 && (g->config.play.p2_assist == 0 || g->sSelect.metaSelected.keymode < 10)) {
 
-		gauge = g->config.play.gaugeOption[0];
+		gauge = g->gameplay.player[0].gaugeType;
 		if (gauge == 1) return 3;
 		else if (gauge == 2) return 4;
 		else if (gauge == 3) return 1;
@@ -47,6 +47,7 @@ int CheckClearLampChallenge(game *g){ //TOFIX : p2_assist == 1 but no battle, do
 uint ConvertOptionHistory(game *g){
 
 	int clear;
+	int gauge;
 	uint ret;
 
 	ret = 0;
@@ -57,15 +58,16 @@ uint ConvertOptionHistory(game *g){
 	}
 	else {
 		clear = g->gameplay.player[0].clearType;
+		gauge = g->gameplay.player[0].gaugeType;
 		if (clear == 2) {
-			if (g->config.play.gaugeOption[0] == 3) {
+			if (gauge == 3) {
 				ret = 8;
 			}
 			return ret;
 		}
 		if (clear > 2) {
 			ret = 0;
-			switch (g->config.play.gaugeOption[0]) {
+			switch (gauge) {
 				case 0:
 					ret = 1;
 					break;
@@ -140,13 +142,14 @@ uint ConvertOptionHistory(game *g){
 
 //405bf0 
 int LogGraphPlayData(GRAPHDATA *grp, PLAYERSTATUS *pstat, int time, int endtime){
-
 	if (grp->cursor < 1000 && time <= endtime && 0 < endtime) {
 		do {
 			if ((time * 1000) / endtime < grp->cursor) {
 				return 1;
 			}
-			grp->hp[grp->cursor] = pstat->HP;
+			for (int i = 0; i < 6; i++) {
+				grp->hp[i][grp->cursor] = pstat->HP[i];
+			}
 			grp->combo[grp->cursor] = pstat->now_combo;
 			grp->exscore[grp->cursor] = pstat->exscore;
 			grp->cursor++;
@@ -180,7 +183,9 @@ int LogGraphPlayerDataToEnd(GRAPHDATA *grp, PLAYERSTATUS *pstat){
 
 	if (grp->cursor >= 1) {
 		for (int i = grp->cursor; i < 1000; i++) {
-			grp->hp[i] = pstat->HP;
+			for (int gauge = 0; gauge < 6; gauge++) {
+				grp->hp[gauge][i] = pstat->HP[gauge];
+			}
 			grp->combo[i] = pstat->now_combo;
 			grp->exscore[i] = pstat->exscore;
 		}
@@ -188,7 +193,9 @@ int LogGraphPlayerDataToEnd(GRAPHDATA *grp, PLAYERSTATUS *pstat){
 	}
 	else {
 		for (int i = grp->cursor; i < 1000; i++) {
-			grp->hp[i] = grp->hp[0];
+			for (int gauge = 0; gauge < 6; gauge++) {
+				grp->hp[gauge][i] = grp->hp[gauge][0];
+			}
 			grp->combo[i] = grp->combo[0];
 			grp->exscore[i] = grp->exscore[0];
 		}
@@ -206,7 +213,7 @@ int CheckClear(PLAYERSTATUS *pstat, int gaugeType, char isCourse){
 		return pstat->clearType;
 	}
 	if (gaugeType == 1 || gaugeType == 5 || gaugeType == 4) {
-		if ( pstat->note_current == pstat->totalnotes && pstat->HP >= 2.0) {
+		if ( pstat->note_current == pstat->totalnotes && pstat->HP[gaugeType] >= 2.0) {
 			pstat->clearType = 4;
 		}
 	}
@@ -214,12 +221,12 @@ int CheckClear(PLAYERSTATUS *pstat, int gaugeType, char isCourse){
 		if (isCourse) {
 			if (pstat->note_current != pstat->totalnotes)
 				return pstat->clearType;
-			if (pstat->HP >= 2.0) {
+			if (pstat->HP[gaugeType] >= 2.0) {
 				pstat->clearType = (gaugeType != 3) + 2;
 				return pstat->clearType;
 			}
 		}
-		if (pstat->note_current == pstat->totalnotes && pstat->HP >= 80.0) {
+		if (pstat->note_current == pstat->totalnotes && pstat->HP[gaugeType] >= 80.0) {
 			pstat->clearType = (gaugeType != 3) + 2;
 			return pstat->clearType;
 		}
@@ -259,6 +266,7 @@ int CheckCourseClear(game *g) {
 		}
 	}
 
+	std::array<int, 2> gauge = { g->gameplay.player[0].gaugeType, g->gameplay.player[1].gaugeType };
 	for (int p = 0; p < 2; p++) {
 		memcpy(g->gameplay.player[p].judgecount, g->gameplay.player[p].judgecount2, sizeof(int) * 6);
 		g->gameplay.player[p].exscore = g->gameplay.player[p].judgecount[4] + g->gameplay.player[p].judgecount[5] * 2;
@@ -268,19 +276,19 @@ int CheckCourseClear(game *g) {
 		
 		g->gameplay.player[p].clearType = 1;
 
-		if (g->gameplay.player[p].HP < 2.0 || g->gameplay.courseStageNow < g->gameplay.courseStageCount - 1) {
+		if (g->gameplay.player[p].HP[gauge[p]] < 2.0 || g->gameplay.courseStageNow < g->gameplay.courseStageCount - 1) {
 			g->gameplay.player[p].clearType = 1;
 		}
 		else if (g->gameplay.player[p].total_note == g->gameplay.player[p].max_combo_course) {
 			g->gameplay.player[p].clearType = 5;
 		}
-		else if (g->config.play.gaugeOption[p] == 1 || g->config.play.gaugeOption[p] == 5 || g->config.play.gaugeOption[p] == 4) {
-			if (g->gameplay.player[p].note_current2 == g->gameplay.player[p].total_note && g->gameplay.player[p].HP > 2.0) {
+		else if (gauge[p] == 1 || gauge[p] == 5 || gauge[p] == 4) {
+			if (g->gameplay.player[p].note_current2 == g->gameplay.player[p].total_note && g->gameplay.player[p].HP[gauge[p]] > 2.0) {
 				g->gameplay.player[p].clearType = 4;
 			}
 		}
-		else if (g->gameplay.player[p].note_current2 == g->gameplay.player[p].total_note && g->gameplay.player[p].HP > 2.0) {
-			g->gameplay.player[p].clearType = (g->config.play.gaugeOption[p] != 3) + 2;
+		else if (g->gameplay.player[p].note_current2 == g->gameplay.player[p].total_note && g->gameplay.player[p].HP[gauge[p]] > 2.0) {
+			g->gameplay.player[p].clearType = (gauge[p] != 3) + 2;
 		}
 	}
 
@@ -300,10 +308,11 @@ int CheckMission(game *g){
 	if (g->config.play.p1_assist == 2) 
 		return 0;
 
-	gauge = g->config.play.gaugeOption[0];
-	if (g->config.play.gaugeOption[0] == 3) 
+	gauge = g->gameplay.player[0].gaugeType;
+
+	if (g->gameplay.player[0].gaugeType == 3)
 		return 0;
-	if (g->config.play.gaugeOption[1] == 3) 
+	if (g->gameplay.player[1].gaugeType == 3)
 		return 0;
 
 	//converge 7 14 25 35 40
@@ -334,7 +343,7 @@ int CheckMission(game *g){
 			}
 			break;
 		case 4:
-			if (gauge == 0 && 80.0 <= g->gameplay.player[0].HP && g->gameplay.player[0].HP < 86.0) {
+			if (gauge == 0 && 80.0 <= g->gameplay.player[0].HP[gauge] && g->gameplay.player[0].HP[gauge] < 86.0) {
 				g->gameplay.playerstat.trial = level + 1;
 			}
 			break;
@@ -441,12 +450,12 @@ int CheckMission(game *g){
 			}
 			break;
 		case 20:
-			if (gauge == 0 && g->gameplay.player[0].HP >= 80.0 && g->gameplay.player[0].HP < 82.0) {
+			if (gauge == 0 && g->gameplay.player[0].HP[gauge] >= 80.0 && g->gameplay.player[0].HP[gauge] < 82.0) {
 				g->gameplay.playerstat.trial = level + 1;
 			}
 			break;
 		case 21:
-			if (gauge == 1 && g->gameplay.player[0].HP < 4.0) {
+			if (gauge == 1 && g->gameplay.player[0].HP[gauge] < 4.0) {
 				g->gameplay.playerstat.trial = level + 1;
 			}
 			break;
@@ -590,7 +599,7 @@ int SaveResult(game *g, sqlite3* sql) {
 
 	if (g->gameplay.isAutoplay) return -1;
 
-	CheckClear(&g->gameplay.player[0], g->config.play.gaugeOption[0], g->gameplay.isCourse);
+	CheckClear(&g->gameplay.player[0], g->gameplay.player[0].gaugeType, g->gameplay.isCourse);
 	if (g->gameplay.courseType == 0 || g->gameplay.courseType == 2) {
 		ErrorLogFmtAdd("エキスパ用のスコア保存処理を行います\n");
 		if (CheckScoreSaveConditon(g) == 0) return -1;
@@ -642,10 +651,10 @@ int SaveResult(game *g, sqlite3* sql) {
 			bms.mybest.rseed = g->gameplay.randomseed;
 
 			if (bms.keymode < 10) {
-				bms.mybest.op_best = g->config.play.gaugeOption[0] + g->config.play.random[0] * 10;
+				bms.mybest.op_best = g->gameplay.player[0].gaugeType + g->config.play.random[0] * 10;
 			}
 			else {
-				bms.mybest.op_best = g->config.play.gaugeOption[0] + g->config.play.random[0] * 10 + g->config.play.random[1] * 100 + g->config.play.dpflip * 1000;
+				bms.mybest.op_best = g->gameplay.player[0].gaugeType + g->config.play.random[0] * 10 + g->config.play.random[1] * 100 + g->config.play.dpflip * 1000;
 			}
 
 			isNewRecord = true;
@@ -748,7 +757,7 @@ int SaveResult(game *g, sqlite3* sql) {
 		ErrorLogFmtAdd("通常のスコア保存処理を行います\n");
 		
 		if (g->config.play.battle == 1) {
-			CheckClear(&g->gameplay.player[1], g->config.play.gaugeOption[1], g->gameplay.isCourse);
+			CheckClear(&g->gameplay.player[1], g->gameplay.player[1].gaugeType, g->gameplay.isCourse);
 		}
 		else {
 			g->gameplay.player[1].clearType = g->gameplay.player[0].clearType;
@@ -967,10 +976,10 @@ int SaveResult(game *g, sqlite3* sql) {
 					g->sSelect.bmsList[g->sSelect.cur_song].mybest.rseed = g->gameplay.randomseed;
 
 					if (g->sSelect.bmsList[g->sSelect.cur_song].keymode < 10) {
-						g->sSelect.bmsList[g->sSelect.cur_song].mybest.op_best = g->config.play.gaugeOption[0] + g->config.play.random[0] * 10;
+						g->sSelect.bmsList[g->sSelect.cur_song].mybest.op_best = g->gameplay.player[0].gaugeType + g->config.play.random[0] * 10;
 					}
 					else {
-						g->sSelect.bmsList[g->sSelect.cur_song].mybest.op_best = g->config.play.gaugeOption[0] + g->config.play.random[0] * 10 + g->config.play.random[1] * 100 + g->config.play.dpflip * 1000;
+						g->sSelect.bmsList[g->sSelect.cur_song].mybest.op_best = g->gameplay.player[0].gaugeType + g->config.play.random[0] * 10 + g->config.play.random[1] * 100 + g->config.play.dpflip * 1000;
 					}
 
 					isNewRecord = true;

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -1391,6 +1391,11 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 								ReleaseReplayBuffer(&gs.gameplay.replay);
 							}
 
+							if (gs.gameplay.courseType == 0 || gs.gameplay.courseType == 2) {
+								gs.gameplay.player[0].lastCourseGaugeType = gs.gameplay.player[0].gaugeType;
+								gs.gameplay.player[1].lastCourseGaugeType = gs.gameplay.player[1].gaugeType;
+							}
+
 							if (gs.gameplay.isAutoplay == 1 && (gs.gameplay.courseType == 0 || gs.gameplay.courseType == 2) && gs.gameplay.courseStageNow < gs.gameplay.courseStageCount -1  && gs.gameplay.flag_closingPhase == 0) {
 								gs.gameplay.courseStageNow++;
 								gs.procSelecter = 4;
@@ -1418,7 +1423,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 							}
 							StopSysSound(&gs);
 							if (gs.gameplay.courseType == 0 || gs.gameplay.courseType == 2) {
-								if (gs.gameplay.courseStageNow < gs.gameplay.courseStageCount -1 && gs.gameplay.player[0].clearType != 0 && (gs.gameplay.player[1].clearType != 0 || gs.config.play.battle != 1) && gs.gameplay.player[0].HP >= 2.0) {
+								gs.gameplay.player[0].gaugeType = gs.gameplay.player[0].lastCourseGaugeType;
+								gs.gameplay.player[1].gaugeType = gs.gameplay.player[1].lastCourseGaugeType;
+								if (gs.gameplay.courseStageNow < gs.gameplay.courseStageCount -1 && gs.gameplay.player[0].clearType != 0 && (gs.gameplay.player[1].clearType != 0 || gs.config.play.battle != 1) && gs.gameplay.player[0].HP[gs.gameplay.player[0].gaugeType] >= 2.0) {
 									gs.gameplay.courseStageNow++;
 									gs.procSelecter = 4;
 								}

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -109,7 +109,7 @@ int Print_ManiacOptions(game *g) {
 	printfDx("変態オプションの仮置き場です。\n");
 	printfDx("トライアル改訂の際はこの手のオプションを多数取り入れる予定です。\n");
 	printfDx("これらのオプションは、基本的にリプレイに反映されません。\n");
-	printfDx("カーソルキーで選択・変更ができます。\n%03d/%03d\n\n\n",g->sSelect.maniac_cursor + 1, 21);
+	printfDx("カーソルキーで選択・変更ができます。\n%03d/%03d\n\n\n",g->sSelect.maniac_cursor + 1, 22);
 
 	int pg_cursor = g->sSelect.maniac_cursor / 10 * 10;
 	int pg_max = pg_cursor + 10;
@@ -423,6 +423,16 @@ int Print_ManiacOptions(game *g) {
 					if (g->KeyInput.inputID[KEY_INPUT_RIGHT] == 1) g->config.play.m_lunaris = g->config.play.m_lunaris == 0;
 				}
 				break;
+			case 21:
+				printfDx("GAUGE AUTO SHIFT    ");
+				if (g->config.play.m_gas == 0) printfDx("OFF");
+				if (g->config.play.m_gas == 1) printfDx("ON");
+
+				if (g->sSelect.maniac_cursor == 21) {
+					if (g->KeyInput.inputID[KEY_INPUT_LEFT] == 1) g->config.play.m_gas = g->config.play.m_gas == 0;
+					if (g->KeyInput.inputID[KEY_INPUT_RIGHT] == 1) g->config.play.m_gas = g->config.play.m_gas == 0;
+				}
+				break;
 			default:
 				break;
 		}
@@ -523,14 +533,19 @@ int Print_ManiacOptions(game *g) {
 	case 20:
 		printfDx("2008年エイプリルフールネタのテト○ス風ミニゲームをプレイできます。\n");
 		break;
+	case 21:
+		printfDx("GAS automatically changes the gauge to the easier one during gameplay.\n");
+		printfDx("Will not shift to the gauge harder than originally selected (Start with easy -> groove).\n");
+		printfDx("If enabled, will save the score with the best survived gauge regardless of what's displayed.\n");
+		break;
 	}
 
 	if (g->KeyInput.inputID[KEY_INPUT_UP] == 1) {
-		LoopInRange(0, 20, -1, &g->sSelect.maniac_cursor);
+		LoopInRange(0, 21, -1, &g->sSelect.maniac_cursor);
 	}
 
 	if (g->KeyInput.inputID[KEY_INPUT_DOWN] == 1) {
-		LoopInRange(0, 20, 1, &g->sSelect.maniac_cursor);
+		LoopInRange(0, 21, 1, &g->sSelect.maniac_cursor);
 	}
 
 	return 1;

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -10,14 +10,39 @@
 #include "Engine.h"
 #include "LR2.h"
 
+static int PerformGAS(gameplay& gameplay, int playerIdx, CONFIG_PLAY& cfg) {
+	PLAYERSTATUS& player = gameplay.player[playerIdx];
+	if (playerIdx == 1 && gameplay.ghostBattle) return player.gaugeType;
+	if (cfg.gaugeOption[playerIdx] == 5) return 5;
+	constexpr std::array<int, 5> gaugeArr({ 4, 2, 1, 0, 3 });
+	unsigned int i = 0;
+	for (; i < gaugeArr.size(); i++)
+		if (gaugeArr[i] == cfg.gaugeOption[playerIdx])
+			break;
+	auto is_gauge_alive = [](int gaugeIdx, double hp) {
+		switch (gaugeIdx) {
+		case 0:
+		case 3:
+			return hp >= 80.;
+		default: return hp >= 2.;
+		}
+	};
+	for (; i < gaugeArr.size(); i++)
+		if (is_gauge_alive(gaugeArr[i], player.HP[gaugeArr[i]]))
+			return gaugeArr[i];
+	if (gameplay.courseType == 2) return 0;
+	return 3;
+}
+
 //405Fb0
-int ApplyJudgeNote(int judge, game *g, int player, int lane, Timer *T, char isReplay) {
+int ApplyJudgeNote(int judge, game *g, int _player, int lane, Timer *T, char isReplay) {
 
 	if (g->gameplay.replay.status == 2) return 0; //playing replay
 	if (g->gameplay.replay.status == 1 && isReplay == 0) { //recording replay, not playing replay??
-		AddReplayData(&g->gameplay.replay, GetTimeLapse(41, &g->timer1), player * 2 + (lane >= 10) + 210, judge);
+		AddReplayData(&g->gameplay.replay, GetTimeLapse(41, &g->timer1), _player * 2 + (lane >= 10) + 210, judge);
 	}
 
+	auto& player = g->gameplay.player[_player];
 	if (g->gameplay.isAutoplay == 0 && g->config.play.m_lunaris == 0 && g->gameplay.replay.status != 2) {
 
 		switch (judge) {
@@ -53,7 +78,7 @@ int ApplyJudgeNote(int judge, game *g, int player, int lane, Timer *T, char isRe
 	if (!(0 <= judge && judge <= 5)) return 0;
 
 	if (judge >= 1) {
-		if (player == 0) {
+		if (_player == 0) {
 			if(isReplay == 0) g->gameplay.p1Score.AddJudgeQueue(judge);
 			if (g->gameplay.ghostBattle == 0 && g->gameplay.isAutoplay == 0 && g->config.play.battle != 1) {
 				while (g->gameplay.highScore.DealJudgeFromQueue() == 0) {}
@@ -68,97 +93,103 @@ int ApplyJudgeNote(int judge, game *g, int player, int lane, Timer *T, char isRe
 			}
 
 		}
-		g->gameplay.player[player].note_current++ ;
-		g->gameplay.player[player].note_current2++ ;
-		if (g->gameplay.player[player].note_current == g->gameplay.player[player].totalnotes) SetTimeLapse(143 + player, T); //final note timer
+		player.note_current++ ;
+		player.note_current2++ ;
+		if (player.note_current == player.totalnotes) SetTimeLapse(143 + _player, T); //final note timer
 
 	}
 	else {
 		if (judge == 0) {
-			if (isReplay == 0 && player == 0) g->gameplay.p1Score.AddJudgeQueue(player); //0
+			if (isReplay == 0 && _player == 0) g->gameplay.p1Score.AddJudgeQueue(_player); //0
 		}
 	}
 
-	g->gameplay.player[player].recent_judge = judge;
+	player.recent_judge = judge;
 	if (judge < 3) {
-		if (g->gameplay.ghostBattle == 0 || player == 0) {
+		if (g->gameplay.ghostBattle == 0 || _player == 0) {
 			g->gameplay.lastMissTime = GetTimeWrap();
 		}
-		g->gameplay.misslayerTime[player]= GetTimeWrap();
+		g->gameplay.misslayerTime[_player]= GetTimeWrap();
 	}
 
 	if (judge == 0) {
-		g->gameplay.player[player].judgecount[1]++;
-		g->gameplay.player[player].judgecount2[1]++;
+		player.judgecount[1]++;
+		player.judgecount2[1]++;
 	}
 	else {
-		g->gameplay.player[player].judgecount[judge]++;
-		g->gameplay.player[player].judgecount2[judge]++;
+		player.judgecount[judge]++;
+		player.judgecount2[judge]++;
 	}
 
-	int hp = ((int)g->gameplay.player[player].HP / 2) * 2;
-	double damage;
-	if (hp <= 30 && (!(g->config.play.gaugeOption[player] == 0 || g->config.play.gaugeOption[player] == 3) || g->gameplay.isCourse != 0) && judge <= 2) {
-		damage = g->gameplay.player[player].judge_damage[judge] * 0.6;
-	}
-	else {
-		damage = g->gameplay.player[player].judge_damage[judge];
-	}
-	g->gameplay.player[player].HP += damage;
-
-	if (g->gameplay.isCourse == 0 && g->gameplay.player[player].HP <= 2.0 && (g->config.play.gaugeOption[player] == 0 || g->config.play.gaugeOption[player] == 3)) {
-		g->gameplay.player[player].HP = 2.0;
-	}
-
-	if (g->gameplay.player[player].HP >= 100.0) g->gameplay.player[player].HP = 100.0;
-	if (g->gameplay.player[player].HP < 0.0) g->gameplay.player[player].HP = 0.0;
-
-	int newhp = ((int)g->gameplay.player[player].HP / 2) * 2;
-	if (hp <= 0) {
-		g->gameplay.player[player].HP = 0; //prevents revive after death
-		newhp = 0;
-		ResetTimeLapse(44 + player, T);
-	}
-	else if (newhp != 100)
-		ResetTimeLapse(44 + player, T);
-
-	if (hp < newhp) {
-		if (newhp == 100) {
-			ResetTimeLapse(42 + player, T);
-			SetTimeLapse(44 + player, T);
+	int oldHp = ((int)player.HP[player.gaugeType] / 2) * 2;
+	for (int gauge = 0; gauge < 6; gauge++) {
+		int hp = ((int)player.HP[gauge] / 2) * 2;
+		double damage;
+		if (hp <= 30 && (!(gauge == 0 || gauge == 3) || g->gameplay.isCourse != 0) && judge <= 2) {
+			damage = player.judge_damage[gauge][judge] * 0.6;
 		}
 		else {
-			SetTimeLapse(42 + player, T);
+			damage = player.judge_damage[gauge][judge];
+		}
+		player.HP[gauge] += damage;
+
+		if (g->gameplay.isCourse == 0 && player.HP[gauge] <= 2.0 && (gauge == 0 || gauge == 3)) {
+			player.HP[gauge] = 2.0;
+		}
+
+		if (player.HP[gauge] >= 100.0) player.HP[gauge] = 100.0;
+		if (player.HP[gauge] < 0.0) player.HP[gauge] = 0.0;
+
+		if (hp <= 0) player.HP[gauge] = 0; //prevents revive after death
+	}
+	if (g->config.play.m_gas)
+		player.gaugeType = PerformGAS(g->gameplay, _player, g->config.play);
+
+	int newHp = ((int)player.HP[player.gaugeType] / 2) * 2;
+	if (oldHp <= 0) {
+		newHp = 0;
+		ResetTimeLapse(44 + _player, T);
+	}
+	else if (newHp != 100)
+		ResetTimeLapse(44 + _player, T);
+
+	if (oldHp < newHp) {
+		if (newHp == 100) {
+			ResetTimeLapse(42 + _player, T);
+			SetTimeLapse(44 + _player, T);
+		}
+		else {
+			SetTimeLapse(42 + _player, T);
 		}
 	}
 
-	if (g->gameplay.player[player].totalnotes > 0) {
-		g->gameplay.player[player].score = (g->gameplay.player[player].judgecount[3] + (g->gameplay.player[player].judgecount[4] + g->gameplay.player[player].judgecount[5] * 2) * 2) * 50000 / g->gameplay.player[player].totalnotes;
+	if (player.totalnotes > 0) {
+		player.score = (player.judgecount[3] + (player.judgecount[4] + player.judgecount[5] * 2) * 2) * 50000 / player.totalnotes;
 	}
-	g->gameplay.player[player].exscore = g->gameplay.player[player].judgecount[4] + g->gameplay.player[player].judgecount[5] * 2;
+	player.exscore = player.judgecount[4] + player.judgecount[5] * 2;
 
-	if (g->gameplay.player[player].note_current > 0) g->gameplay.player[player].rate = g->gameplay.player[player].exscore * 100 / (double)(g->gameplay.player[player].note_current * 2);
+	if (player.note_current > 0) player.rate = player.exscore * 100 / (double)(player.note_current * 2);
 
 	switch (judge) {
 		case 1:
 		case 2:
-			g->gameplay.player[player].now_combo = 0;
-			g->gameplay.player[player].now_combo_course = 0;
+			player.now_combo = 0;
+			player.now_combo_course = 0;
 			break;
 		case 3:
 		case 4:
 		case 5:
-			g->gameplay.player[player].now_combo++;
-			if (g->gameplay.player[player].now_combo > g->gameplay.player[player].max_combo) g->gameplay.player[player].max_combo = g->gameplay.player[player].now_combo;
-			g->gameplay.player[player].now_combo_course++;
-			if (g->gameplay.player[player].now_combo_course > g->gameplay.player[player].max_combo_course) g->gameplay.player[player].max_combo_course = g->gameplay.player[player].now_combo_course;
+			player.now_combo++;
+			if (player.now_combo > player.max_combo) player.max_combo = player.now_combo;
+			player.now_combo_course++;
+			if (player.now_combo_course > player.max_combo_course) player.max_combo_course = player.now_combo_course;
 			break;
 	}
 
-	if (g->gameplay.player[player].now_combo == g->gameplay.player[player].totalnotes) SetTimeLapse(48 + player, T); //fullcombo timer
+	if (player.now_combo == player.totalnotes) SetTimeLapse(48 + _player, T); //fullcombo timer
 
 	if (lane >= 10) {
-		if (player == 0) {
+		if (_player == 0) {
 			g->gameplay.player[1].judge_draw = g->gameplay.player[0].recent_judge;
 			g->gameplay.player[1].combo_song_draw = g->gameplay.player[0].now_combo;
 			g->gameplay.player[1].combo_draw = g->gameplay.player[0].now_combo_course;
@@ -166,14 +197,14 @@ int ApplyJudgeNote(int judge, game *g, int player, int lane, Timer *T, char isRe
 			return 1;
 		}
 	}
-	else if (player == 0) {
+	else if (_player == 0) {
 		g->gameplay.player[0].judge_draw = g->gameplay.player[0].recent_judge;
 		g->gameplay.player[0].combo_song_draw = g->gameplay.player[0].now_combo;
 		g->gameplay.player[0].combo_draw = g->gameplay.player[0].now_combo_course;
 		SetTimeLapse(46, T);
 		return 1;
 	}
-	if (player == 1 && lane >= 10) {
+	if (_player == 1 && lane >= 10) {
 		g->gameplay.player[1].judge_draw = g->gameplay.player[1].recent_judge;
 		g->gameplay.player[1].combo_song_draw = g->gameplay.player[1].now_combo;
 		g->gameplay.player[1].combo_draw = g->gameplay.player[1].now_combo_course;
@@ -183,39 +214,45 @@ int ApplyJudgeNote(int judge, game *g, int player, int lane, Timer *T, char isRe
 }
 
 //406530
-int ApplyJudgeMine(int judge, game *g, int player, int lane, int damage) {
+int ApplyJudgeMine(int judge, game *g, int _player, int lane, int damage) {
 
 	if (g->gameplay.replay.status == 2) return 0; //playing replay
 	if (g->gameplay.replay.status == 1) {
-		AddReplayData(&g->gameplay.replay, GetTimeLapse(41, &g->timer1), player*2 + (lane>=10) + 214, damage); //214 = 0xD6
+		AddReplayData(&g->gameplay.replay, GetTimeLapse(41, &g->timer1), _player*2 + (lane>=10) + 214, damage); //214 = 0xD6
 	}
 
+	auto& player = g->gameplay.player[_player];
 	if (judge >= 0) {
-		if (judge == 0) g->gameplay.player[player].judgecount[1]++;
-		else g->gameplay.player[player].judgecount[judge]++;
+		if (judge == 0) player.judgecount[1]++;
+		else player.judgecount[judge]++;
 	}
-	g->gameplay.player[player].judgecount[judge]++;
-	g->gameplay.player[player].HP -= damage;
+	player.judgecount[judge]++;
 
-	if (g->gameplay.player[player].HP <= 2.0 && (g->config.play.gaugeOption[player] == 0 || g->config.play.gaugeOption[player] == 3)) {
-		g->gameplay.player[player].HP = 2.0;
-	}
-	if (g->gameplay.player[player].HP >= 100.0) {
-		g->gameplay.player[player].HP = 100.0;
-	}
-	if (g->gameplay.player[player].HP < 0.0) {
-		g->gameplay.player[player].HP = 0.0;
-	}
+	for (int gauge = 0; gauge < 6; gauge++) {
+		player.HP[gauge] -= damage;
 
-	if ((int)g->gameplay.player[player].HP / 2 != 50) ResetTimeLapse(44 + player, &g->timer1);
+		if (player.HP[gauge] <= 2.0 && (gauge == 0 || gauge == 3)) {
+			player.HP[gauge] = 2.0;
+		}
+		if (player.HP[gauge] >= 100.0) {
+			player.HP[gauge] = 100.0;
+		}
+		if (player.HP[gauge] < 0.0) {
+			player.HP[gauge] = 0.0;
+		}
+	}
+	if (g->config.play.m_gas)
+		player.gaugeType = PerformGAS(g->gameplay, _player, g->config.play);
+
+	if ((int)player.HP[player.gaugeType] / 2 != 50) ResetTimeLapse(44 + _player, &g->timer1);
 
 	if (lane >= 10) {
-		if (player == 0) {
+		if (_player == 0) {
 			g->gameplay.player[1].judge_draw = g->gameplay.player[0].recent_judge;
 			g->gameplay.player[1].combo_song_draw = g->gameplay.player[0].now_combo;
 			g->gameplay.player[1].combo_draw = g->gameplay.player[0].now_combo_course;
 		}
-		else if (player == 1) {
+		else if (_player == 1) {
 			g->gameplay.player[1].judge_draw = g->gameplay.player[1].recent_judge;
 			g->gameplay.player[1].combo_song_draw = g->gameplay.player[1].now_combo;
 			g->gameplay.player[1].combo_draw = g->gameplay.player[1].now_combo_course;
@@ -223,7 +260,7 @@ int ApplyJudgeMine(int judge, game *g, int player, int lane, int damage) {
 
 		SetTimeLapse(47, &g->timer1);
 	}
-	else if (player == 0) {
+	else if (_player == 0) {
 		g->gameplay.player[0].judge_draw = g->gameplay.player[0].recent_judge;
 		g->gameplay.player[0].combo_song_draw = g->gameplay.player[0].now_combo;
 		g->gameplay.player[0].combo_draw = g->gameplay.player[0].now_combo_course;
@@ -645,7 +682,7 @@ int DrawHPgauge(game *g){
 	char survival;
 
 	for (int i = 0; i < 2; i++) {
-		if (g->gameplay.isCourse == 0 && (g->config.play.gaugeOption[i] == 0 || g->config.play.gaugeOption[i] == 3)) {
+		if (g->gameplay.isCourse == 0 && (g->gameplay.player[i].gaugeType == 0 || g->gameplay.player[i].gaugeType == 3)) {
 			survival = 0;
 		}
 		else {
@@ -1177,7 +1214,7 @@ int ProcGame(game *g) {
 	}
 		
 	while (true) {
-
+		int gaugeType[2] = { g->gameplay.player[0].gaugeType, g->gameplay.player[1].gaugeType };
 		if (g->gameplay.bmsobj.notes[g->gameplay.bmsobj.note_count].realTiming >= t142 || g->gameplay.bpmChangedBmstime >= 0) {
 			SoundGetCurrentTime(&g->audio, &g->gameplay.muon); //anti cheat
 			NONE_004b6770();
@@ -1187,8 +1224,7 @@ int ProcGame(game *g) {
 			}
 
 			if (g->is_starter || (g->procSelecter == 4 && g->procPhase != 2 && g->procPhase != 3)) {
-
-				if ((g->gameplay.player[0].HP >= 2.0 || g->config.play.battle == 1) && (g->gameplay.player[0].HP >= 2.0 || g->gameplay.player[1].HP >= 2.0 || g->config.play.battle != 1) || g->gameplay.isPreviewLoad) {
+				if ((g->gameplay.player[0].HP[gaugeType[0]] >= 2.0 || g->config.play.battle == 1) && (g->gameplay.player[0].HP[gaugeType[0]] >= 2.0 || g->gameplay.player[1].HP[gaugeType[1]] >= 2.0 || g->config.play.battle != 1) || g->gameplay.isPreviewLoad) {
 
 					if (g->gameplay.isAutoplay == 0 && g->config.play.m_lunaris == 0 && g->gameplay.isPreviewLoad == 0) {
 						oldt142 = t142;
@@ -1219,12 +1255,12 @@ int ProcGame(game *g) {
 					}
 
 					for (int p = 0; p < 2; p++) {
-						if (g->gameplay.player[p].HP_unk != g->gameplay.player[p].HP) {
+						if (g->gameplay.player[p].HP_unk != g->gameplay.player[p].HP[gaugeType[p]]) {
 							g->gameplay.player[p].HP_old = g->gameplay.player[p].HP_print;
 							g->gameplay.player[p].time_oldHP = GetTimeWrap();
-							g->gameplay.player[p].time_newHP = (int)GetTimeWrap() + abs((int)(g->gameplay.player[p].HP_old - g->gameplay.player[p].HP)) * 10;
+							g->gameplay.player[p].time_newHP = (int)GetTimeWrap() + abs((int)(g->gameplay.player[p].HP_old - g->gameplay.player[p].HP[gaugeType[p]])) * 10;
 						}
-						g->gameplay.player[p].HP_unk = g->gameplay.player[p].HP;
+						g->gameplay.player[p].HP_unk = g->gameplay.player[p].HP[gaugeType[p]];
 						if (g->gameplay.player[p].score != g->gameplay.player[p].score_unk) {
 							g->gameplay.player[p].score_old = g->gameplay.player[p].score_print;
 							g->gameplay.player[p].time_oldScore = GetTimeWrap();
@@ -1232,7 +1268,7 @@ int ProcGame(game *g) {
 						}
 						g->gameplay.player[p].score_unk = g->gameplay.player[p].score;
 
-						g->gameplay.player[p].HP_print = ChangeValueByTime(g->gameplay.player[p].HP_old, g->gameplay.player[p].HP, g->gameplay.player[p].time_oldHP, g->gameplay.player[p].time_newHP, GetTimeWrap(), 0);
+						g->gameplay.player[p].HP_print = ChangeValueByTime(g->gameplay.player[p].HP_old, g->gameplay.player[p].HP[gaugeType[p]], g->gameplay.player[p].time_oldHP, g->gameplay.player[p].time_newHP, GetTimeWrap(), 0);
 						g->gameplay.player[p].score_print = ChangeValueByTime(g->gameplay.player[p].score_old, g->gameplay.player[p].score, g->gameplay.player[p].time_oldScore, g->gameplay.player[p].time_newScore, GetTimeWrap(), 0);
 					}
 
@@ -1482,8 +1518,8 @@ int ProcGame(game *g) {
 				break;
 			}
 		}
-
-		if ((g->gameplay.player[0].HP < 2.0 && g->config.play.battle != 1 && g->gameplay.ghostBattle == 0) || (g->gameplay.player[0].HP < 2.0 && g->gameplay.player[1].HP < 2.0 && (g->config.play.battle == 1 || g->gameplay.ghostBattle)) && (g->gameplay.isPreviewLoad == 0)) {
+		
+		if ((g->gameplay.player[0].HP[gaugeType[0]] < 2.0 && g->config.play.battle != 1 && g->gameplay.ghostBattle == 0) || (g->gameplay.player[0].HP[gaugeType[0]] < 2.0 && g->gameplay.player[1].HP[gaugeType[1]] < 2.0 && (g->config.play.battle == 1 || g->gameplay.ghostBattle)) && (g->gameplay.isPreviewLoad == 0)) {
 			SetTimeLapse(3, &g->timer1);
 			g->procPhase = 3;
 			for (int i = 0; i < 6480; i++) {
@@ -1519,14 +1555,14 @@ int ProcGame(game *g) {
 	if (g->procSelecter != 2) {
 		if (g->is_recordmode == 0 || g->rec.recMode == 2) {
 			ReactInput(g);
-
+			int gaugeType[2] = { g->gameplay.player[0].gaugeType, g->gameplay.player[1].gaugeType };
 			for (int p = 0; p < 2; p++) {
-				if (g->gameplay.player[p].HP_unk != g->gameplay.player[p].HP) {
+				if (g->gameplay.player[p].HP_unk != g->gameplay.player[p].HP[gaugeType[p]]) {
 					g->gameplay.player[p].HP_old = g->gameplay.player[p].HP_print;
 					g->gameplay.player[p].time_oldHP = GetTimeWrap();
-					g->gameplay.player[p].time_newHP = (int)GetTimeWrap() + abs((int)(g->gameplay.player[p].HP_old - g->gameplay.player[p].HP)) * 10;
+					g->gameplay.player[p].time_newHP = (int)GetTimeWrap() + abs((int)(g->gameplay.player[p].HP_old - g->gameplay.player[p].HP[gaugeType[p]])) * 10;
 				}
-				g->gameplay.player[p].HP_unk = g->gameplay.player[p].HP;
+				g->gameplay.player[p].HP_unk = g->gameplay.player[p].HP[gaugeType[p]];
 				if (g->gameplay.player[p].score != g->gameplay.player[p].score_unk) {
 					g->gameplay.player[p].score_old = g->gameplay.player[p].score_print;
 					g->gameplay.player[p].time_oldScore = GetTimeWrap();
@@ -1534,7 +1570,7 @@ int ProcGame(game *g) {
 				}
 				g->gameplay.player[p].score_unk = g->gameplay.player[p].score;
 
-				g->gameplay.player[p].HP_print = ChangeValueByTime(g->gameplay.player[p].HP_old, g->gameplay.player[p].HP, g->gameplay.player[p].time_oldHP, g->gameplay.player[p].time_newHP, GetTimeWrap(), 0);
+				g->gameplay.player[p].HP_print = ChangeValueByTime(g->gameplay.player[p].HP_old, g->gameplay.player[p].HP[gaugeType[p]], g->gameplay.player[p].time_oldHP, g->gameplay.player[p].time_newHP, GetTimeWrap(), 0);
 				g->gameplay.player[p].score_print = ChangeValueByTime(g->gameplay.player[p].score_old, g->gameplay.player[p].score, g->gameplay.player[p].time_oldScore, g->gameplay.player[p].time_newScore, GetTimeWrap(), 0);
 			}
 
@@ -1548,7 +1584,10 @@ int ProcGame(game *g) {
 				g->procPhase = 2;
 			}
 			for (int p = 0; p < 2; p++) {
-				if (g->gameplay.player[p].totalnotes > g->gameplay.player[p].note_current) g->gameplay.player[p].HP = 0;
+				if (g->gameplay.player[p].totalnotes > g->gameplay.player[p].note_current) {
+					for (int gauge = 0; gauge < 6; gauge++)
+						g->gameplay.player[p].HP[gauge] = 0;
+				}
 			}
 			LogGraphPlayerDataToEnd(&g->gameplay.statgraph[0], &g->gameplay.player[0]);
 			if(g->config.play.battle == 1)
@@ -1576,7 +1615,7 @@ int ProcGame(game *g) {
 					g->gameplay.player[0].clearType = 1;
 					if(g->gameplay.player[0].totalnotes == g->gameplay.player[0].max_combo)
 						g->gameplay.player[0].clearType = 5;
-					else if (g->gameplay.player[0].note_current == g->gameplay.player[0].totalnotes && g->gameplay.player[0].HP >= 80.0) {
+					else if (g->gameplay.player[0].note_current == g->gameplay.player[0].totalnotes && g->gameplay.player[0].HP[gaugeType[0]] >= 80.0) {
 						//if(g->gameplay.player[0].judgecount[2] + g->gameplay.player[0].judgecount[1] < 10) //TOFIX: BP under 10 is considered as hard clear, but not working. now, do we want it? // it's starter mode or plugout4 code, don't mind it
 						//	g->gameplay.player[0].clearType = 4;
 						g->gameplay.player[0].clearType = 3;
@@ -1701,11 +1740,11 @@ void ProcGameThread(game *g) {
 		}
 	}
 
-	int gauge = g->config.play.gaugeOption[0];
+	int gauge = g->gameplay.player[0].gaugeType;
 	if (gauge == 1 || gauge == 2 || gauge == 4 || gauge == 5) {
 		SetTimeLapse(44, &g->timer1);
 	}
-	gauge = g->config.play.gaugeOption[1];
+	gauge = g->gameplay.player[1].gaugeType;
 	if (gauge == 1 || gauge == 2 || gauge == 4 || gauge == 5) {
 		SetTimeLapse(45, &g->timer1);
 	}

--- a/LR2/Scene05_Result.cpp
+++ b/LR2/Scene05_Result.cpp
@@ -37,15 +37,16 @@ int Proc_Result(game *g, skstruct *sk, Timer *T) {
 		
 		if (sk->src_GAUGECHART_1P[0].op1 <= 0) return 0;
 
-		int val = g->gameplay.statgraph[0].hp[0];
+		int gauge = g->gameplay.player[0].gaugeType;
+		int val = g->gameplay.statgraph[0].hp[gauge][0];
 		int length = ChangeValueByTime(0.0, sk->src_GAUGECHART_1P[0].op1, sk->src_GAUGECHART_1P[0].op3, sk->src_GAUGECHART_1P[0].op4, GetTimeLapse(0, T), 0);
 		for (int i = 0; i < length; i += sk->dst_GAUGECHART_1P[0].draw->w) {
 			int axis = i * 1000 / sk->src_GAUGECHART_1P[0].op1;
 
 			int last = 0;
-			while (val != g->gameplay.statgraph[0].hp[axis]) {
+			while (val != g->gameplay.statgraph[0].hp[gauge][axis]) {
 				
-				if (g->gameplay.isCourse == 0 && g->config.play.gaugeOption[0] != 1 && g->config.play.gaugeOption[0] != 2 && g->config.play.gaugeOption[0] != 5 && g->config.play.gaugeOption[0] != 4 && val < 80) {
+				if (g->gameplay.isCourse == 0 && gauge != 1 && gauge != 2 && gauge != 5 && gauge != 4 && val < 80) {
 					
 					int targetval = sk->src_GAUGECHART_1P[0].op2 * val / (-100);
 					if (last != targetval) {
@@ -61,15 +62,15 @@ int Proc_Result(game *g, skstruct *sk, Timer *T) {
 					}
 				}
 
-				if (val < g->gameplay.statgraph[0].hp[axis]) val++;
-				if (val > g->gameplay.statgraph[0].hp[axis]) val--;
+				if (val < g->gameplay.statgraph[0].hp[gauge][axis]) val++;
+				if (val > g->gameplay.statgraph[0].hp[gauge][axis]) val--;
 			}
 
-			if (g->gameplay.isCourse == 0 && g->config.play.gaugeOption[0] != 1 && g->config.play.gaugeOption[0] != 2 && g->config.play.gaugeOption[0] != 5 && g->config.play.gaugeOption[0] != 4 && g->gameplay.statgraph[0].hp[axis] < 80) {
-				AddDrawingBuffer_Object(&sk->drBuf, &sk->src_GAUGECHART_1P[0], &sk->dst_GAUGECHART_1P[0], T, i, sk->src_GAUGECHART_1P[0].op2 * g->gameplay.statgraph[0].hp[axis] / (-100));
+			if (g->gameplay.isCourse == 0 && gauge != 1 && gauge != 2 && gauge != 5 && gauge != 4 && g->gameplay.statgraph[0].hp[gauge][axis] < 80) {
+				AddDrawingBuffer_Object(&sk->drBuf, &sk->src_GAUGECHART_1P[0], &sk->dst_GAUGECHART_1P[0], T, i, sk->src_GAUGECHART_1P[0].op2 * g->gameplay.statgraph[0].hp[gauge][axis] / (-100));
 			}
 			else {
-				AddDrawingBuffer_Object(&sk->drBuf, &sk->src_GAUGECHART_1P[1], &sk->dst_GAUGECHART_1P[1], T, i, sk->src_GAUGECHART_1P[1].op2 * g->gameplay.statgraph[0].hp[axis] / (-100));
+				AddDrawingBuffer_Object(&sk->drBuf, &sk->src_GAUGECHART_1P[1], &sk->dst_GAUGECHART_1P[1], T, i, sk->src_GAUGECHART_1P[1].op2 * g->gameplay.statgraph[0].hp[gauge][axis] / (-100));
 			}
 		}
 	}
@@ -80,15 +81,16 @@ int Proc_Result(game *g, skstruct *sk, Timer *T) {
 
 		if (sk->src_GAUGECHART_2P[0].op1 <= 0) return 0;
 
-		int val = g->gameplay.statgraph[1].hp[0];
+		int gauge = g->gameplay.player[1].gaugeType;
+		int val = g->gameplay.statgraph[1].hp[gauge][0];
 		int length = ChangeValueByTime(0.0, sk->src_GAUGECHART_2P[0].op1, sk->src_GAUGECHART_2P[0].op3, sk->src_GAUGECHART_2P[0].op4, GetTimeLapse(0, T), 0);
 		for (int i = 0; i < length; i += sk->dst_GAUGECHART_2P[0].draw->w) {
 			int axis = i * 1000 / sk->src_GAUGECHART_2P[0].op1;
 
 			int last = 0;
-			while (val != g->gameplay.statgraph[1].hp[axis]) {
+			while (val != g->gameplay.statgraph[1].hp[gauge][axis]) {
 
-				if (g->gameplay.isCourse == 0 && g->config.play.gaugeOption[p] != 1 && g->config.play.gaugeOption[p] != 2 && val < 80) {
+				if (g->gameplay.isCourse == 0 && gauge != 1 && gauge != 2 && val < 80) {
 
 					int targetval = sk->src_GAUGECHART_2P[0].op2 * val / (-100);
 					if (last != targetval) {
@@ -104,15 +106,15 @@ int Proc_Result(game *g, skstruct *sk, Timer *T) {
 					}
 				}
 
-				if (val < g->gameplay.statgraph[1].hp[axis]) val++;
-				if (val > g->gameplay.statgraph[1].hp[axis]) val--;
+				if (val < g->gameplay.statgraph[1].hp[gauge][axis]) val++;
+				if (val > g->gameplay.statgraph[1].hp[gauge][axis]) val--;
 			}
 
-			if (g->gameplay.isCourse == 0 && g->config.play.gaugeOption[p] != 1 && g->config.play.gaugeOption[p] != 2 && g->gameplay.statgraph[1].hp[axis] < 80) {
-				AddDrawingBuffer_Object(&sk->drBuf, &sk->src_GAUGECHART_2P[0], &sk->dst_GAUGECHART_2P[0], T, i, sk->src_GAUGECHART_2P[0].op2 * g->gameplay.statgraph[1].hp[axis] / (-100));
+			if (g->gameplay.isCourse == 0 && gauge != 1 && gauge != 2 && g->gameplay.statgraph[1].hp[gauge][axis] < 80) {
+				AddDrawingBuffer_Object(&sk->drBuf, &sk->src_GAUGECHART_2P[0], &sk->dst_GAUGECHART_2P[0], T, i, sk->src_GAUGECHART_2P[0].op2 * g->gameplay.statgraph[1].hp[gauge][axis] / (-100));
 			}
 			else {
-				AddDrawingBuffer_Object(&sk->drBuf, &sk->src_GAUGECHART_2P[1], &sk->dst_GAUGECHART_2P[1], T, i, sk->src_GAUGECHART_2P[1].op2 * g->gameplay.statgraph[1].hp[axis] / (-100));
+				AddDrawingBuffer_Object(&sk->drBuf, &sk->src_GAUGECHART_2P[1], &sk->dst_GAUGECHART_2P[1], T, i, sk->src_GAUGECHART_2P[1].op2 * g->gameplay.statgraph[1].hp[gauge][axis] / (-100));
 			}
 		}
 	}
@@ -193,6 +195,40 @@ int Proc_Result(game *g, skstruct *sk, Timer *T) {
 //409300
 char fWaitHiScoreUpdateInput = 0;
 int ProcI_Result(game *g) {
+
+	auto switch_gauge_display = [](gameplay& gameplay, int buttonVal, PLAYERSTATUS& player) {
+		if (buttonVal == 1 && player.gaugeType != 5) {
+			int& gauge = player.gaugeType;
+			if (gameplay.courseType != 2) [[likely]] {
+				switch (gauge) {
+				case 0: gauge = 1; break;
+				case 1: gauge = 2; break;
+				case 2: gauge = 4; break;
+				case 3: gauge = 0; break;
+				case 4: gauge = 3; break;
+				default: break;
+				}
+			}
+			else {
+				switch (gauge) {
+				case 0: gauge = 1; break;
+				case 1: gauge = 2; break;
+				case 2: gauge = 4; break;
+				case 4: gauge = 0; break;
+				default: break;
+				}
+			}
+		}
+	};
+	if (g->config.play.m_gas && g->procSelecter != 13) {
+		switch_gauge_display(g->gameplay, g->KeyInput.p1_buttonInput[13], g->gameplay.player[0]);
+		if (g->config.play.battle == 1) {
+			switch_gauge_display(g->gameplay, g->KeyInput.p2_buttonInput[13], g->gameplay.player[1]);
+		}
+		else {
+			switch_gauge_display(g->gameplay, g->KeyInput.p2_buttonInput[13], g->gameplay.player[0]);
+		}
+	}
 
 	if ((g->KeyInput.mouse_buttonR == 2 || g->KeyInput.mouse_buttonL == 2 || g->KeyInput.inputID[KEY_INPUT_ESCAPE] == 1 || g->KeyInput.inputID[KEY_INPUT_RETURN] == 1
 		|| g->KeyInput.p1_buttonInput[1] == 1 || g->KeyInput.p1_buttonInput[2] == 1 || g->KeyInput.p1_buttonInput[3] == 1 || g->KeyInput.p1_buttonInput[4] == 1 || g->KeyInput.p1_buttonInput[5] == 1 || g->KeyInput.p1_buttonInput[6] == 1 || g->KeyInput.p1_buttonInput[7] == 1

--- a/LR2/Scene07_Skinselect.cpp
+++ b/LR2/Scene07_Skinselect.cpp
@@ -379,7 +379,9 @@ int PlayPreviewSample(game *g) {
 			for (int i = 0; i < 1000; i++) {
 				g->gameplay.statgraph[p].combo[i] = g->gameplay.player[p].totalnotes * i / 1000;
 				g->gameplay.statgraph[p].exscore[i] = g->gameplay.player[p].totalnotes * i * 16 / 9000;
-				g->gameplay.statgraph[p].hp[i] = (100 * i) / 1000;
+				for (int gauge = 0; gauge < 6; gauge++) {
+					g->gameplay.statgraph[p].hp[gauge][i] = (100 * i) / 1000;
+				}
 				if (p == 0) {
 					g->gameplay.rategraph[0].val[i] = g->gameplay.statgraph[0].exscore[0] * 7 / 8;
 					g->gameplay.rategraph[1].val[i] = g->gameplay.statgraph[0].exscore[0] * 6 / 8;

--- a/LR2/Scene08_Lunaris.cpp
+++ b/LR2/Scene08_Lunaris.cpp
@@ -517,36 +517,37 @@ int LUNARIS_JUDGE(game *g) {
 		LUNARIS_LAND();
 		int lineclear = LUNARIS_CHECKLINE();
 		int up = LUNARIS_GETBLOCKUP();
+		int gauge = g->config.play.gaugeOption[0];
 
 		g->gameplay.player[0].judgecount[1]++;
 
-		if (g->config.play.gaugeOption[0] == 0) {
-			g->gameplay.player[0].HP -= 1.5;
+		if (gauge == 0) {
+			g->gameplay.player[0].HP[gauge] -= 1.5;
 			g->gameplay.player[0].HP_print -= 1.5;
 			g->gameplay.player[0].HP_old -= 1.5;
-			if (g->gameplay.player[0].HP < 2.0) {
-				g->gameplay.player[0].HP = 2.0;
+			if (g->gameplay.player[0].HP[gauge] < 2.0) {
+				g->gameplay.player[0].HP[gauge] = 2.0;
 				g->gameplay.player[0].HP_print = 2.0;
 				g->gameplay.player[0].HP_old = 2.0;
 			}
 		}
-		else if (g->config.play.gaugeOption[0] == 3) {
-			g->gameplay.player[0].HP -= 1.0;
+		else if (gauge == 3) {
+			g->gameplay.player[0].HP[gauge] -= 1.0;
 			g->gameplay.player[0].HP_print -= 1.0;
 			g->gameplay.player[0].HP_old -= 1.0;
-			if (g->gameplay.player[0].HP < 2.0) {
-				g->gameplay.player[0].HP = 2.0;
+			if (g->gameplay.player[0].HP[gauge] < 2.0) {
+				g->gameplay.player[0].HP[gauge] = 2.0;
 				g->gameplay.player[0].HP_print = 2.0;
 				g->gameplay.player[0].HP_old = 2.0;
 			}
 		}
 		else {
-			g->gameplay.player[0].HP -= 5.0;
+			g->gameplay.player[0].HP[gauge] -= 5.0;
 			g->gameplay.player[0].HP_print -= 5.0;
 			g->gameplay.player[0].HP_old -= 5.0;
 		}
 
-		if (lun_field[7][1] || lun_y + up - 1 + lineclear < 0 || g->gameplay.player[0].HP < 0.0) {
+		if (lun_field[7][1] || lun_y + up - 1 + lineclear < 0 || g->gameplay.player[0].HP[gauge] < 0.0) {
 			SetTimeLapse(3, &g->timer1);
 			g->procPhase = 3;
 			StopAllKeysound(g);
@@ -563,9 +564,9 @@ int LUNARIS_JUDGE(game *g) {
 			g->gameplay.player[0].recent_judge = 2;
 			SetTimeLapse(46, &g->timer1);
 
-			g->gameplay.player[0].HP += 4.0;
-			if (g->config.play.gaugeOption[0] == 2 || g->config.play.gaugeOption[0] == 4) {
-				g->gameplay.player[0].HP = 0.0;
+			g->gameplay.player[0].HP[gauge] += 4.0;
+			if (gauge == 2 || gauge == 4) {
+				g->gameplay.player[0].HP[gauge] = 0.0;
 
 				SetTimeLapse(3, &g->timer1);
 				g->procPhase = 3;
@@ -583,9 +584,9 @@ int LUNARIS_JUDGE(game *g) {
 			g->gameplay.player[0].recent_judge = 3;
 			SetTimeLapse(46, &g->timer1);
 
-			g->gameplay.player[0].HP += 16.0;
-			if (g->config.play.gaugeOption[0] == 4) {
-				g->gameplay.player[0].HP = 0.0;
+			g->gameplay.player[0].HP[gauge] += 16.0;
+			if (gauge == 4) {
+				g->gameplay.player[0].HP[gauge] = 0.0;
 
 				SetTimeLapse(3, &g->timer1);
 				g->procPhase = 3;
@@ -603,7 +604,7 @@ int LUNARIS_JUDGE(game *g) {
 			g->gameplay.player[0].recent_judge = 4;
 			SetTimeLapse(46, &g->timer1);
 
-			g->gameplay.player[0].HP += 30.0;
+			g->gameplay.player[0].HP[gauge] += 30.0;
 			g->gameplay.player[0].score += 3000;
 		}
 		else if (lineclear == 4) {
@@ -615,11 +616,11 @@ int LUNARIS_JUDGE(game *g) {
 			g->gameplay.player[0].recent_judge = 5;
 			SetTimeLapse(46, &g->timer1);
 
-			g->gameplay.player[0].HP += 40.0;
+			g->gameplay.player[0].HP[gauge] += 40.0;
 			g->gameplay.player[0].score += 12000;
 		}
 
-		if (g->gameplay.player[0].HP > 100.0) g->gameplay.player[0].HP = 100.0;
+		if (g->gameplay.player[0].HP[gauge] > 100.0) g->gameplay.player[0].HP[gauge] = 100.0;
 	}
 	lun_judgetime = GetTimeWrap();
 	return 1;

--- a/LR2/Scene13_Courseresult.cpp
+++ b/LR2/Scene13_Courseresult.cpp
@@ -61,10 +61,10 @@ int ProcS_subCourseResult(game *g, sqlite3 *sql) {
 		g->sSelect.bmsList[g->sSelect.cur_song].mybest.rseed = g->gameplay.randomseed;
 
 		if (g->sSelect.bmsList[g->sSelect.cur_song].keymode < 10) {
-			g->sSelect.bmsList[g->sSelect.cur_song].mybest.op_best = g->config.play.gaugeOption[0] + g->config.play.random[0] * 10;
+			g->sSelect.bmsList[g->sSelect.cur_song].mybest.op_best = g->gameplay.player[0].gaugeType + g->config.play.random[0] * 10;
 		}
 		else {
-			g->sSelect.bmsList[g->sSelect.cur_song].mybest.op_best = g->config.play.gaugeOption[0] + g->config.play.random[0] * 10 + g->config.play.random[1] * 100 + g->config.play.dpflip * 1000;
+			g->sSelect.bmsList[g->sSelect.cur_song].mybest.op_best = g->gameplay.player[0].gaugeType + g->config.play.random[0] * 10 + g->config.play.random[1] * 100 + g->config.play.dpflip * 1000;
 		}
 	}
 

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -6,6 +6,9 @@
 #include <array>
 #include "FMOD/fmod.h"
 #include "strclass.h"
+
+struct sqlite3;
+
 typedef unsigned char   undefined;
 typedef unsigned int    ImageBaseOffset32;
 //typedef unsigned char    bool;
@@ -198,6 +201,7 @@ struct CONFIG_PLAY {
 	int is_extra;
 	int m_extra;
 	char m_lunaris;
+	bool m_gas;
 	char unk_f1;
 	char unk_f2;
 	int gomiscore; 
@@ -1199,7 +1203,7 @@ struct EXTENDEDPLAYERSTATS {
 struct PLAYERSTATUS {
 	int flag_active = 0;
 	int judgecount[6] = {}; /* 0unknown 1poor 2bad 3good 4great 5pgreat */
-	int max_combo = 0; 
+	int max_combo = 0;
 	int now_combo = 0;
 	int combo_song_draw = 0;
 	int max_combo_course = 0;
@@ -1208,7 +1212,7 @@ struct PLAYERSTATUS {
 	int judgecount2[6] = {}; /* 0unknown 1poor 2bad 3good 4great 5pgreat */
 	int total_note = 0;
 	int note_current2 = 0;
-	double HP = 0.;
+	std::array<double, 6> HP = {};
 	double HP_unk = 0.;
 	double HP_print = 0.;
 	double HP_old = 0.;
@@ -1216,7 +1220,9 @@ struct PLAYERSTATUS {
 	uint time_newHP = 0;
 	int recent_judge = 0;
 	int judge_draw = 0;
-	double judge_damage[6] = {};
+	int gaugeType = 0;
+	int lastCourseGaugeType = 0;
+	std::array<std::array<double, 6>, 6> judge_damage = {}; 
 	int judgetime[6] = {}; /* 0unknown 1poor 2bad 3good 4great 5pgreat */
 	int totalnotes = 0;
 	int score = 0;
@@ -1229,10 +1235,10 @@ struct PLAYERSTATUS {
 	int time_newScore = 0;
 	int note_current = 0;
 	int clearType = 0;
-	EXTENDEDPLAYERSTATS extendedStats;
-	std::array<EXTENDEDPLAYERSTATS, 20> extendedColumnStats;
-	EXTENDEDPLAYERSTATS extendedStatsCourse;
-	std::array<EXTENDEDPLAYERSTATS, 20> extendedColumnStatsCourse;
+	EXTENDEDPLAYERSTATS extendedStats = {};
+	std::array<EXTENDEDPLAYERSTATS, 20> extendedColumnStats = {};
+	EXTENDEDPLAYERSTATS extendedStatsCourse = {};
+	std::array<EXTENDEDPLAYERSTATS, 20> extendedColumnStatsCourse = {};
 	int lastJudgedColumnIdx = 0;
 };
 
@@ -1264,10 +1270,10 @@ struct PLAYSCORE {
 };
 
 struct GRAPHDATA {
-	int hp[1000];
-	int combo[1000];
-	int exscore[1000];
-	int cursor;
+	std::array<std::array<int, 1000>, 6> hp = {};
+	int combo[1000] = {};
+	int exscore[1000] = {};
+	int cursor = 0;
 };
 
 struct PLAYERSTATISTIC {


### PR DESCRIPTION
Can be enabled from maniac options menu (F2). This option is saved to config in ["play"]["gaugeautoshift"].
You can cycle between gauge graphs for display with 'SELECT' button on result scene.
Works in battle, courses.
TODO:
Save score with the best survived gauge, regardless of the display gauge at the moment of finishing the play.
Overwrite gauge type to the gauge you cleared with in replay (currently saves starting gauge in op 0x65 and 0x97).
Don't use g-battle gauge type when GAS is enabled.