### PR TITLE
Fix compiling errors on Linux and some small issues

### DIFF
--- a/LR2/En_audio.cpp
+++ b/LR2/En_audio.cpp
@@ -609,7 +609,7 @@ int LoadSound(AUDIO *aud, SOUNDDATA *sound, CSTR filepath, int loop, int disable
 	path.assign(&filepath);
 
 	if (IsFileExist(filepath) == false && IsAltSoundExist(&filepath) == -1) {
-		ErrorLogFmtAdd("音声ファイルが見つかりません。%s...\n",path);
+		ErrorLogFmtAdd("音声ファイルが見つかりません。%s...\n",path.body);
 		if (sound->load == '\0') {
 			sound->filename.fillzero();
 			sound->load = '\0';

--- a/LR2/En_audio.cpp
+++ b/LR2/En_audio.cpp
@@ -12,6 +12,9 @@
 #include <algorithm>
 #include <cmath>
 #include <array>
+#include <cstdint>
+
+using std::uintptr_t;
 
 #include "Engine.h"
 
@@ -554,11 +557,11 @@ int RecordSound(AUDIO *aud, SOUNDDATA *sound, double time, double len) {
 				aud->size = aud->size * 2;
 			}
 
-			int newval = *(short*)((int)aud->buffer + (paramlen + i) * 2) + (float)(*(short*)(sound->raw.data + i * 2)) * aud->volume * fade;
+			int newval = *(short*)((uintptr_t)aud->buffer + (paramlen + i) * 2) + (float)(*(short*)(sound->raw.data + i * 2)) * aud->volume * fade;
 
-			if (newval >= 0x7fff) *(short*)((int)aud->buffer + (paramlen + i) * 2) = 0x7fff;
-			else if (newval < -0x7fff) *(short*)((int)aud->buffer + (paramlen + i) * 2) = -0x8000;
-			else *(short*)((int)aud->buffer + (paramlen + i) * 2) = (short)newval;
+			if (newval >= 0x7fff) *(short*)((uintptr_t)aud->buffer + (paramlen + i) * 2) = 0x7fff;
+			else if (newval < -0x7fff) *(short*)((uintptr_t)aud->buffer + (paramlen + i) * 2) = -0x8000;
+			else *(short*)((uintptr_t)aud->buffer + (paramlen + i) * 2) = (short)newval;
 		}
 		return 1;
 	}

--- a/LR2/En_audio.cpp
+++ b/LR2/En_audio.cpp
@@ -16,6 +16,21 @@
 
 using std::uintptr_t;
 
+#ifndef _WIN32
+
+#include <chrono>
+
+#define LOWORD(l) ((WORD)(((DWORD_PTR)(l)) & 0xffff))
+#define HIWORD(l) ((WORD)((((DWORD_PTR)(l)) >> 16) & 0xffff))
+
+static DWORD timeGetTime()
+{
+	return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
+		.count();
+}
+
+#endif // _WIN32
+
 #include "Engine.h"
 
 //we got the fmodex 4.13.04. so we have no version problem now.
@@ -26,7 +41,6 @@ using std::uintptr_t;
 //https://www.fmod.com/docs/2.02/api/white-papers-transitioning-from-fmodex.html#system_adddsp-removed-from-the-system-api
 //https://www.fmod.com/docs/2.02/api/welcome-revision-history.html
 //http://upstream.rosalinux.ru/changelogs/fmod/44418/changelog.html
-
 
 //4b7b80
 const char* GetFMODerror(int errCode){
@@ -1289,10 +1303,10 @@ void RAWSOUND::MakeSampleRate44100(void) {
 						WORD lo = (int)((double)(unk[0] - LOWORD(val)) * (count / (double)(count + 1))) + LOWORD(val);
 
 						if ((int)hi >= 0x8000) hi = 0x7fff;
-						else if ((int)hi < -0x8000) hi = 0xffff8000;
+						else if ((int)hi < -0x8000) hi = 0xffff8000; // FIXME: narrowing
 
 						if ((int)lo >= 0x8000) lo = 0x7fff;
-						else if ((int)lo < -0x8000) lo = 0xffff8000;
+						else if ((int)lo < -0x8000) lo = 0xffff8000; // FIXME: narrowing
 
 						*unkd[j] = (hi << 16) | (lo && 0xffff);
 					}

--- a/LR2/En_audio.cpp
+++ b/LR2/En_audio.cpp
@@ -344,8 +344,7 @@ int EndSound(AUDIO *aud){
 }
 
 //4b82f0
-//v_chn not used
-int SOUND_dxlibFx(SOUNDDATA sound, int v_master, int v_chn, int pitch, double freq){
+int SOUND_dxlibFx(SOUNDDATA sound, int v_master, int /*v_chn*/, int pitch, double freq) {
 
 	double dMul;
 	
@@ -478,7 +477,7 @@ void WriteSoundFile(AUDIO *aud, CSTR filename, uint size) {
 }
 
 //4b8770
-int SOUND_normalize(AUDIO *aud, SOUNDDATA *sound){
+int SOUND_normalize(AUDIO */*aud*/, SOUNDDATA *sound){
 	uint len;
 	int bitdepth;
 	int channels;
@@ -777,7 +776,7 @@ int SOUND_FmodToDxlib(AUDIO *aud) {
 }
 
 //4b9340
-int ApplySoundFX(AUDIO *aud, int flag, char disable) {
+int ApplySoundFX(AUDIO *aud, int /*flag*/, char /*disable*/) {
 
 	if(aud->cmd_mediaOut) return 0;
 	if (aud->is_fmod_disabled == 1) {
@@ -1107,7 +1106,6 @@ int InitSound(AUDIO *aud, uint bufferLength, int numBuffer, char fDisable, int o
 
 	int numDrivers;
 	char driverName[256];
-	int chn2D, chn3D, chnTotal;
 
 	if (aud->cmd_mediaOut) {
 		FMOD_System_Create(&aud->fmodSys, FMOD_VERSION);

--- a/LR2/En_audio.cpp
+++ b/LR2/En_audio.cpp
@@ -1109,29 +1109,43 @@ int InitSound(AUDIO *aud, uint bufferLength, int numBuffer, char fDisable, int o
 		FMOD_System_Init(aud->fmodSys, 1, 0, NULL);
 		return 1;
 	}
-	else if (aud->is_fmod_disabled != true) {
+	if (!aud->is_fmod_disabled) {
 		ErrorLogAdd("サウンドシステムの初期化を行います。\n");
 		FMOD_System_Create(&aud->fmodSys, FMOD_VERSION);
 		FMOD_System_SetDSPBufferSize(aud->fmodSys, bufferLength, numBuffer);
 		ErrorLogAdd("\n");
 		FMOD_System_SetSoftwareChannels(aud->fmodSys, 0x100);
-		FMOD_System_Init(aud->fmodSys, 0x100, FMOD_INIT_NORMAL, NULL);
-		if (outputType == 0) {
-			FMOD_System_SetOutput(aud->fmodSys, FMOD_OUTPUTTYPE_WASAPI);
-			ErrorLogAdd("OUTPUT TYPE:DIRECTSOUND\n");
+		if (FMOD_System_Init(aud->fmodSys, 0x100, FMOD_INIT_NORMAL, NULL) != FMOD_OK) {
+			ErrorLogAdd("FMOD_System_Init failed!\n");
+			EndSound(aud);
+			return 1;
 		}
-		else if (outputType == 1) {
-			FMOD_System_SetOutput(aud->fmodSys, FMOD_OUTPUTTYPE_WASAPI);
-			ErrorLogAdd("OUTPUT TYPE:WASAPI\n");
+
+#ifdef _WIN32
+		if ([&] {
+			switch (outputType) {
+			case 0:
+			default:
+				ErrorLogAdd("OUTPUT TYPE:WASAPI (LR2 DIRECTSOUND config ignored)\n");
+				return FMOD_System_SetOutput(aud->fmodSys, FMOD_OUTPUTTYPE_WASAPI);
+			case 1:
+				ErrorLogAdd("OUTPUT TYPE:WASAPI\n");
+				return FMOD_System_SetOutput(aud->fmodSys, FMOD_OUTPUTTYPE_WASAPI);
+			case 2:
+				ErrorLogAdd("OUTPUT TYPE:ASIO\n");
+				return FMOD_System_SetOutput(aud->fmodSys, FMOD_OUTPUTTYPE_ASIO);
+			}
+			}() != FMOD_OK) {
+			ErrorLogAdd("FMOD_System_SetOutput failed! Using autodetect\n");
+			if (FMOD_System_SetOutput(aud->fmodSys, FMOD_OUTPUTTYPE_AUTODETECT) != FMOD_OK)
+			{
+				// FMOD_SYSTEM* is unusable after FMOD_System_SetOutput failed.
+				ErrorLogAdd("FMOD_System_SetOutput failed hard!\n");
+				EndSound(aud);
+				return 0;
+			}
 		}
-		else if (outputType == 2) {
-			FMOD_System_SetOutput(aud->fmodSys, FMOD_OUTPUTTYPE_ASIO);
-			ErrorLogAdd("OUTPUT TYPE:ASIO\n");
-		}
-		else{
-			FMOD_System_SetOutput(aud->fmodSys, FMOD_OUTPUTTYPE_WASAPI);
-			ErrorLogAdd("OUTPUT TYPE:DIRECTSOUND\n");
-		}
+#endif // _WIN32
 
 		FMOD_System_GetNumDrivers(aud->fmodSys, &numDrivers);
 		if (driver > numDrivers - 1) {

--- a/LR2/En_audio.cpp
+++ b/LR2/En_audio.cpp
@@ -505,6 +505,7 @@ int SOUND_normalize(AUDIO *aud, SOUNDDATA *sound){
 	sound->raw.dataSize = len;
 	sound->raw.samples = samples;
 	sound->raw.data = (byte *)malloc(len);
+	assert(sound->raw.data != nullptr);
 	
 	memcpy(sound->raw.data, sound, len);
 
@@ -547,6 +548,7 @@ int RecordSound(AUDIO *aud, SOUNDDATA *sound, double time, double len) {
 			if (aud->size <= paramlen + i) {
 				//exapnd aud buffer size (*2)
 				short* newbuffer = (short*)malloc(aud->size * 2 * 2);
+				assert(newbuffer != nullptr);
 				memset(newbuffer, 0, aud->size * 4);
 				memcpy(newbuffer, aud->buffer, aud->size * 2);
 				if (aud->buffer != NULL) {

--- a/LR2/En_dbio.cpp
+++ b/LR2/En_dbio.cpp
@@ -1,8 +1,17 @@
 #include "En_dbio.h"
 
+#include <cstring>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+using LPCSTR = const char*;
+#endif // _WIN32
+
 //444130 //TODO more readable
 //ANSI >> UTF-16(unicode) >> UTF-8
 bool ANSItoUTF8(LPCSTR str, char *oBuf, size_t *oSize){
+#ifdef _WIN32
 	int cchWideChar;
 	LPWSTR lpWideCharStr;
 	LPSTR lpMultiByteStr;
@@ -27,11 +36,15 @@ bool ANSItoUTF8(LPCSTR str, char *oBuf, size_t *oSize){
 	free(lpWideCharStr);
 	free(lpMultiByteStr);
 	return true;
+#else
+	return {}; // FIXME(linux): stub
+#endif // _WIN32
 }
 
 //444210
 //UTF-8 >> UTF-16(unicode) >> ANSI
 bool UTF8toANSI(LPCSTR str, char *oBuf, size_t *oSize){
+#ifdef _WIN32
 	int cchWideChar;
 	LPWSTR lpWideCharStr;
 	LPSTR lpMultiByteStr;
@@ -56,11 +69,14 @@ bool UTF8toANSI(LPCSTR str, char *oBuf, size_t *oSize){
 	free(lpWideCharStr);
 	free(lpMultiByteStr);
 	return true;
+#else
+	return {}; // FIXME(linux): stub
+#endif // _WIN32
 }
 
 //4442f0
 int SQL_Run(CSTR queryStr, sqlite3 *sql){
-	
+#ifdef _WIN32
 	int result;
 	int cchWideChar;
 	LPCWSTR lpWideCharStr;
@@ -85,11 +101,14 @@ int SQL_Run(CSTR queryStr, sqlite3 *sql){
 	result = sqlite3_exec(sql, oBuf, NULL, NULL, NULL);
 	free((void*)oBuf);
 	return result;
+#else
+	return {}; // FIXME(linux): stub
+#endif // _WIN32
 }
 
 //4443f0
 int SQL_prepare(CSTR queryStr, sqlite3 *sql, sqlite3_stmt **ppStmt){
-	
+#ifdef _WIN32
 	int cchWideChar;
 	LPCWSTR lpWideCharStr;
 	LPCSTR lpMultiByteStr;
@@ -114,6 +133,9 @@ int SQL_prepare(CSTR queryStr, sqlite3 *sql, sqlite3_stmt **ppStmt){
 	result = sqlite3_prepare(sql, oBuf, -1, ppStmt, NULL);
 	free((void*)oBuf);
 	return result;
+#else
+	return sqlite3_prepare(sql, queryStr.body, -1, ppStmt, nullptr); // FIXME(linux): stub
+#endif // _WIN32
 }
 
 //4444f0
@@ -128,11 +150,15 @@ CSTR SQL_GetColumn(int i, sqlite3_stmt *pStmt){
 	else {
 		sqlite3_column_bytes(pStmt, i);
 		columnText = (LPCSTR)sqlite3_column_text(pStmt, i);
+#ifdef _WIN32
 		UTF8toANSI(columnText, NULL, &size);
 		oBuf.resize2(size + 1);
 		memset(oBuf.body, 0, size + 1);
 		UTF8toANSI(columnText, oBuf.body, &size);
 		*oBuf.atPos(size) = 0;
+#else
+		oBuf = columnText; // FIXME(linux): stub
+#endif // _WIN32
 	}
 	return oBuf;
 }

--- a/LR2/En_dbio.h
+++ b/LR2/En_dbio.h
@@ -9,9 +9,6 @@ extern "C" {
 extern int EnabledInsane;
 inline std::mutex g_db_lock;
 
-bool ANSItoUTF8(LPCSTR str, char * oBuf, size_t * oSize);
-bool UTF8toANSI(LPCSTR str, char * oBuf, size_t * oSize);
-
 int SQL_Run(CSTR queryStr, sqlite3 * sql);
 int SQL_prepare(CSTR queryStr, sqlite3 * sql, sqlite3_stmt ** ppStmt);
 CSTR SQL_GetColumn(int i, sqlite3_stmt * pStmt);

--- a/LR2/En_fileutil.cpp
+++ b/LR2/En_fileutil.cpp
@@ -819,9 +819,9 @@ void MD5byte(char **iStr, uint len, char *oByte){
 	uVar13 = iVar20 + 0x80 + len;
 	piVar12 = (int *)realloc(*iStr, uVar13);
 	*iStr = (char *)piVar12;
-	memset((undefined *)((int)piVar12 + len), 0, iVar21);
-	piVar16 = (int *)((int)piVar12 + iVar21 + len);
-	*(undefined *)((int)piVar12 + len) = 0x80;
+	memset((undefined *)((uintptr_t)piVar12 + len), 0, iVar21);
+	piVar16 = (int *)((uintptr_t)piVar12 + iVar21 + len);
+	*(undefined *)((uintptr_t)piVar12 + len) = 0x80;
 	*piVar16 = len * 8;
 	piVar16[1] = len >> 0x1d;
 	iVar20 = 0x67452301;

--- a/LR2/En_fileutil.cpp
+++ b/LR2/En_fileutil.cpp
@@ -2,6 +2,12 @@
 #include <md5.h>
 #include "DxLib/DxLib.h" //log
 
+#ifndef _WIN32
+#include <chrono>
+#include <filesystem>
+#include <sys/stat.h>
+#endif // _WIN32
+
 //437210
 //437260
 //4372c0
@@ -44,14 +50,20 @@ int makeFileHash(LPCSTR filepath, LPCSTR oBuf) {
 
 //TODO : posix 2038y problem
 //437de0
-time_t GetNowUnixtime(void){
+time_t GetNowUnixtime() {
+#ifdef _WIN32
 	SYSTEMTIME systime;
-	_FILETIME filetime;
-
 	GetSystemTime((LPSYSTEMTIME)&systime);
+
+	_FILETIME filetime;
 	SystemTimeToFileTime(&systime, &filetime);
-		
+
 	return GetUnixtimeFromFiletime(filetime);
+#else
+	// TODO(linux): seconds? milliseconds?
+	return std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch())
+		.count();
+#endif // _WIN32
 }
 
 //437e90
@@ -62,6 +74,7 @@ time_t GetUnixtimeFromFiletime(FILETIME &filetime) {
 
 //437f00
 time_t GetFileUnixtime(CSTR str) {
+#ifdef _WIN32
 	WIN32_FIND_DATA FindFileData;
 	LPWIN32_FIND_DATAA lpFindFileData;
 	HANDLE hFindFile;
@@ -79,10 +92,20 @@ time_t GetFileUnixtime(CSTR str) {
 
 	FindClose(hFindFile);
 	return GetUnixtimeFromFiletime(FindFileData.ftLastWriteTime);
+#else
+	// TODO(linux): seconds? milliseconds?
+	struct stat sb;
+	int ret = stat(str.body, &sb);
+	if (ret != 0) {
+		return -1;
+	}
+	return static_cast<time_t>(sb.st_mtim.tv_sec);
+#endif
 }
 
 //438040
 CSTR GetRandomFileOnDir(CSTR path, char fOnlyName) {
+#ifdef _WIN32
 	CSTR oBuf;
 	//CSTR str1,str2,str3;
 	WIN32_FIND_DATA FindFileData;
@@ -137,7 +160,10 @@ CSTR GetRandomFileOnDir(CSTR path, char fOnlyName) {
 	}
 	//oBuf = CSTR("ERROR");
 	return CSTR("ERROR");
-
+#else
+	// FIXME(linux): stub
+	return CSTR("ERROR");
+#endif // _WIN32
 }
 
 //438540
@@ -304,6 +330,7 @@ bool IsLR2Folder(CSTR str) {
 
 //439510
 bool IsFileExist(CSTR path) {
+#ifdef _WIN32
 	HANDLE hFindFile;
 	_WIN32_FIND_DATAA findFileData;
 	char *cur;
@@ -322,11 +349,14 @@ bool IsFileExist(CSTR path) {
 		FindClose(-1);
 	}*/
 	return hFindFile != (HANDLE)-1;
+#else // TODO(refactor): is this implementation enough?
+	return std::filesystem::exists(path.body);
+#endif // _WIN32
 }
 
 //4396b0 //0:already_exist 1:not_exist 2:changed
 int IsFileChanged(unsigned int oldUnixtime, CSTR filepath, int *oNewtime) { 
-
+#ifdef _WIN32
 	HANDLE hFindFile;
 	char* lpFileName;
 	_WIN32_FIND_DATAA findFileData;
@@ -353,6 +383,12 @@ int IsFileChanged(unsigned int oldUnixtime, CSTR filepath, int *oNewtime) {
 		FindClose(hFindFile);
 		return 0;
 	}
+#else
+	// FIXME(linux): stub
+	if (!IsFileExist(filepath))
+		return 1;
+	return 0;
+#endif // _WIN32
 }
 
 //439820
@@ -721,18 +757,18 @@ int FindAltSound(CSTR filename, CSTR dir, CSTR *oBuf) {
 
 //43a900
 CSTR GetRandomFile(CSTR path, char fOnlyName) {
-	WIN32_FIND_DATA FindFileData;
-	HANDLE hFindFile;
 	CSTR oBuf;
 	int count;
 
 	//call function if wildcard is on directory
 	if (path.findStrPos("*/") != -1 || path.findStrPos("*\\") != -1 || path.right(1).isSame("*")) {
-		return CSTR(GetRandomFileOnDir(path, fOnlyName));
+		return GetRandomFileOnDir(path, fOnlyName);
 	}
 
+#ifdef _WIN32
+	WIN32_FIND_DATA FindFileData;
 	//count files for random
-	hFindFile = FindFirstFileA(path, (LPWIN32_FIND_DATAA)&FindFileData);
+	HANDLE hFindFile = FindFirstFileA(path, (LPWIN32_FIND_DATAA)&FindFileData);
 	if (hFindFile == (HANDLE)-1) return CSTR("ERROR");
 	
 	count = 0;
@@ -757,11 +793,21 @@ CSTR GetRandomFile(CSTR path, char fOnlyName) {
 		path.assign((char*)FindFileData.cFileName);
 		path.nullAtPos(path.findStrPos("."));
 	}
-	return CSTR(path);
+	return path;
+#else
+	// FIXME(linux): stub
+	path.replace("\\", "/");
+	return path;
+#endif // _WIN32
 }
 
 //43abe0
 CSTR GetRandomFileNoError(CSTR path, CSTR dir) {
+#ifndef _WIN32
+	// TODO(linux): check if needed
+	path.replace("\\" ,"/");
+	dir.replace("\\" ,"/");
+#endif // _WIN32
 	CSTR filepath;
 	filepath.assign(GetRandomFile(path, 0));
 	if (filepath.isDiff("ERROR")) return CSTR(filepath);

--- a/LR2/En_fileutil.cpp
+++ b/LR2/En_fileutil.cpp
@@ -76,10 +76,9 @@ time_t GetFileUnixtime(CSTR str) {
 		ErrorLogFmtAdd("ファイルのLR2TIME取得エラー:%sが見つからない\n", str);
 		return -1;
 	}
-	else {
-		FindClose(hFindFile);
-		return GetUnixtimeFromFiletime(FindFileData.ftLastWriteTime);
-	}
+
+	FindClose(hFindFile);
+	return GetUnixtimeFromFiletime(FindFileData.ftLastWriteTime);
 }
 
 //438040
@@ -87,7 +86,6 @@ CSTR GetRandomFileOnDir(CSTR path, char fOnlyName) {
 	CSTR oBuf;
 	//CSTR str1,str2,str3;
 	WIN32_FIND_DATA FindFileData;
-	LPWIN32_FIND_DATAA lpFindFileData;
 	HANDLE hFindFile;
 	int fileCount = 0;
 	CSTR str1( path.left(path.findStrPos("*")) );
@@ -99,52 +97,47 @@ CSTR GetRandomFileOnDir(CSTR path, char fOnlyName) {
 		//oBuf = CSTR("ERROR");
 		return CSTR("ERROR");
 	}
-	else {
-		do {
-			if (FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-				if (strcmp("..", (char*)FindFileData.cFileName) && strcmp(".", (char*)FindFileData.cFileName)) fileCount++;
-			}
-		} while (FindNextFileA(hFindFile, (LPWIN32_FIND_DATAA)&FindFileData));
-		FindClose(hFindFile);
-		if (fileCount > 0) {
-			fileCount = GetRand(fileCount - 1);
-
-			hFindFile = FindFirstFileA(str3, (LPWIN32_FIND_DATAA)&FindFileData);
-			if (hFindFile != (HANDLE)-1) {
-				do {
-					if (FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-						if (strcmp("..", (char*)FindFileData.cFileName) && strcmp(".", (char*)FindFileData.cFileName)) {
-							//LAB_00438327
-							int i = 0;
-							while (i < fileCount) {
-								FindNextFileA(hFindFile, (LPWIN32_FIND_DATAA)&FindFileData);
-								if (FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-									if (strcmp("..", (char*)FindFileData.cFileName) && strcmp(".", (char*)FindFileData.cFileName)) i++;
-								}
-							}
-							FindClose(hFindFile);
-							path.assign(&str1);
-							path.add((char*)FindFileData.cFileName);
-							path.add(&str2);
-							if (fOnlyName) {
-								//oBuf = CSTR(FindFileData.cFileName);
-								return CSTR((char*)FindFileData.cFileName);
-							}
-							else {
-								//oBuf = CSTR(path);
-								return CSTR(path);
-							}
-							return oBuf;
-						}
-					}
-					FindNextFileA(hFindFile, (LPWIN32_FIND_DATAA)&FindFileData);
-				} while (true);
-			}
+	do {
+		if (FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+			if (strcmp("..", (char*)FindFileData.cFileName) && strcmp(".", (char*)FindFileData.cFileName)) fileCount++;
 		}
-		//oBuf = CSTR("ERROR");
-		return CSTR("ERROR");
+	} while (FindNextFileA(hFindFile, (LPWIN32_FIND_DATAA)&FindFileData));
+	FindClose(hFindFile);
+	if (fileCount > 0) {
+		fileCount = GetRand(fileCount - 1);
+
+		hFindFile = FindFirstFileA(str3, (LPWIN32_FIND_DATAA)&FindFileData);
+		if (hFindFile != (HANDLE)-1) {
+			do {
+				if (FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+					if (strcmp("..", (char*)FindFileData.cFileName) && strcmp(".", (char*)FindFileData.cFileName)) {
+						//LAB_00438327
+						int i = 0;
+						while (i < fileCount) {
+							FindNextFileA(hFindFile, (LPWIN32_FIND_DATAA)&FindFileData);
+							if (FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+								if (strcmp("..", (char*)FindFileData.cFileName) && strcmp(".", (char*)FindFileData.cFileName)) i++;
+							}
+						}
+						FindClose(hFindFile);
+						path.assign(&str1);
+						path.add((char*)FindFileData.cFileName);
+						path.add(&str2);
+						if (fOnlyName) {
+							//oBuf = CSTR(FindFileData.cFileName);
+							return CSTR((char*)FindFileData.cFileName);
+						}
+						//oBuf = CSTR(path);
+						return CSTR(path);
+					}
+				}
+				FindNextFileA(hFindFile, (LPWIN32_FIND_DATAA)&FindFileData);
+			} while (true);
+		}
 	}
-	return oBuf;
+	//oBuf = CSTR("ERROR");
+	return CSTR("ERROR");
+
 }
 
 //438540
@@ -395,7 +388,7 @@ int DealWhiteSpace(CSTR *str) {
 }
 
 //439a30 SplitCSV
-int SplitCSV(CSTR csvStr, CSVbuf *oBuf, const char *splitter) {
+int SplitCSV(CSTR csvStr, CSVbuf *oBuf, const char */*splitter*/) {
 	int pos,i;
 	bool bEnd = false;
 	
@@ -737,7 +730,6 @@ int FindAltSound(CSTR filename, CSTR dir, CSTR *oBuf) {
 //43a900
 CSTR GetRandomFile(CSTR path, char fOnlyName) {
 	WIN32_FIND_DATA FindFileData;
-	LPWIN32_FIND_DATAA lpFindFileData;
 	HANDLE hFindFile;
 	CSTR oBuf;
 	int count;
@@ -977,7 +969,6 @@ void MD5byte(char **iStr, uint len, char *oByte){
 	*(int *)oByte = iVar20;
 	*(uint *)(oByte + 8) = uVar19;
 	*(uint *)(oByte + 0xc) = uVar17;
-	return;
 }
 
 //443ff0

--- a/LR2/En_fileutil.cpp
+++ b/LR2/En_fileutil.cpp
@@ -781,6 +781,10 @@ CSTR GetRandomFileNoError(CSTR path, CSTR dir) {
 
 //443550 _ need simplification
 void MD5byte(char **iStr, uint len, char *oByte){
+#ifdef _MSC_VER
+#pragma warning (push)
+#pragma warning (disable: 4554) // ignore >> precedence
+#endif
 	int iVar1;
 	int iVar2;
 	int iVar3;
@@ -969,6 +973,9 @@ void MD5byte(char **iStr, uint len, char *oByte){
 	*(int *)oByte = iVar20;
 	*(uint *)(oByte + 8) = uVar19;
 	*(uint *)(oByte + 0xc) = uVar17;
+#ifdef _MSC_VER
+#pragma warning (pop)
+#endif
 }
 
 //443ff0

--- a/LR2/En_fileutil.cpp
+++ b/LR2/En_fileutil.cpp
@@ -66,8 +66,8 @@ time_t GetFileUnixtime(CSTR str) {
 	LPWIN32_FIND_DATAA lpFindFileData;
 	HANDLE hFindFile;
 
-	if ( str.right(1).isSame("\\") ) {
-		str.nullAtPos( str.length() - 1 );
+	if (str.right(1).isSame("\\") ||  str.right(1).isSame("/")) {
+		str.nullAtPos(str.length() - 1);
 	}
 
 	lpFindFileData = (LPWIN32_FIND_DATAA)&FindFileData;
@@ -306,18 +306,10 @@ bool IsLR2Folder(CSTR str) {
 bool IsFileExist(CSTR path) {
 	HANDLE hFindFile;
 	_WIN32_FIND_DATAA findFileData;
-	bool isDir = false;
 	char *cur;
 	char dirFlag = 0;
 
-	if (path.right(1).isSame("\\") == true) {
-		isDir = true;
-	}
-	else if (path.right(1).isSame("/") == true) {
-		isDir = true;
-	}
-
-	if (isDir) {
+	if (path.right(1).isSame("\\") || path.right(1).isSame("/")) {
 		cur = path.atPos(path.length() - 1);
 		*cur = 0;
 	}
@@ -339,7 +331,7 @@ int IsFileChanged(unsigned int oldUnixtime, CSTR filepath, int *oNewtime) {
 	char* lpFileName;
 	_WIN32_FIND_DATAA findFileData;
 
-	if (filepath.right(1).isSame("\\")) {
+	if (filepath.right(1).isSame("\\") || filepath.right(1).isSame("/")) {
 		filepath.nullAtPos(filepath.length() - 1);
 	}
 	lpFileName = filepath;
@@ -599,7 +591,7 @@ int FindAltImage(CSTR filename, CSTR dir, CSTR *oBuf) {
 		}
 	}
 
-	path.assign(dir).add("..\\").add(filename);
+	path.assign(dir).add("../").add(filename);
 	if (IsFileExist(path)) {
 		oBuf->assign(path);
 		return 1;
@@ -683,7 +675,7 @@ int FindAltSound(CSTR filename, CSTR dir, CSTR *oBuf) {
 		}
 	}
 
-	path.assign(dir).add("..\\").add(filename);
+	path.assign(dir).add("../").add(filename);
 	if (IsFileExist(path)) {
 		oBuf->assign(path);
 		return 1;

--- a/LR2/En_fileutil.h
+++ b/LR2/En_fileutil.h
@@ -1,4 +1,34 @@
+#pragma once
+
 #include "structure.h"
+#include "strclass.h"
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+#else
+
+#define ULONGLONG unsigned long long
+
+typedef union _ULARGE_INTEGER {
+  struct {
+    DWORD LowPart;
+    DWORD HighPart;
+  } DUMMYSTRUCTNAME;
+  struct {
+    DWORD LowPart;
+    DWORD HighPart;
+  } u;
+  ULONGLONG QuadPart;
+} ULARGE_INTEGER;
+
+typedef struct _FILETIME {
+  DWORD dwLowDateTime;
+  DWORD dwHighDateTime;
+} FILETIME, *PFILETIME, *LPFILETIME;
+
+#endif // _WIN32
 
 //hash
 int makeFileHash(LPCSTR filepath, LPCSTR oBuf);

--- a/LR2/En_input.cpp
+++ b/LR2/En_input.cpp
@@ -34,7 +34,7 @@ void EndMIDIInput(void){
 }
 
 //4bd740
-void GetMidiInput(dword msg, dword timestamp) {
+void GetMidiInput(dword msg, dword /*timestamp*/) {
 	// http://www.gweep.net/~prefect/eng/reference/protocol/midispec.html
 	byte status = (msg & 0xff);
 	byte data1 = LOWORD(msg) >> 8;
@@ -285,7 +285,7 @@ void ProcessInput(inputStructure *is, int interval) {
 }
 
 //4bef60
-void CALLBACK MIDIInProc(HMIDIIN hMidiIn, uint wMsg, dword dwInstance, dword dwParam1, dword dwParam2){
+void CALLBACK MIDIInProc(HMIDIIN /*hMidiIn*/, uint wMsg, dword /*dwInstance*/, dword dwParam1, dword dwParam2){
 	if (wMsg == 0x3c3) { // = 963
 		GetMidiInput(dwParam1, dwParam2);
 	}
@@ -418,9 +418,7 @@ int InputToButton(inputStructure *is, CONFIG_INPUT *cfg_input, int player, int i
 
 //4bf3e0
 void InitMIDIInput(void){
-	int iVar1;
 	UINT numDev;
-	UINT uDeviceID;
 	HMIDIIN phmi;
 
 	for (int i = 0; i < 256; i++) { //TOFIX : unneccessary loop

--- a/LR2/En_input.cpp
+++ b/LR2/En_input.cpp
@@ -1,7 +1,16 @@
 ﻿#include "En_input.h"
 #include "En_timer.h"
 
+#include <DxLib/DxLib.h>
+
+#include <cstring>
+
 MIDI midi;
+
+#ifndef _WIN32
+#define LOWORD(l) ((WORD)(((DWORD_PTR)(l)) & 0xffff))
+#define HIWORD(l) ((WORD)((((DWORD_PTR)(l)) >> 16) & 0xffff))
+#endif
 
 //4bd6a0 //TODO structure array rework
 int InitInputStructure2(inputStructure *is){
@@ -19,6 +28,7 @@ int InitInputStructure2(inputStructure *is){
 
 //4bd6f0
 void EndMIDIInput(void){
+#ifdef _WIN32
 	UINT numDev;
 
 	numDev = midiInGetNumDevs();
@@ -30,7 +40,7 @@ void EndMIDIInput(void){
 		midiInStop(midi.phmiArray[i]);
 		midiInClose(midi.phmiArray[i]);
 	}
-	return;
+#endif // _WIN32
 }
 
 //4bd740
@@ -123,7 +133,9 @@ void ProcessInput(inputStructure *is, int interval) {
 	char new_keyInput[256];
 	int keyError;
 
+#ifdef _WIN32 // TODO(linux): implement?
 	if (GetWindowActiveFlag() == 0) return;
+#endif // _WIN32
 
 	GetMousePoint(&mouseX, &mouseY);
 	is->mouse_moveX = mouseX - is->mouse_oldX;
@@ -168,7 +180,6 @@ void ProcessInput(inputStructure *is, int interval) {
 		}
 	}
 
-	
 	if ((GetMouseInput() & 2) == 0) {
 		if (is->mouse_buttonR == 0 || is->mouse_buttonR == 3) {
 			is->mouse_buttonR = 0;
@@ -294,7 +305,6 @@ void CALLBACK MIDIInProc(HMIDIIN /*hMidiIn*/, uint wMsg, dword /*dwInstance*/, d
 
 //4bef80
 int WaitInput(inputStructure *is){
-
 	is->is_doubleclick = 0;
 	is->mousewheel = 0;
 	is->mouse_buttonL = 0;
@@ -418,6 +428,7 @@ int InputToButton(inputStructure *is, CONFIG_INPUT *cfg_input, int player, int i
 
 //4bf3e0
 void InitMIDIInput(void){
+#ifdef _WIN32
 	UINT numDev;
 	HMIDIIN phmi;
 
@@ -436,7 +447,7 @@ void InitMIDIInput(void){
 		midiInStart(phmi);
 		midi.phmiArray[i] = phmi;
 	}
-	return;
+#endif // _WIN32
 }
 
 //4bf480

--- a/LR2/En_input.h
+++ b/LR2/En_input.h
@@ -1,9 +1,15 @@
 #pragma once
+
 #include "structure.h"
+
+#ifdef _WIN32
 #include <windows.h>
-
-#include "DxLib/DxLib.h"
-
+#else
+struct HMIDIIN {};
+#ifndef CALLBACK
+#define CALLBACK
+#endif // CALLBACK
+#endif // _WIN32
 
 typedef struct MIDI {
 	byte input[260]; //0x101:ptich_minus 0x102:pitch_plus 0x103:pedal;

--- a/LR2/En_recordmovie.cpp
+++ b/LR2/En_recordmovie.cpp
@@ -47,7 +47,7 @@ bool RECORDING::Release() {
 }
 
 //4bf610
-int REC_CpyAVIStreamToFile(PAVIFILE pfile, PAVISTREAM pavi, int unused) {
+int REC_CpyAVIStreamToFile(PAVIFILE pfile, PAVISTREAM pavi, int /*unused*/) {
 
 	unsigned int lpos;
 	AVISTREAMINFOA si;

--- a/LR2/En_recordmovie.cpp
+++ b/LR2/En_recordmovie.cpp
@@ -1,10 +1,20 @@
-﻿#pragma comment(lib,"vfw32.lib")
-#include "En_recordmovie.h"
-#include "DxLib/DxLib.h"
+﻿#include "En_recordmovie.h"
+
+#include <cstring>
+
+#include "structure.h"
+
+#include <DxLib/DxLib.h>
+
+#ifdef _WIN32
+#pragma comment(lib,"vfw32.lib")
+ #include <windows.h>
+ #include <vfw.h>
+#endif
 
 //4bf4f0
 RECORDING::RECORDING() {
-	memset(this, 0, sizeof(RECORDING));
+	memset(this, 0, sizeof(RECORDING)); // FIXME: bad memset
 }
 
 //4bf510
@@ -20,15 +30,19 @@ int RECORDING::GetCurTime() {
 
 //4bf540
 int RECORDING::CpyScreenToAVI() {
+#ifdef _WIN32
 	this->srcHDC = GetDC(this->hwnd);
 	BitBlt(this->dstHDC, 0, 0, this->bmiHeader.biWidth, this->bmiHeader.biHeight, this->srcHDC, 0, 0, SRCCOPY);
 	ReleaseDC(this->hwnd, this->srcHDC);
 	return AVIStreamWrite(this->pAVIstream, this->writeSamplePos++, 1, this->buf, this->bmiHeader.biSizeImage, AVIIF_KEYFRAME, 0, 0); //watch out that ++
+#else
+	return {};
+#endif // _WIN32
 }
 
 //4bf5b0
 bool RECORDING::Release() {
-	
+#ifdef _WIN32
 	if (this->compvars.hic) {
 		ICCompressorFree(&this->compvars);
 		this->compvars.hic = NULL;
@@ -44,10 +58,14 @@ bool RECORDING::Release() {
 		this->pAVIFILE = NULL;
 	}
 	return true;
+#else
+	return {};
+#endif // _WIN32
 }
 
+#ifdef _WIN32
 //4bf610
-int REC_CpyAVIStreamToFile(PAVIFILE pfile, PAVISTREAM pavi, int /*unused*/) {
+static int REC_CpyAVIStreamToFile(PAVIFILE pfile, PAVISTREAM pavi, int /*unused*/) {
 
 	unsigned int lpos;
 	AVISTREAMINFOA si;
@@ -91,7 +109,7 @@ int REC_CpyAVIStreamToFile(PAVIFILE pfile, PAVISTREAM pavi, int /*unused*/) {
 }
 
 //4bf7f0
-int CreateStream(CSTR filename, int framerate, COMPVARS *compvars, BITMAPINFOHEADER* lpbmi, PAVIFILE* pAVIFILE, PAVISTREAM* pAVIstream) {
+static int CreateStream(CSTR filename, int framerate, COMPVARS *compvars, BITMAPINFOHEADER* lpbmi, PAVIFILE* pAVIFILE, PAVISTREAM* pAVIstream) {
 
 	IAVIFile* pFile;
 	AVISTREAMINFOA si;
@@ -140,10 +158,11 @@ int CreateStream(CSTR filename, int framerate, COMPVARS *compvars, BITMAPINFOHEA
 	AVIStreamRelease(pavi);
 	return 1;
 }
+#endif // _WIN32
 
 //4bfa10
 bool RECORDING::PrepareAVIRecord(double framerate, int bit, CSTR filename, uint frameLen, HWND hwnd) {
-	
+#ifdef _WIN32
 	tagRECT cRect;
 
 	this->framerate = framerate;
@@ -200,11 +219,14 @@ bool RECORDING::PrepareAVIRecord(double framerate, int bit, CSTR filename, uint 
 	this->hBIT = CreateDIBSection(NULL, (BITMAPINFO*)&this->bmiHeader, 0, &this->buf, NULL, 0); //it needs bitmapInfo(44bytes), not bitmapInfoHeader(40bytes)
 	this->hGDI = SelectObject(this->dstHDC, this->hBIT);
 	return 1;
+#else
+	return {};
+#endif // _WIN32
 }
 
+#ifdef _WIN32
 //4bfcb0
 int RECORDING::InsertAudioToMovie(CSTR pathAudio, bool deleteFlag) {
-
 	CSTR path(pathAudio);
 	bool isMp3 = path.lower().right(3).isSame("mp3");
 
@@ -240,9 +262,10 @@ int RECORDING::InsertAudioToMovie(CSTR pathAudio, bool deleteFlag) {
 
 	return 1;
 }
+#endif // _WIN32
 
 //4bfec0
-int REC_COPYFILE(FILE *oFile, FILE *iFile, uint size){
+static int REC_COPYFILE(FILE *oFile, FILE *iFile, uint size){
 	void *buf;
 	uint bufSize;
 	uint _Count;

--- a/LR2/En_recordmovie.cpp
+++ b/LR2/En_recordmovie.cpp
@@ -77,8 +77,9 @@ int REC_CpyAVIStreamToFile(PAVIFILE pfile, PAVISTREAM pavi, int unused) {
 		for (; lpos <= totalLength; lpos += samples) {
 			if (!(AVIStreamRead(pavi, lpos, -1, NULL, 0, &sz, &samples) == 0 && sz > 0 && samples > 0)) break;
 			if (AVIStreamRead(pavi, lpos, 4096, NULL, 0, &sz, &samples) != 0) break;
-			lpFormat = realloc(lpFormat, sz);
-			if (lpFormat == NULL) break;
+			auto* format = realloc(lpFormat, sz);
+			if (format == nullptr) break;
+			lpFormat = format;
 			if (AVIStreamRead(pavi, lpos, samples, lpFormat, sz, &sz, &samples) != 0) break;
 			if (AVIStreamWrite(pNewavi, lpos, samples, lpFormat, sz, 0, NULL, NULL) != 0) break;
 		}

--- a/LR2/En_recordmovie.cpp
+++ b/LR2/En_recordmovie.cpp
@@ -154,7 +154,7 @@ bool RECORDING::PrepareAVIRecord(double framerate, int bit, CSTR filename, uint 
 	this->curFrame = 0;
 
 	remove(filename);
-	CSTR dat("LR2files\\Config\\compvars.dat");
+	CSTR dat("LR2files/Config/compvars.dat");
 
 	if (dat.canOpenFile()) {
 		FILE* pFile = fopen(dat, "rb");
@@ -167,7 +167,7 @@ bool RECORDING::PrepareAVIRecord(double framerate, int bit, CSTR filename, uint 
 		memset(&this->compvars, 0, sizeof(COMPVARS));
 		this->compvars.cbSize = 64;
 		if (ICCompressorChoose(NULL,0,NULL,NULL,&this->compvars,NULL) == 0) return false;
-		FILE *pFile = fopen("LR2files\\Config\\compvars.dat", "wb");
+		FILE *pFile = fopen("LR2files/Config/compvars.dat", "wb");
 		fwrite(&this->compvars, sizeof(COMPVARS), 1, pFile);
 		fclose(pFile);
 		MessageBoxA(NULL, "圧縮設定が保存されました。\n設定の変更はJUKEBOXタブ→詳細設定→動画圧縮設定で行えます。", "報告", 0);

--- a/LR2/En_recordmovie.h
+++ b/LR2/En_recordmovie.h
@@ -1,20 +1,6 @@
 #pragma once
-#include "structure.h"
-#include <windows.h>
-#include <vfw.h>
 
-
-	// RECORDING();
-	// bool RefreshCurFrame();
-	// int GetCurTime();
-	// int CpyScreenToAVI();
-	// bool Release();
-	// bool PrepareAVIRecord(double framerate, int bit, CSTR filename, uint frameLen, HWND hwnd);
-	// int InsertAudioToMovie(CSTR pathAudio, bool deleteFlag);
-    
-int REC_CpyAVIStreamToFile(PAVIFILE pfile, PAVISTREAM pavi, int unused);
-int CreateStream(CSTR filename, int framerate, COMPVARS *compvars, BITMAPINFOHEADER* lpbmi, PAVIFILE* pAVIFILE, PAVISTREAM* pAVIstream);
-int REC_COPYFILE(FILE *oFile, FILE *iFile, uint size);
+#include <cstdio>
 
 int Mp3toWavF(FILE * iFile, FILE * oFile);
 bool Mp3toWavP(char * iPath, char * oPath);

--- a/LR2/En_timer.cpp
+++ b/LR2/En_timer.cpp
@@ -1,10 +1,25 @@
 ﻿#include "En_timer.h"
-#include <Windows.h>
 #include "DxLib/DxLib.h" // for error log
 
 double manualTimer;
 bool flagManualTimer;
 bool flagHighPerformanceTimer;
+
+#ifdef _WIN32
+
+#include <Windows.h>
+
+#else
+
+static DWORD timeGetTime()
+{
+	return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
+		.count();
+}
+static void timeBeginPeriod(int /*unused*/) {}
+static void timeEndPeriod(int /*unused*/) {}
+
+#endif // _WIN32
 
 //4b6710
 int SetManualTimer(Timer *T, double newTime){
@@ -51,30 +66,28 @@ int ResetTimeLapse(int timerID, Timer *T){
 
 //4b6800 //logic shortened
 double GetTime(void){
-	DWORD time;
+#ifdef _WIN32
 	LARGE_INTEGER pfc_time;
 	LARGE_INTEGER pfc_freq;
-
 	if (flagHighPerformanceTimer){
 		if (QueryPerformanceFrequency(&pfc_freq)) {
 			QueryPerformanceCounter(&pfc_time);
 			return (double)pfc_time.QuadPart*1000 / (double)pfc_freq.QuadPart;
 		}
 	}
+#endif // _WIN32
 
-	time = timeGetTime();
+	DWORD time = timeGetTime();
 	return (double)(time & 0x7fffffff);
 }
 
 //4b6890
 double GetTimeWrap(void) {
-	double ret;
-
 	if (flagManualTimer) {
 		return manualTimer;
 	}
 	timeBeginPeriod(1);
-	ret = GetTime();
+	double ret = GetTime();
 	timeEndPeriod(1);
 	return ret;
 }

--- a/LR2/En_timer.cpp
+++ b/LR2/En_timer.cpp
@@ -54,7 +54,6 @@ double GetTime(void){
 	DWORD time;
 	LARGE_INTEGER pfc_time;
 	LARGE_INTEGER pfc_freq;
-	double ret;
 
 	if (flagHighPerformanceTimer){
 		if (QueryPerformanceFrequency(&pfc_freq)) {
@@ -114,8 +113,6 @@ int CalcFPS(Timer *t){
 
 //4b6b10
 double GetTimeLapse(uint timerID, Timer *T) {
-	double ret;
-
 	if (500 < timerID) return -1.0;
 	if (timerID == 140) return T->Rhythm;
 

--- a/LR2/En_xml.cpp
+++ b/LR2/En_xml.cpp
@@ -117,7 +117,7 @@ void WriteXML_Tab2Str(FILE *hFile, const char *tag, CSTR str){
 	str.replace(">", "&gt;");
 	str.replace("\'", "&apos;");
 	str.replace("\"", "&quot;");
-	sprintf(buf, "\t\t<%s>%s</%s>\n", tag, str, tag);
+	sprintf(buf, "\t\t<%s>%s</%s>\n", tag, str.body, tag);
 	fputs(buf, hFile);
 	return;
 }

--- a/LR2/En_xml.cpp
+++ b/LR2/En_xml.cpp
@@ -1,6 +1,4 @@
-﻿#pragma once
-
-#include "En_xml.h"
+﻿#include "En_xml.h"
 #include "tinyxml/tinyxml.h"
 
 //43c060

--- a/LR2/Engine.h
+++ b/LR2/Engine.h
@@ -38,7 +38,6 @@
 
 
 #include "DxLib/DxLib.h"
-#include <process.h>
 
 
 //temp DEBUG

--- a/LR2/LR2_audio.cpp
+++ b/LR2/LR2_audio.cpp
@@ -417,6 +417,9 @@ int ReadLR2SoundSet(game *g, CSTR filepath, char reFlag) {
 				}
 			}
 
+#ifndef _WIN32 // TODO(linux): check if needed
+			csv.str[1].replace("\\" ,"/");
+#endif // _WIN32
 			if (fBuf.left(7).isSame("#SELECT") && !load_select) {
 				LoadSound(&g->audio, &g->audio.sysSound.select, GetRandomFileNoError(csv.str[1], dir), 1, g->config.sound.disabledsp, 0);
 				if (g->audio.sysSound.select.load) load_select = true;

--- a/LR2/LR2_audio.cpp
+++ b/LR2/LR2_audio.cpp
@@ -328,7 +328,7 @@ int ReadLR2SoundSet(game *g, CSTR filepath, char reFlag) {
 	if (g->audio.is_fmod_disabled == 0) FMOD_System_Update(g->audio.fmodSys);
 
 	CSTR path;
-	cstrSprintf(&path, "LR2files\\SkinCustomize\\%s.xml", MD5str(filepath));
+	cstrSprintf(&path, "LR2files/SkinCustomize/%s.xml", MD5str(filepath));
 	ReadSkinCustomize(&sku, path);
 	
 	CSTR dir(filepath.getDirectory());

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -2,6 +2,8 @@
 #include "Engine.h"
 #include "LR2_replay.h"
 
+#include <algorithm>
+
 //4081d0
 int StopAllKeysound(game *g){
 	for (int i = 0; i < 6480; i++) {
@@ -514,7 +516,9 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 		return 1;
 	}
 	
+#ifdef _WIN32
 	if (cfg->system.isablebmsthread == 0) CoInitialize(NULL);
+#endif // _WIN32
 	GetTransColor(&Rtmp,&Gtmp,&Btmp);
 	SetTransColor(0,0,0);
 	for (int i = 0; i < 6480; i++) {
@@ -531,13 +535,17 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 		}
 
 		if (gp->flag_closingPhase) {
+#ifdef _WIN32
 			if (cfg->system.isablebmsthread == 0) CoUninitialize();
+#endif // _WIN32
 			return 1;
 		}
 	}
 
 	SetTransColor(Rtmp, Gtmp, Btmp);
+#ifdef _WIN32
 	if (cfg->system.isablebmsthread == 0) CoUninitialize();
+#endif // _WIN32
 	if (gp->bgaHandle[0] != -1) gp->missLayer = 0;
 
 	if (gp->isAutoplay == 1) {

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -474,7 +474,7 @@ int InitGameplay(gameplay *gp, CONFIG_PLAY *cfg) {
 }
 
 //4acc60
-int LoadBmsResource(gameplay *gp, CSTR BMSfilepath, AUDIO *aud, ConfigStruct *cfg, BMSMETA *meta, char bga, char flip, char noVideo){
+int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct *cfg, BMSMETA */*meta*/, char /*bga*/, char /*flip*/, char noVideo){
 
 	int Rtmp, Gtmp, Btmp;
 
@@ -1745,14 +1745,14 @@ int SPtoDP(LaneStruct *lane, int baseNoteID, CHARTCONVERTER *cc) {
 				}
 				cc->flagSplitUnknown ^= 1;
 			}
-			else if (0 < 0) {
+			else /*if (0 < 0)*/ {
 				cc->arr1[i].field3_0xc = 1;
 				unkArr[1] += cc->arr1[i].count;
 			}
-			else {
-				cc->arr1[i].field3_0xc = 0;
-				unkArr[0] += cc->arr1[i].count;
-			}
+			//else {
+			//	cc->arr1[i].field3_0xc = 0;
+			//	unkArr[0] += cc->arr1[i].count;
+			//}
 		}
 	}
 	

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -2033,7 +2033,7 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 			ErrorLogAdd("BMSを開けません。\n");
 			return -1;
 		}
-		if (isPMS = filename.right(4).lower().isSame(".pms")) {
+		if (isPMS = filename.right(4).lower().isSame(".pms"); isPMS) {
 			is9key = 1;
 		}
 		else if (meta->keymode == 9) {

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -3763,7 +3763,7 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 			if (recover <= 0) recover = 1;
 
 			double dmg_totalbase = 100.0 / (double)recover;
-			double dmg = max(dmg_notebase * 10, dmg_totalbase) / 10.0;
+			double dmg = std::max(dmg_notebase * 10, dmg_totalbase) / 10.0;
 
 			if (!gp->isCourse) {
 				gp->player[p].judge_damage[0][5] = total[p] / (float)notes;

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -79,6 +79,7 @@ int ExpandNoteBuffer(LaneStruct *lane, int addsize){
 	oldCount = lane->size;
 	lane->size += addsize;
 	lane->notes = (NoteStruct*)realloc(lane->notes, (lane->size) * sizeof(NoteStruct));
+	assert(lane->notes != nullptr);
 
 	for (int i = oldCount; i < lane->size; i++) {
 		lane->notes[i].bmsTiming_ln = -1.0;
@@ -2608,6 +2609,7 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 					if (gp->bpmt_count == gp->bpmt_buffersize) {
 						gp->bpmt_buffersize += 100;
 						gp->bpmt_data = (BPMtiming*)realloc(gp->bpmt_data, gp->bpmt_buffersize * sizeof(BPMtiming));
+						assert(gp->bpmt_data != nullptr);
 						for (int i = gp->bpmt_buffersize - 100; i < gp->bpmt_buffersize; i++) {
 							gp->bpmt_data[i].BPM = 0;
 							gp->bpmt_data[i].converted = 0;
@@ -2622,6 +2624,7 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 					if (gp->bpmt_count == gp->bpmt_buffersize) {
 						gp->bpmt_buffersize += 100;
 						gp->bpmt_data = (BPMtiming*)realloc(gp->bpmt_data, gp->bpmt_buffersize * sizeof(BPMtiming));
+						assert(gp->bpmt_data != nullptr);
 						for (int i = gp->bpmt_buffersize - 100; i < gp->bpmt_buffersize; i++) {
 							gp->bpmt_data[i].BPM = 0;
 							gp->bpmt_data[i].converted = 0;
@@ -2719,6 +2722,7 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 					if (gp->bpmt_count == gp->bpmt_buffersize) {
 						gp->bpmt_buffersize += 100;
 						gp->bpmt_data = (BPMtiming*)realloc(gp->bpmt_data, gp->bpmt_buffersize * sizeof(BPMtiming));
+						assert(gp->bpmt_data != nullptr);
 						for (int i = gp->bpmt_buffersize - 100; i < gp->bpmt_buffersize; i++) {
 							gp->bpmt_data[i].BPM = 0;
 							gp->bpmt_data[i].converted = 0;
@@ -2738,6 +2742,7 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 						if (gp->bpmt_count == gp->bpmt_buffersize) {
 							gp->bpmt_buffersize += 100;
 							gp->bpmt_data = (BPMtiming*)realloc(gp->bpmt_data, gp->bpmt_buffersize * sizeof(BPMtiming));
+							assert(gp->bpmt_data != nullptr);
 							for (int i = gp->bpmt_buffersize - 100; i < gp->bpmt_buffersize; i++) {
 								gp->bpmt_data[i].BPM = 0;
 								gp->bpmt_data[i].converted = 0;
@@ -2762,6 +2767,7 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 					if (gp->bpmt_count == gp->bpmt_buffersize) {
 						gp->bpmt_buffersize += 100;
 						gp->bpmt_data = (BPMtiming*)realloc(gp->bpmt_data, gp->bpmt_buffersize * sizeof(BPMtiming));
+						assert(gp->bpmt_data != nullptr);
 						for (int i = gp->bpmt_buffersize - 100; i < gp->bpmt_buffersize; i++) {
 							gp->bpmt_data[i].BPM = 0;
 							gp->bpmt_data[i].converted = 0;
@@ -2802,6 +2808,7 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 					if (gp->bpmt_count == gp->bpmt_buffersize) {
 						gp->bpmt_buffersize += 100;
 						gp->bpmt_data = (BPMtiming*)realloc(gp->bpmt_data, gp->bpmt_buffersize * sizeof(BPMtiming));
+						assert(gp->bpmt_data != nullptr);
 						for (int i = gp->bpmt_buffersize - 100; i < gp->bpmt_buffersize; i++) {
 							gp->bpmt_data[i].BPM = 0;
 							gp->bpmt_data[i].converted = 0;

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -3984,19 +3984,19 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 	if (gp->soundonly == 1 && bgaFlag && (cfg->play.bga == 3 || cfg->play.bga == 1 || (cfg->play.bga == 2 && gp->isAutoplay)) && cfg->play.autojudge != 2) {
 		DeleteGraph(gp->bgaHandle[1295]);
 		gp->bgaHandle[1295] = -1;
-		CSTR defaultMovieFile = GetRandomFile("LR2files\\Movie\\*.mpg", 0);
+		CSTR defaultMovieFile = GetRandomFile("LR2files/Movie/*.mpg", 0);
 		if (defaultMovieFile.isDiff("ERROR")) gp->bgaHandle[1295] = LoadGraph(defaultMovieFile);
 		if (gp->bgaHandle[1295] == -1) {
-			defaultMovieFile = GetRandomFile("LR2files\\Movie\\*.avi", 0);
+			defaultMovieFile = GetRandomFile("LR2files/Movie/*.avi", 0);
 			if (defaultMovieFile.isDiff("ERROR")) gp->bgaHandle[1295] = LoadGraph(defaultMovieFile);
 			if (gp->bgaHandle[1295] == -1) {
-				defaultMovieFile = GetRandomFile("LR2files\\Movie\\*.wmv", 0);
+				defaultMovieFile = GetRandomFile("LR2files/Movie/*.wmv", 0);
 				if (defaultMovieFile.isDiff("ERROR")) gp->bgaHandle[1295] = LoadGraph(defaultMovieFile);
 				if (gp->bgaHandle[1295] == -1) {
-					defaultMovieFile = GetRandomFile("LR2files\\Movie\\*.mp4", 0);
+					defaultMovieFile = GetRandomFile("LR2files/Movie/*.mp4", 0);
 					if (defaultMovieFile.isDiff("ERROR")) gp->bgaHandle[1295] = LoadGraph(defaultMovieFile);
 					if (gp->bgaHandle[1295] == -1) {
-						defaultMovieFile = GetRandomFile("LR2files\\Movie\\*.ogv", 0);
+						defaultMovieFile = GetRandomFile("LR2files/Movie/*.ogv", 0);
 						if (defaultMovieFile.isDiff("ERROR")) gp->bgaHandle[1295] = LoadGraph(defaultMovieFile);
 					}
 				}

--- a/LR2/LR2_configsave.cpp
+++ b/LR2/LR2_configsave.cpp
@@ -1023,12 +1023,7 @@ int WriteSkinCustomizeXml(SkinUser *sku, char *filepath) {
 
 //441d30
 int ReadConfig(game* g, const char* filepath) {
-	int* piVar1;
-	bool bVar2;
 	TiXmlDocument* hXml;
-	TiXmlDocument* pTVar7;
-	uint uStack32;
-	int* local_c;
 
 	memset(&g->config.play, 0, sizeof(g->config.play));
 	g->config.play.hiSpeed[0] = 200;

--- a/LR2/LR2_configsave.cpp
+++ b/LR2/LR2_configsave.cpp
@@ -1047,7 +1047,7 @@ int ReadConfig(game* g, const char* filepath) {
 	ReadXml_Int("config", "system", "directdraw", 0, &g->config.system.directdraw, hXml);
 	ReadXml_Int("config", "system", "maindisplay", 0, &g->config.system.maindisplay, hXml);
 	Read_JukeboxPath(&g->config.jukebox, hXml);
-	ReadXml_Str("config", "system", "newsongfolder", "NEW SONG\\", &g->config.jukebox.newsongfolder, hXml);
+	ReadXml_Str("config", "system", "newsongfolder", "NEW SONG/", &g->config.jukebox.newsongfolder, hXml);
 	ReadXml_Int("config", "system", "titleflash", 24, &g->config.jukebox.titleflash, hXml);
 	ReadXml_Int("config", "system", "softwarerendering", 0, &g->config.system.softwarerendering, hXml);
 	ReadXml_Int("config", "system", "autoreload", 2, &g->config.jukebox.autoreload, hXml);

--- a/LR2/LR2_ghost.cpp
+++ b/LR2/LR2_ghost.cpp
@@ -811,7 +811,7 @@ int WriteGhostInDatabase(sqlite3 *sql, CSTR songMD5, PLAYSCORE *score) {
 	ErrorLogAdd("データベースにゴーストを書き込みます\n");
 	CSTR ghostdata = score->EncodeGhostData();
 	CSTR query;
-	cstrSprintf(&query, "UPDATE score SET ghost = \'%s\' WHERE hash = \'%s\'", ghostdata, songMD5);
+	cstrSprintf(&query, "UPDATE score SET ghost = \'%s\' WHERE hash = \'%s\'", ghostdata.body, songMD5.body);
 	SQL_Run(query, sql);
 	ErrorLogAdd("ゴーストの書き込みが終了しました\n");
 	return 0;
@@ -826,7 +826,7 @@ int ReadGhostToScore(sqlite3 *sql, CSTR songMD5, PLAYSCORE *score) {
 
 	ErrorLogAdd("データベースからゴーストを読み込みます\n");
 
-	sqlite3_snprintf(0x400, query, "SELECT ghost FROM score WHERE hash = \'%q\'", songMD5);
+	sqlite3_snprintf(0x400, query, "SELECT ghost FROM score WHERE hash = \'%q\'", songMD5.body);
 	SQL_prepare(query, sql, &pStmt);
 
 	if (sqlite3_step(pStmt) == 100) {
@@ -852,7 +852,7 @@ CSTR ReadGhost(sqlite3 *sql, CSTR songMD5) {
 
 	ErrorLogAdd("データベースからゴーストを読み込みます\n");
 
-	sqlite3_snprintf(0x400, query, "SELECT ghost FROM score WHERE hash = \'%q\'", songMD5);
+	sqlite3_snprintf(0x400, query, "SELECT ghost FROM score WHERE hash = \'%q\'", songMD5.body);
 	SQL_prepare(query, sql, &pStmt);
 
 	if (sqlite3_step(pStmt) == 100) {

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -459,25 +459,20 @@ int NETWORK::GetInsaneList() {
 	CSTR hash;
 	sqlite3_open("LR2files/Database/song.db", &pSongDB);
 	SQL_Run("BEGIN", pSongDB);
-	int exlevel;
 	while (cur) {
-		TiXmlElement *val;
-		val = cur->FirstChildElement("hash");
-		if (val && val->ToElement()) {
+		if (TiXmlElement *val = cur->FirstChildElement("hash"); val && val->ToElement()) {
 			cstrSprintf(&hash, "%s", val->ToElement()->GetText());
 		}
 
-		val = cur->FirstChildElement("exlevel");
-		if (val) {
-			exlevel = atol(val->ToElement()->GetText());
+		if (TiXmlElement *val = cur->FirstChildElement("exlevel"); val) {
+			int exlevel = atol(val->ToElement()->GetText());
+			cstrSprintf(&query, "UPDATE song SET exlevel=%d WHERE hash=\'%s\'",exlevel,hash);
+			SQL_Run(query, pSongDB);
 		}
-
-		cstrSprintf(&query, "UPDATE song SET exlevel=%d WHERE hash=\'%s\'",exlevel,hash);
-		SQL_Run(query, pSongDB);
 
 		cur = cur->NextSiblingElement();
 	}
-	
+
 	if (hXml) delete(hXml);
 	SQL_Run("COMMIT", pSongDB);
 	sqlite3_close(pSongDB);

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -6,7 +6,9 @@
 #include "En_fileutil.h"
 #include "En_timer.h"
 
+#ifdef _WIN32
 #include <shellapi.h>
+#endif // _WIN32
 
 //401000
 void MYRANKING::InitRanking() {
@@ -60,7 +62,7 @@ void RANKING::ExpandRankingBuffer(int add) {
 	assert(this->ranking != nullptr);
 
 	for (int i = this->rankingMax; i < this->rankingMax + add; i++) {
-		memset(&this->ranking[i], 0, sizeof(RANKINGPLAYER));
+		memset(&this->ranking[i], 0, sizeof(RANKINGPLAYER)); // FIXME: bad memset
 	}
 
 	this->rankingMax += add;
@@ -540,6 +542,7 @@ void NETWORK::ParseRankingXml(const char* path)
 
 //4bbd20
 int NETWORK::HTTPrequest() {
+#ifdef _WIN32
 	SOCKET s;
 	struct sockaddr_in server;
 	hostent* host;
@@ -668,6 +671,9 @@ int NETWORK::HTTPrequest() {
 	cstrSprintf(&this->request_debug, "その他のエラーです : %d\n", WSAGetLastError());
 	ErrorLogAdd(this->request_debug);
 	return this->isRequestSuccess = 0;
+#else
+	return -1; // FIXME(linux): stub
+#endif // _WIN32
 }
 
 //4bc2b0
@@ -735,11 +741,17 @@ int NETWORK::GetRivalInfo(int rivalID) {
 
 //4bc600
 int OpenWebRanking(CSTR songmd5){
+#ifdef _WIN32
 	CSTR url;
-
 	cstrSprintf(&url, "\"http://www.dream-pro.info/~lavalse/LR2IR/search.cgi?mode=ranking&bmsmd5=%s#status&\"", songmd5.body);
 	ShellExecuteA(NULL, "open", url, NULL, NULL, 1);
 	return 1;
+#else
+	CSTR url;
+	url.resize(126);
+	cstrSprintf(&url, "xdg-open \"http://www.dream-pro.info/~lavalse/LR2IR/search.cgi?mode=ranking&bmsmd5=%s#status&\" &", songmd5.body);
+	return system(url.body) == 0;
+#endif
 }
 
 //4bc6b0 //
@@ -832,13 +844,15 @@ NETWORK::NETWORK(){
 
 //4bcda0
 int NETWORK::WS_clean() {
+#ifdef _WIN32
 	WSACleanup();
+#endif // _WIN32
 	return 1;
 }
 
 //4bcdd0
 int NETWORK::Login(int isDirectPlay) {
-
+#ifdef _WIN32
 	if (WSAStartup(2, &this->wsa)) {
 		this->request_debug = "WinSockの初期化に失敗しました\n";
 		this->request_result = "WinSockの初期化に失敗しました。ネットワーク機能は使用できません・\n";
@@ -848,6 +862,16 @@ int NETWORK::Login(int isDirectPlay) {
 		WSACleanup();
 		return this->loginResult;
 	}
+#else
+	if (true) { // FIXME(linux): stub
+		this->request_debug = "linux\n";
+		this->request_result = "happy with yourself?\n";
+		this->loginResult = -99;
+		this->isOnline = 0;
+		ErrorLogAdd(this->request_debug);
+		return this->loginResult;
+	}
+#endif // _WIN32
 
 	cstrSprintf(&this->param, "passmd5=%s&id=%d&name=%s&version=%d", this->IR_passMD5, this->IR_ID, this->IR_name, 100130); //version 100130
 	this->target_URL = "http://www.dream-pro.info/~lavalse/LR2IR/2/login.cgi";

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -5,7 +5,8 @@
 #include "En_dbio.h"
 #include "En_fileutil.h"
 #include "En_timer.h"
-#include <process.h>
+
+#include <shellapi.h>
 
 //401000
 void MYRANKING::InitRanking() {

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -633,7 +633,7 @@ int NETWORK::HTTPrequest() {
 			else {
 				request.add(recvBuf);
 			}
-			Sleep(10);
+			std::this_thread::sleep_for(std::chrono::milliseconds(10));
 		}
 		if (i == timeout) {
 			request = "TIMEOUT";

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -57,6 +57,7 @@ int CMP_PlayerByExscore(const void *p1, const void *p2) {
 void RANKING::ExpandRankingBuffer(int add) {
 	
 	this->ranking = (RANKINGPLAYER*)realloc(this->ranking, (this->rankingMax + add) * sizeof(RANKINGPLAYER));
+	assert(this->ranking != nullptr);
 
 	for (int i = this->rankingMax; i < this->rankingMax + add; i++) {
 		memset(&this->ranking[i], 0, sizeof(RANKINGPLAYER));
@@ -511,6 +512,7 @@ CSTR UrlEncode(CSTR in) {
 //4bb820
 RANKING::RANKING() {
 	ranking = (RANKINGPLAYER*)malloc(sizeof(RANKINGPLAYER) * 1000);
+	assert(ranking != nullptr);
 	rankingCount = 0;
 	rankingMax = 1000;
 	for (int i = 0; i < rankingMax; i++) memset(&ranking[i], 0, sizeof(RANKINGPLAYER));

--- a/LR2/LR2_makemp3.cpp
+++ b/LR2/LR2_makemp3.cpp
@@ -42,7 +42,7 @@ int RunMP3Encoder(ConfigStruct *cfg, CSTR wavPath, CSTR mp3Path, char deleteWav,
 }
 
 //40d840
-int Proc_Auto2avi(game *g, CSTR directory, CSTR filename) {
+int Proc_Auto2avi(game *g, CSTR /*directory*/, CSTR filename) {
 
 	printfDx("BMSを読み込み中です。しばらくお待ち下さい。");
 	ScreenFlip();

--- a/LR2/LR2_makemp3.cpp
+++ b/LR2/LR2_makemp3.cpp
@@ -4,7 +4,7 @@
 
 //40d680
 int RunMP3Encoder(ConfigStruct *cfg, CSTR wavPath, CSTR mp3Path, char deleteWav, char movie) {
-
+#ifdef _WIN32
 	if (cfg->tools.mp3enc_body.canOpenFile() == 0) {
 		MessageBoxA(NULL, "MP3エンコーダーが見つかりません。\nコンフィグプログラムのJUKEBOX→詳細設定で設定して下さい。", "エラー", 0);
 		return 0;
@@ -39,11 +39,14 @@ int RunMP3Encoder(ConfigStruct *cfg, CSTR wavPath, CSTR mp3Path, char deleteWav,
 		remove(wavPath);
 	}
 	return 1;
+#else
+	return {}; // FIXME(linux): stub
+#endif // _WIN32
 }
 
 //40d840
 int Proc_Auto2avi(game *g, CSTR /*directory*/, CSTR filename) {
-
+#ifdef _WIN32
 	printfDx("BMSを読み込み中です。しばらくお待ち下さい。");
 	ScreenFlip();
 	ClsDrawScreen();
@@ -107,11 +110,14 @@ int Proc_Auto2avi(game *g, CSTR /*directory*/, CSTR filename) {
 	}
 
 	return 1;
+#else
+	return {}; // FIXME(linux): stub
+#endif // _WIN32
 }
 
 //40dc30
 int RecordBmsSound(game *g, CSTR oPath) {
-
+#ifdef _WIN32
 	int startTime = g->rec.GetCurTime();
 	ErrorLogFmtAdd("音声の記録を開始します　曲開始時間+%dです。\n", startTime);
 	printfDx("処理中です。しばらくお待ち下さい。");
@@ -182,4 +188,7 @@ int RecordBmsSound(game *g, CSTR oPath) {
 
 	g->rec.Release();
 	return 1;
+#else
+	return {}; // FIXME(linux): stub
+#endif // _WIN32
 }

--- a/LR2/LR2_makemp3.cpp
+++ b/LR2/LR2_makemp3.cpp
@@ -34,7 +34,7 @@ int RunMP3Encoder(ConfigStruct *cfg, CSTR wavPath, CSTR mp3Path, char deleteWav,
 	sinfo.dwFlags = 0;
 	sinfo.lpReserved2 = 0;
 	CreateProcessA(NULL, cmd, 0, 0, 0, 0, 0, 0, (LPSTARTUPINFOA)&sinfo, &pinfo);
-	WaitForSingleObject(pinfo.hProcess, -1);
+	WaitForSingleObject(pinfo.hProcess, INFINITE);
 	if (deleteWav) {
 		remove(wavPath);
 	}

--- a/LR2/LR2_makemp3.cpp
+++ b/LR2/LR2_makemp3.cpp
@@ -98,7 +98,7 @@ int Proc_Auto2avi(game *g, CSTR /*directory*/, CSTR filename) {
 	CSTR ext = filename.right(3).lower();
 	if(ext.isSame("mp3")) {
 		CSTR tPath = g->baseDirectory;
-		tPath.add("LR2files\\temp.wav");
+		tPath.add("LR2files/temp.wav");
 		WriteSoundFile(&g->audio, tPath, 0);
 		RunMP3Encoder(&g->config, tPath, filename, 1, 0);
 	}
@@ -155,11 +155,11 @@ int RecordBmsSound(game *g, CSTR oPath) {
 	CSTR wavPath;
 	if (g->config.tools.movie_audio == 0) {
 		wavPath = g->baseDirectory;
-		wavPath.add("LR2files\\movie_temp.wav");
+		wavPath.add("LR2files/movie_temp.wav");
 		WriteSoundFile(&g->audio, wavPath, GetTimeWrap()*44100.0 / 1000.0 * 2);
 
 		CSTR mp3Path(g->baseDirectory);
-		mp3Path.add("LR2files\\movie_temp.mp3");
+		mp3Path.add("LR2files/movie_temp.mp3");
 		if (RunMP3Encoder(&g->config, wavPath, mp3Path, 1, 1) == 1) {
 			g->rec.InsertAudioToMovie(mp3Path, true);
 		}
@@ -169,7 +169,7 @@ int RecordBmsSound(game *g, CSTR oPath) {
 	}
 	else if (g->config.tools.movie_audio == 1) {
 		wavPath = g->baseDirectory;
-		wavPath.add("LR2files\\movie_temp.wav");
+		wavPath.add("LR2files/movie_temp.wav");
 		WriteSoundFile(&g->audio, wavPath, GetTimeWrap()*44100.0 / 1000.0 * 2);
 		g->rec.InsertAudioToMovie(wavPath, true);
 	}

--- a/LR2/LR2_replay.cpp
+++ b/LR2/LR2_replay.cpp
@@ -3,7 +3,7 @@
 
 //4c03c0 //TODO suspection about usage of cstrsprintf
 int MoveReplayFile(CSTR songMD5, CSTR localID){
-
+#ifdef _WIN32
 	if (songMD5.length() > 36) {
 		songMD5 = MD5str(songMD5);
 	}
@@ -29,6 +29,9 @@ int MoveReplayFile(CSTR songMD5, CSTR localID){
 	ErrorLogFmtAdd("リプレイの移動終了 stage%d\n", stage);
 
 	return (stage != 0);
+#else
+	return {}; // FIXME(linux): stub
+#endif
 }
 
 //4c05e0

--- a/LR2/LR2_replay.cpp
+++ b/LR2/LR2_replay.cpp
@@ -161,7 +161,7 @@ int ReleaseReplayBuffer(REPLAY *rp){
 
 
 //4c0c00
-int AddReplayData(REPLAY *rp, int timing, char op, short value){
+int AddReplayData(REPLAY *rp, int timing, uchar op, short value){
 
 	if (rp->max < 1) {
 		return 0;

--- a/LR2/LR2_replay.cpp
+++ b/LR2/LR2_replay.cpp
@@ -169,6 +169,7 @@ int AddReplayData(REPLAY *rp, int timing, uchar op, short value){
 	if (rp->max == rp->count) {
 		rp->max += 10000;
 		rp->data = (ReplayData *)realloc(rp->data, rp->max * sizeof(ReplayData));
+		assert(rp->data != nullptr);
 	}
 	rp->data[rp->count].op = op;
 	rp->data[rp->count].timing = timing;

--- a/LR2/LR2_replay.h
+++ b/LR2/LR2_replay.h
@@ -10,7 +10,7 @@ int LoadReplayFile(REPLAY * rp, CSTR songMD5, CSTR localID);
 int SaveReplay(REPLAY * rp, CSTR songMD5, CSTR localID);
 
 //write replay
-int AddReplayData(REPLAY * rp, int timing, char op, short value);
+int AddReplayData(REPLAY * rp, int timing, uchar op, short value);
 int AddReplayDataHeader(CONFIG_PLAY * cfg, REPLAY * rp, AUDIO * snd, gameplay * gp);
 int InputToReplay(REPLAY * rp, inputStructure * is, int timing, int scratchSide);
 

--- a/LR2/LR2_skindraw.cpp
+++ b/LR2/LR2_skindraw.cpp
@@ -1012,6 +1012,7 @@ void LRDrawText(int* grHandle, DSTdraw *dstd, CSTR *str, ImageFont *imF) {
 
 //49b7c0
 void LRDrawTextInput(int* hFont, DSTdraw *dstd, int* hInput, ImageFont *imgfont) {
+#ifdef _WIN32
 	IMEINPUTDATA* pIME;
 	CSTR buf(0x401);
 	int grLen;
@@ -1067,6 +1068,9 @@ void LRDrawTextInput(int* hFont, DSTdraw *dstd, int* hInput, ImageFont *imgfont)
 			LRDrawText(hFont, dstd, &buf, imgfont);
 		}
 	}
+#else
+	// FIXME(linux): stub
+#endif // _WIN32
 }
 
 //49bc50

--- a/LR2/LR2_skindraw.cpp
+++ b/LR2/LR2_skindraw.cpp
@@ -459,7 +459,7 @@ int AddDrawingBuffer_Gauge(DrawingBuf *drb, SRCstruct *src, DSTstruct *dst, Time
 }
 
 //49d990
-int AddDrawingBuffer_BGA(DrawingBuf *drb, SRCstruct *src, DSTstruct *dst, Timer *T, int grHandle, char flag) {
+int AddDrawingBuffer_BGA(DrawingBuf *drb, SRCstruct */*src*/, DSTstruct *dst, Timer *T, int grHandle, char flag) {
 	DSTdraw tDstd;
 	int x, y;
 
@@ -732,8 +732,7 @@ int AddDrawingBuffer_Slider(DrawingBuf *drb, SRCstruct *src, DSTstruct *dst, Tim
 
 //49e550
 int AddDrawingBuffer_JudgeCombo(DrawingBuf *drb, SRCstruct *jSrc, DSTstruct *jDst, SRCstruct *cSrc, DSTstruct *cDst, Timer *T, int combo, int optX, int optY) {
-	DSTdraw tDstd;// , tDstd2;
-	int grh;
+	DSTdraw tDstd;
 	int digit;
 	float pos, posn;
 

--- a/LR2/LR2_skindraw.cpp
+++ b/LR2/LR2_skindraw.cpp
@@ -38,6 +38,7 @@ int AllocDrawingBuffer(DrawingBuf *drb){
 int ReallocDrawingBuffer(DrawingBuf *drb){
 	drb->max = drb->max + 1000;
 	drb->dstd = (DSTdraw *)realloc(drb->dstd, drb->max * 0x50);
+	assert(drb->dstd != nullptr);
 	if (drb->dstd == (DSTdraw *)0x0) {
 		ErrorLogAdd("描画用バッファのメモリ再取得に失敗しました。\n");
 		return -1;

--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -1687,7 +1687,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						csv.str[1].replace("\\" ,"/");
 #endif // _WIN32
 						if (sk->num_of_ImageFont == 10) {
-							ErrorLogFmtAdd(	"スキン読み込みエラー %d行目\n%s\nこれ以上の登録はできま せん。\n", line, fBuf);
+							ErrorLogFmtAdd("スキン読み込みエラー %d行目\n%s\nこれ以上の登録はできません。\n", line, fBuf.body);
 						}
 						else if (csv.val[2] == 1 || sk->disableimagefont == 0) {
 							if (csv.str[1].isDiff("CONTINUE")) {
@@ -1844,7 +1844,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 				SetMovieVolumeToGraph(0, sk->GrHandle[i]);
 			}
 		}
-		ErrorLogFmtAdd("スキンの読み込みに成功しました。 %s\n", FilePath);
+		ErrorLogFmtAdd("スキンの読み込みに成功しました。 %s\n", FilePath.body);
 		ErrorLogTabSub();
 		SetTransColor(0, 0xff, 0);
 		if (flipside != '\0') {
@@ -1852,7 +1852,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 		}
 		return 1;
 	}
-	ErrorLogFmtAdd("子スキンの読み込みに成功しました。 %s\n", FilePath);
+	ErrorLogFmtAdd("子スキンの読み込みに成功しました。 %s\n", FilePath.body);
 	ErrorLogTabSub();
 	return tSkin_num;
 }

--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -104,8 +104,6 @@ int ReadDST(DSTstruct *dst, CSVbuf *csv, int order){
 
 //49eae0
 int ReadSRC(SRCstruct *src, CSVbuf *csv, skstruct *sk){
-	int div_count;
-
 	src->n = csv->val[1];
 	src->cycle = csv->val[9];
 	src->timer = csv->val[10];
@@ -172,7 +170,7 @@ int ReadSRC_BAR_TITLE(SRCstruct *src, CSVbuf *csv, skstruct *sk){
 
 
 //49ed50 InitSkin
-int InitSkin(skstruct *sk, int p5, char font) {
+int InitSkin(skstruct *sk, int /*unused*/, char font) {
 	SetTransColor(0, 255, 0);
 	sk->startinput_start = 0;
 	sk->startinput_rank = 0;

--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -543,6 +543,10 @@ int InitImageFont(ImageFont *imgfont) {
 
 //4a0480
 int ReadImageFont(CSTR filename, ImageFont *imgfont) {
+#ifndef _WIN32 // TODO(linux): check if needed
+	filename.replace("\\" ,"/");
+#endif // _WIN32
+
 	CSTR str1;
 	
 	str1 = filename.getDirectory();
@@ -1063,6 +1067,9 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						}
 						else {
 							SplitCSV(fBuf, &csv, ",");
+#ifndef _WIN32 // TODO(linux): check if needed
+							csv.str[1].replace("\\" ,"/");
+#endif // _WIN32
 							if (csv.str[1].isSame("CONTINUE")) {
 								sk->caption[sk->count].assign("CONTINUE");
 								sk->count++;
@@ -1676,6 +1683,9 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 					}
 					else if (fBuf.left(8).isSame("#LR2FONT") && !flag_skipFont) {
 						SplitCSV(fBuf, &csv, ",");
+#ifndef _WIN32 // TODO(linux): check if needed
+						csv.str[1].replace("\\" ,"/");
+#endif // _WIN32
 						if (sk->num_of_ImageFont == 10) {
 							ErrorLogFmtAdd(	"スキン読み込みエラー %d行目\n%s\nこれ以上の登録はできま せん。\n", line, fBuf);
 						}
@@ -1698,6 +1708,9 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						}
 					}
 					else if (fBuf.left(9).isSame("#HELPFILE")) {
+#ifndef _WIN32 // TODO(linux): check if needed
+						csv.str[1].replace("\\" ,"/");
+#endif // _WIN32
 						SplitCSV(fBuf, &csv, ",");
 						if (sk->helpfileCount < 10) {
 							sk->helpfilePath[sk->helpfileCount].assign(&csv.str[1]);
@@ -1732,6 +1745,9 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 					}
 					else if (fBuf.left(8).isSame("#INCLUDE")) {
 						SplitCSV(fBuf, &csv, ",");
+#ifndef _WIN32 // TODO(linux): check if needed
+						csv.str[1].replace("\\" ,"/");
+#endif // _WIN32
 						for (int i = 0; i < sk->customfile_count; i++) {
 							if (sk->customfileRANDOM[i].isSame(csv.str[1].left(sk->customfileRANDOM[i].length()))
 								&& sk->customfile[i].isDiff("RANDOM") && sk->customfile[i].isDiff("ERROR")
@@ -1749,6 +1765,9 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 					}
 					else if (fBuf.left(11).isSame("#CUSTOMFILE")) {
 						SplitCSV(fBuf, &csv, ",");
+#ifndef _WIN32 // TODO(linux): check if needed
+						csv.str[2].replace("\\" ,"/");
+#endif // _WIN32
 						sk->customfileRANDOM[sk->customfile_count].assign(&csv.str[2]);
 						sk->customfile[sk->customfile_count].assign(&sku->customize_filename[sk->customfile_count]);
 						if (sk->customfile[sk->customfile_count].isSame("RANDOM")) {
@@ -1758,6 +1777,9 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 					}
 					else if (fBuf.left(13).isSame("#CUSTOMFOLDER")) {
 						SplitCSV(fBuf, &csv, ",");
+#ifndef _WIN32 // TODO(linux): check if needed
+						csv.str[2].replace("\\" ,"/");
+#endif // _WIN32
 						sk->customfileRANDOM[sk->customfile_count].assign(&csv.str[2]);
 						sk->customfile[sk->customfile_count].assign(&sku->customize_filename[sk->customfile_count]);
 						sk->customfile_count++;

--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -75,6 +75,7 @@ int ReadDST(DSTstruct *dst, CSVbuf *csv, int order){
 	if (dst->dataSize == dst->dstCount) {
 		dst->dataSize = dst->dataSize + 10;
 		dst->draw = (DSTdraw*)realloc(dst->draw, dst->dataSize * sizeof(DSTdraw));
+		assert(dst->draw != nullptr);
 		for (int i = dst->dstCount; i < dst->dataSize; i++) {
 			InitDSTdraw(&dst->draw[i]);
 		}
@@ -125,6 +126,7 @@ int ReadSRC(SRCstruct *src, CSVbuf *csv, skstruct *sk){
 		src->count = src->graphcount;
 		src->grHandles = (int*)realloc(src->grHandles, src->graphcount * sizeof(int));
 	}
+	assert(src->grHandles != nullptr);
 	for (int i = 0; i < src->count; i++) {
 		src->grHandles[i] = -1;
 	}
@@ -919,7 +921,9 @@ int ClearSkinGraph(skstruct *sk){
 int ExpandSkinObjectMax(SkinObject *so, int add) {
 	if (so->dstSize - 1 == so->srcSize) {
 		so->src = (SRCstruct*)realloc(so->src, (so->dstSize + add) * sizeof(SRCstruct));
+		assert(so->src != nullptr);
 		so->dst = (DSTstruct*)realloc(so->dst, (so->dstSize + add) * sizeof(DSTstruct));
+		assert(so->dst != nullptr);
 		for (int i = so->dstSize; i < so->dstSize + add; i++) {
 			memset(&so->src[i], 0, sizeof(SRCstruct));
 			InitSRC(&so->src[i]);

--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -492,9 +492,9 @@ int InitSkin(skstruct *sk, int /*unused*/, char font) {
 	if (sk->GrHandle[101] == -1) sk->GrHandle[101] = MakeGraph(640, 480);
 	if (sk->GrHandle[102] == -1) sk->GrHandle[102] = MakeGraph(300, 80);
 	DeleteGraph(sk->GrHandle[110]);
-	sk->GrHandle[110] = LoadGraph("LR2files\\Config\\black.bmp");
+	sk->GrHandle[110] = LoadGraph("LR2files/Config/black.bmp");
 	DeleteGraph(sk->GrHandle[111]);
-	sk->GrHandle[111] = LoadGraph("LR2files\\Config\\white.bmp");
+	sk->GrHandle[111] = LoadGraph("LR2files/Config/white.bmp");
 	sk->reloadbanner = 0;
 	for (int i = 0; i < 10; i++) {
 		InitSRC(&sk->src_BAR_RANK[i]);
@@ -1841,7 +1841,7 @@ int LoadScene(skstruct *sk, CSTR skinfile, int p5, char font) {
 	CSTR tStr;
 	InitSkin(sk, p5, font);
 	sk->skinMD5.assign(MD5str(skinfile));
-	cstrSprintf(&tStr, "LR2files\\SkinCustomize\\%s.xml",sk->skinMD5.body);
+	cstrSprintf(&tStr, "LR2files/SkinCustomize/%s.xml",sk->skinMD5.body);
 	ReadSkinCustomize(&tsku, tStr);
 	(sk->adjust).shift_x = tsku.adjust.shift_x;
 	(sk->adjust).shift_y = tsku.adjust.shift_y;

--- a/LR2/LR2_skinmanage.cpp
+++ b/LR2/LR2_skinmanage.cpp
@@ -2,6 +2,7 @@
 #include "Engine.h"
 #include "LR2_configsave.h"
 
+#include <filesystem>
 
 //maybe deleted by compiler, restored it for convenience
 int SetFirstSkin(SkinManage *sm, SKINTYPE type, CSTR *skinName) {
@@ -325,34 +326,21 @@ int ParseLR2SkinCustom(SkinManage *skm, CSTR filepath) {
 
 //4a8230 MakeSkinList
 int MakeSkinList(SkinManage *skm, CSTR dir) {
-	HANDLE hFindFile, hFindFileOld;
-	_WIN32_FIND_DATAA findFileData;
-	CSTR filter;
-	bool isLR2Skin;
-	if (dir.right(1).isDiff("\\")) 
+	if (dir.right(1).isDiff("\\") && dir.right(1).isDiff("/"))
 		dir.add("\\");
-	
-	filter.assign(&dir).add("*");
-	hFindFile = FindFirstFileA(filter, &findFileData);
-	do{
-		if ( (findFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
-			filter.assign(&dir).add(findFileData.cFileName);
-			isLR2Skin = false;
-			if (filter.right(8).isSame(".lr2skin"))		isLR2Skin = true;
-			else if (filter.right(6).isSame(".lr2ss"))	isLR2Skin = true;
-			
-			if (isLR2Skin) ParseLR2SkinCustom(skm, filter); 
-		}
-		else {  //logic arranged
-		if (strcmp("..", findFileData.cFileName) && strcmp(".", findFileData.cFileName)) {
-			filter.assign(&dir).add(findFileData.cFileName).add("\\");
+#ifndef _WIN32
+	dir.replace("\\", "/");
+#endif // _WIN32
+	CSTR filter;
+	for (const auto& entry : std::filesystem::directory_iterator(dir.body)) {
+		if (entry.is_directory()) {
+			filter.assign(&dir).add(entry.path().filename().string().c_str());
 			MakeSkinList(skm, filter);
+		} else {
+			filter.assign(&dir).add(entry.path().filename().string().c_str());
+			if (filter.right(8).isSame(".lr2skin") || filter.right(6).isSame(".lr2ss"))
+				ParseLR2SkinCustom(skm, filter);
 		}
-		}
-		hFindFileOld = hFindFile;
-		if (FindNextFileA(hFindFile, &findFileData) == 0) {
-			FindClose(hFindFileOld);
-			return 0;
-		}
-	} while (true);
+	}
+	return 0;
 }

--- a/LR2/LR2_skinmanage.cpp
+++ b/LR2/LR2_skinmanage.cpp
@@ -270,8 +270,6 @@ int ParseLR2SkinCustom(SkinManage *skm, CSTR filepath) {
 			}
 		}
 		else if (buffer.left(11).isSame("#CUSTOMFILE")) {
-			HANDLE hFindFile;
-			_WIN32_FIND_DATAA findFileData;
 			int flag;
 			SkinHeader &rSkin = skm->Data[skm->Count - 1];
 			SkinCustom &rCustom = rSkin.customs[rSkin.custom_count];
@@ -279,7 +277,10 @@ int ParseLR2SkinCustom(SkinManage *skm, CSTR filepath) {
 			SplitCSV(buffer, &csvBuf, ",");
 			rCustom.title.assign(&csvBuf.str[1]);
 			rCustom.dst_op_start = 0;
-			hFindFile = FindFirstFileA(csvBuf.str[2], &findFileData);
+
+#ifdef _WIN32
+			_WIN32_FIND_DATAA findFileData;
+			HANDLE hFindFile = FindFirstFileA(csvBuf.str[2], &findFileData);
 			do {
 				flag = 0; //logic arranged
 				if ( (findFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) 	flag = 2;
@@ -293,11 +294,38 @@ int ParseLR2SkinCustom(SkinManage *skm, CSTR filepath) {
 				}
 				if (rCustom.dst_op_count == rCustom.labelCapacity-2) {
 					rCustom.op_label = (CSTR*)realloc( rCustom.op_label, sizeof(CSTR)*(rCustom.labelCapacity + 100) );
+					// FIXME: invalid memset
 					memset(&rCustom.op_label[rCustom.labelCapacity],0,sizeof(CSTR)*100);
 					rCustom.labelCapacity += 100;
 				}
 			} while (FindNextFileA(hFindFile,&findFileData));
 			FindClose(hFindFile);
+#else
+			// NOTE: bad impl because of wildcards (see LunaticVibes for details)
+			auto p = csvBuf.str[2];
+			p.replace("\\", "/");
+			auto p_view = std::string_view{ p.body };
+			auto p_wildcard_pos = p_view.find('*');
+			for (const auto& entry : std::filesystem::directory_iterator({p_view.substr(0, p_wildcard_pos)})) {
+				auto fp = entry.path();
+				if (p_wildcard_pos != p_view.npos && p_view.size() > p_wildcard_pos + 1 && !fp.string().ends_with(p_view.substr(p_wildcard_pos + 1)))
+					continue;
+				const bool is_directory = entry.is_directory();
+				fName = fp.filename().string().c_str();
+				if (!is_directory && fName.right(3).isDiff("txt")) {
+					fName.nullAtPos(fName.findStrPos("."));
+					rCustom.op_label[rCustom.dst_op_count].assign(&fName);
+					rCustom.dst_op_count++;
+				}
+				if (rCustom.dst_op_count == rCustom.labelCapacity-2) {
+					rCustom.op_label = (CSTR*)realloc( rCustom.op_label, sizeof(CSTR)*(rCustom.labelCapacity + 100) );
+					// FIXME: invalid memset
+					memset(&rCustom.op_label[rCustom.labelCapacity],0,sizeof(CSTR)*100);
+					rCustom.labelCapacity += 100;
+				}
+			}
+#endif // _WIN32
+
 			rCustom.op_label[rCustom.dst_op_count].assign("RANDOM");
 			rCustom.dst_op_count++;
 

--- a/LR2/LR2_skinmanage.cpp
+++ b/LR2/LR2_skinmanage.cpp
@@ -270,8 +270,7 @@ int ParseLR2SkinCustom(SkinManage *skm, CSTR filepath) {
 			}
 		}
 		else if (buffer.left(11).isSame("#CUSTOMFILE")) {
-			FILE *pFile;
-			HANDLE hFindFile, hFindFileOld;
+			HANDLE hFindFile;
 			_WIN32_FIND_DATAA findFileData;
 			int flag;
 			SkinHeader &rSkin = skm->Data[skm->Count - 1];

--- a/LR2/LR2_skinmanage.cpp
+++ b/LR2/LR2_skinmanage.cpp
@@ -101,8 +101,8 @@ int SetFirstSkins(game *g){
 	ErrorLogAdd("スキンを列挙します。\n");
 	sm = &g->skinData;
 	InitSkinData(sm);
-	MakeSkinList(sm, CSTR("LR2files\\Theme\\"));
-	MakeSkinList(sm, CSTR("LR2files\\Sound\\"));
+	MakeSkinList(sm, CSTR("LR2files/Theme/"));
+	MakeSkinList(sm, CSTR("LR2files/Sound/"));
 	ErrorLogAdd("スキンの列挙を終了しました。\n");
 
 	if (SetFirstSkin(sm, SKINTYPE_7KEYS, &g->config.skin.skinFilePath[0]) == -1) {
@@ -222,7 +222,7 @@ int ParseLR2SkinCustom(SkinManage *skm, CSTR filepath) {
 	FILE *pFile;
 	char* pBuffer;
 
-	cstrSprintf(&md5Filepath, "LR2files\\SkinCustomize\\%s.xml", MD5str(filepath) );
+	cstrSprintf(&md5Filepath, "LR2files/SkinCustomize/%s.xml", MD5str(filepath) );
 	ReadSkinCustomize(&skCustom, md5Filepath);
 	pFile = fopen(filepath, "r");
 	if (!pFile) return 0;

--- a/LR2/LR2_skinmanage.cpp
+++ b/LR2/LR2_skinmanage.cpp
@@ -177,6 +177,7 @@ int SetFirstSkins(game *g){
 int InitSkinData(SkinManage *skm){
 	skm->Max = 100;
 	skm->Data = (SkinHeader *)malloc(sizeof(SkinHeader) * 100);
+	assert(skm->Data != nullptr);
 	skm->Count = 0;
 	memset(skm->Data, 0, skm->Max * sizeof(SkinHeader));
 	for (int i = 0; i < 100; i++) {
@@ -194,6 +195,7 @@ int InitSkinData(SkinManage *skm){
 //4a7450
 int ExpandSkinMax(SkinManage *skm){
 	skm->Data = (SkinHeader *)realloc(skm->Data, (skm->Max + 100) * 0xb14);
+	assert(skm->Data != nullptr);
 	memset(skm->Data + skm->Max, 0, sizeof(SkinHeader) * 100);
 	if (skm->Max < skm->Max + 100) {
 		for (int i = skm->Max; i < skm->Max + 100; i++) {

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -7,6 +7,8 @@
 #include "LR2_statplay.h"
 #include "Scenes.h"
 
+#include <DxLib/DxLib.h>
+
 //40e790 // _mRet __mRet : return ret, ret : return !ret
 bool GetOptionFlag_dst(game *gs, int option) {
 	int t = 0;
@@ -2676,7 +2678,11 @@ int Proc_Text(game *g, sqlite3 *sql, char flag) {
 	}
 
 	if ( (g->KeyInput.mouse_buttonL == 3) || (g->KeyInput.mouse_buttonR == 3) ) {
+#ifdef WIN32
 		DeleteKeyInput(g->txtStruct.hKeyInput);
+#else
+		// FIXME(linux): stub
+#endif // WIN32
 		g->txtStruct.st_text_num = -1;
 	}
 
@@ -2688,6 +2694,7 @@ int Proc_Text(game *g, sqlite3 *sql, char flag) {
 				&& MouseOnObject(&g->skstruct.otherObject[0].dst[i], &g->timer1, &g->KeyInput.mouse_oldX, &g->KeyInput.mouse_oldY)) {
 				g->sSelect.is_mouseOnTextInput = 1;
 				if (g->KeyInput.mouse_buttonL == 3) {
+#ifdef WIN32
 					InitKeyInput();
 
 					int st = g->skstruct.otherObject[0].src[i].st;
@@ -2715,6 +2722,9 @@ int Proc_Text(game *g, sqlite3 *sql, char flag) {
 					if (g->txtStruct.st_text_num != 30) {
 						SetKeyInputString(GetStringFromArray(g->txtStruct.st_text_num, g->txtStruct.objectStr), g->txtStruct.hKeyInput);
 					}
+#else
+					// FIXME(linux): stub
+#endif // WIN32
 				}
 			}
 			AddDrawingBuffer_Text(&g->skstruct.drBuf, &g->skstruct.otherObject[0].src[i], &g->skstruct.otherObject[0].dst[i], &g->timer1);
@@ -2725,6 +2735,7 @@ int Proc_Text(game *g, sqlite3 *sql, char flag) {
 	if (g->txtStruct.st_text_num != -1) {
 		g->sSelect.is_mouseOnTextInput = 1;
 
+#ifdef _WIN32
 		if (CheckKeyInput(g->txtStruct.hKeyInput) >= 1 && flag == 0) {
 			//CheckKeyInput() 0:doing 1:done 2:cancle -1:error
 			if (CheckKeyInput(g->txtStruct.hKeyInput) == 1) {
@@ -2896,6 +2907,9 @@ int Proc_Text(game *g, sqlite3 *sql, char flag) {
 			g->txtStruct.st_text_num = -1;
 			SetTimeLapse(4, &g->timer1);
 		}
+#else
+					// FIXME(linux): stub
+#endif // WIN32
 	}
 
 	g->KeyInput.mouse_buttonL = mouseL;

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -2796,7 +2796,6 @@ int Proc_Text(game *g, sqlite3 *sql, char flag) {
 					g->sSelect.is_coursemaking_done = 1;
 					break;
 				case 27:
-					atol(buf);
 					if ((0 <= atol(buf) && atol(buf) < 100) || (g->sSelect.bmsList[g->sSelect.cur_song].keymode == 0)) {
 						SetObjectString(g->txtStruct.st_text_num - 10, buf, g->txtStruct.objectStr);
 						SetObjectString(g->txtStruct.st_text_num, buf, g->txtStruct.objectStr);
@@ -4038,19 +4037,15 @@ int MouseOnDSTD(DSTdraw *dstd, int *x, int *y){ //1 right 2 left
 
 //49c070
 int MouseOnObject(DSTstruct *dst, Timer *T, int *x, int *y){
-	DSTdraw _dstd;
-	DSTdraw local_a0;
-	double time;
+	double time = GetTimeLapse(dst->timer, T);
 	DSTstruct _dst;
-
-	time = GetTimeLapse(dst->timer, T);
 	memcpy(&_dst, dst, sizeof(DSTstruct));
-	_dstd = SetDSTdrawByTime(_dst, time);
+	DSTdraw _dstd = SetDSTdrawByTime(_dst, time);
 	return MouseOnDSTD(&_dstd, x, y);
 }
 
 //49c0e0 maybe done
-int SliderByTime(DrawingBuf *drb, SRCstruct *src, DSTstruct *dst, Timer *T, int min, int max, int *value, inputStructure *input, int objectID) {
+int SliderByTime(DrawingBuf */*drb*/, SRCstruct *src, DSTstruct *dst, Timer *T, int min, int max, int *value, inputStructure *input, int objectID) {
 	DSTdraw dstdTemp;
 	DSTstruct dstsTemp;
 	int newVal, newX=0, newY=0;
@@ -4151,7 +4146,7 @@ int SliderByTime(DrawingBuf *drb, SRCstruct *src, DSTstruct *dst, Timer *T, int 
 }
 
 //49c560
-int ButtonByInput(DrawingBuf *drb, SRCstruct *src, DSTstruct *dst, Timer *T, inputStructure *input, int *target, int min, int max, int panel) { //return 1:just clicked 2:changed 0:not changed
+int ButtonByInput(DrawingBuf */*drb*/, SRCstruct *src, DSTstruct *dst, Timer *T, inputStructure *input, int *target, int min, int max, int panel) { //return 1:just clicked 2:changed 0:not changed
 	DSTdraw dstd;
 	int mouse, ret;
 	

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -3582,13 +3582,13 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 					g->KeyInput.config_key = -1;
 					switch (g->KeyInput.config_keymode) {
 						case 0:
-							ReadKeyConfig(g, "LR2files\\Config\\keyconfig.xml");
+							ReadKeyConfig(g, "LR2files/Config/keyconfig.xml");
 							break;
 						case 1:
-							ReadKeyConfig(g, "LR2files\\Config\\keyconfig_p.xml");
+							ReadKeyConfig(g, "LR2files/Config/keyconfig_p.xml");
 							break;
 						case 2:
-							ReadKeyConfig(g, "LR2files\\Config\\keyconfig_5.xml");
+							ReadKeyConfig(g, "LR2files/Config/keyconfig_5.xml");
 							break;
 					}
 					ProcS_Keyconfig(g);
@@ -3649,7 +3649,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 					g->skinData.previewCustomID = 0;
 					CSTR tcstr;
 					SkinUser sku;
-					cstrSprintf(&tcstr, "LR2files\\SkinCustomize\\%s.xml", MD5str(g->skinData.Data[g->skinData.previewID].skinFile));
+					cstrSprintf(&tcstr, "LR2files/SkinCustomize/%s.xml", MD5str(g->skinData.Data[g->skinData.previewID].skinFile));
 					ReadSkinCustomize(&sku, tcstr);
 
 					for (int j = 0; j < 100; j++) { // VULNERABILITY : out of index sku (array size 40, but access to 100)
@@ -3708,7 +3708,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 					g->skinData.previewCustomID = 0;
 					CSTR tcstr;
 					SkinUser sku;
-					cstrSprintf(&tcstr, "LR2files\\SkinCustomize\\%s.xml", MD5str(g->skinData.Data[g->skinData.previewID].skinFile));
+					cstrSprintf(&tcstr, "LR2files/SkinCustomize/%s.xml", MD5str(g->skinData.Data[g->skinData.previewID].skinFile));
 					ReadSkinCustomize(&sku, tcstr);
 
 					for (int j = 0; j < 100; j++) { // VULNERABILITY : out of index sku (array size 40, but access to 100)
@@ -3803,7 +3803,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 
 					CSTR tcstr;
 					SkinUser sku;
-					cstrSprintf(&tcstr, "LR2files\\SkinCustomize\\%s.xml", MD5str(g->skinData.Data[g->skinData.previewID].skinFile));
+					cstrSprintf(&tcstr, "LR2files/SkinCustomize/%s.xml", MD5str(g->skinData.Data[g->skinData.previewID].skinFile));
 					ReadSkinCustomize(&sku, tcstr);
 
 					for (int j = 0; j < 100; j++) { // VULNERABILITY : out of index sku (array size 40, but access to 100)

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -570,12 +570,12 @@ int LoadFolderDataFromDB(CSTR query, SONGDATA *song, sqlite3 *sql, int difficult
 		if (cfg_select->ignorepms == 1 && mode == 9) continue;
 
 		sd.keymode = mode;
-		
+
 		if( (maxsize - 1001) == slistCount){
 			int newsize = nowsize + sizeof(SONGDATA) * 1000;
 			slist = (SONGDATA*)realloc(slist, newsize);
 			if (maxsize - 1000 < maxsize) {
-				memset((void*)((int)slist + nowsize), 0, sizeof(SONGDATA) * 1000);
+				memset((void*)((uintptr_t)slist + nowsize), 0, sizeof(SONGDATA) * 1000);
 			}
 			maxsize += 1000;
 			keymode_A = keymode_B;
@@ -733,7 +733,7 @@ int LoadFolderDataFromDB(CSTR query, SONGDATA *song, sqlite3 *sql, int difficult
 			nowDifficulty = sd.difficulty;
 			difficultyCount = 1;
 			COPY_SONGDATA(&slist[slistCount], &sd);
-			
+
 			slistCount++;
 			folderSongCount++;
 			nowFolder = sd.folder;
@@ -745,7 +745,7 @@ int LoadFolderDataFromDB(CSTR query, SONGDATA *song, sqlite3 *sql, int difficult
 			nowDifficulty = sd.difficulty;
 			difficultyCount = 1;
 			COPY_SONGDATA(&slist[slistCount], &sd);
-			
+
 			slistCount++;
 			folderSongCount++;
 			nowFolder = sd.folder;
@@ -759,7 +759,7 @@ int LoadFolderDataFromDB(CSTR query, SONGDATA *song, sqlite3 *sql, int difficult
 			nowDifficulty = sd.difficulty;
 			difficultyCount = 1;
 			COPY_SONGDATA(&slist[slistCount], &sd);
-			
+
 			slistCount++;
 			folderSongCount++;
 			nowFolder = sd.folder;
@@ -768,7 +768,7 @@ int LoadFolderDataFromDB(CSTR query, SONGDATA *song, sqlite3 *sql, int difficult
 		}
 		else if (nowDifficulty == sd.difficulty || difficulty == 0) {
 			difficultyCount++;
-			
+
 			slistCount++;
 			folderSongCount++;
 			nowFolder = sd.folder;

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -2,7 +2,9 @@
 #include "Engine.h"
 #include "LR2_statlong.h"
 
+#ifdef _WIN32
 #include <shellapi.h>
+#endif // _WIN32
 
 int EnabledInsane;
 //404fe0 thiscall in original code
@@ -397,21 +399,25 @@ int UpdateSongDataTag(SONGDATA *song, sqlite3 *sql){
 
 //446300
 int EditTag(SONGDATA *song, sqlite3 *sql) {
-
-	HANDLE hFindFile;
-	_WIN32_FIND_DATAA findFileData;
 	sqlite3_stmt *stmt;
 	CSTR query;
 
-	hFindFile = FindFirstFileA(song->filepath, &findFileData);
-	if (hFindFile == (HANDLE)-1) {
+	auto last_write = [](const char* filepath) -> time_t {
+#ifdef _WIN32
+		_WIN32_FIND_DATAA findFileData;
+		HANDLE hFindFile = FindFirstFileA(filepath, &findFileData);
+		if (hFindFile == (HANDLE)-1) {
+			FindClose(hFindFile);
+			return -1;
+		}
 		FindClose(hFindFile);
-		return -1;
-	}
+		return GetUnixtimeFromFiletime(findFileData.ftLastWriteTime);
+#else
+		return GetNowUnixtime(); // FIXME(linux): stub
+#endif // _WIN32
+	};
 
-	FindClose(hFindFile);
-
-	int wtime = GetUnixtimeFromFiletime(findFileData.ftLastWriteTime);
+	int wtime = last_write(song->filepath);
 	int ntime = GetNowUnixtime();
 	int temp;
 	if (song->folderType == 0 || song->folderType == 5) {
@@ -802,7 +808,7 @@ int LoadFolderDataFromDB(CSTR query, SONGDATA *song, sqlite3 *sql, int difficult
 
 //4474a0
 int UninstallSong(CSTR path, sqlite3 *sql) {
-
+#ifdef _WIN32
 	SHFILEOPSTRUCTA sh;
 	char query[2048];
 	
@@ -824,11 +830,15 @@ int UninstallSong(CSTR path, sqlite3 *sql) {
 	sh.fFlags = FOF_NOERRORUI | FOF_NOCONFIRMATION | FOF_SILENT; //0x414
 
 	return (SHFileOperationA(&sh) == 0);
+#else
+	// FIXME(linux): stub
+	return {};
+#endif // _WIN32
 }
 
 //4476b0
 int Rename(CSTR path, sqlite3 *sql) {
-
+#ifdef _WIN32
 	SHFILEOPSTRUCTA sh;
 	char query[2048];
 
@@ -845,6 +855,10 @@ int Rename(CSTR path, sqlite3 *sql) {
 	sh.fFlags = FOF_NOERRORUI | FOF_NOCONFIRMATION | FOF_SILENT; //0x414
 
 	return (SHFileOperationA(&sh) == 0);
+#else
+	// FIXME(linux): stub
+	return {};
+#endif // _WIN32
 }
 
 //447820
@@ -1143,7 +1157,7 @@ int ChangeCourseID(sqlite3 *sql, int newID, int oldID, int type) {
 
 //448ea0
 int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
-	
+#ifdef _WIN32
 	HANDLE hFindFile;
 	_WIN32_FIND_DATAA findFileData;
 	int now,filetime;
@@ -1229,6 +1243,10 @@ int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 			return count;
 		}
 	}
+#else
+	// FIXME(linux): stub
+	return {};
+#endif // _WIN32
 }
 
 //449780 TODO:arrange duplicated code
@@ -1738,7 +1756,7 @@ int WriteRandomCourse(sqlite3 *sql, COURSESELECT *course, SONGSELECT *ss, CONFIG
 
 //44beb0 //TOFIX: unneccessary codes
 int GetFolderDataFromPath(CSTR path, sqlite3 *sql) {
-
+#ifdef _WIN32
 	HANDLE hFindFile;
 	_WIN32_FIND_DATAA findFileData;
 	char str[1024];
@@ -1807,6 +1825,10 @@ int GetFolderDataFromPath(CSTR path, sqlite3 *sql) {
 	ErrorLogFmtAdd("ルートの読み込みを終了しました。\n");
 	ErrorLogTabSub();
 	return 1;
+#else
+	// FIXME(linux): stub
+	return {};
+#endif // _WIN32
 }
 
 //44c610 //TODO : rename variables

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -2,6 +2,8 @@
 #include "Engine.h"
 #include "LR2_statlong.h"
 
+#include <shellapi.h>
+
 int EnabledInsane;
 //404fe0 thiscall in original code
 SONGDATA * COPY_SONGDATA(SONGDATA *s1, SONGDATA *s2){

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -438,7 +438,7 @@ int EditTag(SONGDATA *song, sqlite3 *sql) {
 		SQL_Run(query, sql);
 
 		sqlite3_snprintf(1024, query, "INSERT INTO song (hash,title,subtitle,genre,artist,subartist,level,date,path,folder,stagefile,banner,backbmp,parent,maxbpm,minbpm,random,longnote,judge,mode,bga,difficulty,favorite,type,txt,karinotes,adddate,exlevel) VALUES(\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,%d,%d,%d,%d,%d,%d,0,0,%d,%d,%d,%d)",
-			meta.hash, meta.title, meta.subtitle, meta.genre, meta.artist, meta.subartist, meta.selLevel, wtime, song->filepath, AssignCRC32(meta.folderpath), meta.stagefilepath,meta.bannerpath,meta.backBMPpath, AssignCRC32(meta.parentfolderpath), meta.maxbpm,meta.minbpm, meta.random,meta.longnote,meta.judge,meta.keymode,meta.bga,meta.difficulty,meta.hasTxt,meta.notecount,temp,meta.exlevel);
+			meta.hash, meta.title, meta.subtitle, meta.genre, meta.artist, meta.subartist, meta.selLevel, wtime, song->filepath, AssignCRC32(meta.folderpath).body, meta.stagefilepath,meta.bannerpath,meta.backBMPpath, AssignCRC32(meta.parentfolderpath).body, meta.maxbpm,meta.minbpm, meta.random,meta.longnote,meta.judge,meta.keymode,meta.bga,meta.difficulty,meta.hasTxt,meta.notecount,temp,meta.exlevel);
 		SQL_Run(query, sql);
 
 		if (meta.difficulty <= 0 || meta.difficulty > 5) {
@@ -507,7 +507,7 @@ int LoadFolderDataFromDB(CSTR query, SONGDATA *song, sqlite3 *sql, int difficult
 	int slistCount;
 	CSTR nowFolder, newFolder, workingFolder;
 	int nowMode, nowDifficulty;
-	
+
 	//key 0:ALL 1:SINGLE 2:7keys 3:5keys 4:DOUBLE 5:14keys 6:10keys 7:9buttons
 
 	if ((cfg_select->ignorekeyall == 1) && (key == 0)) key = 1;
@@ -561,7 +561,7 @@ int LoadFolderDataFromDB(CSTR query, SONGDATA *song, sqlite3 *sql, int difficult
 
 	int keymode_A = 0;
 	slist = (SONGDATA*)malloc(sizeof(SONGDATA) * 1000);
-	memset(slist, 0, sizeof(SONGDATA) * 1000);
+	memset(slist, 0, sizeof(SONGDATA) * 1000); // FIXME: bad memset
 	slistCount = 0;
 	SQL_prepare(query, sql, &stmt);
 
@@ -1301,14 +1301,14 @@ int ReloadSongsByQuery(CSTR query, sqlite3 *sql, CONFIG_JUKEBOX *jb) {
 						ParseBMSMETA(&meta, str, 1);
 						LoadBMSMETAFromDB(&meta, sql);
 						SQL_Run(sqlite3_snprintf(1024, sBuf, "INSERT INTO song (hash,title,subtitle,genre,artist,subartist,level,date,path,folder,stagefile,banner,backbmp,parent,maxbpm,minbpm,random,longnote,judge,mode,bga,difficulty,favorite,type,txt,karinotes,adddate,exlevel) VALUES(\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,%d,%d,%d,%d,%d,%d,0,0,%d,%d,%d,%d)",
-							meta.hash, meta.title, meta.subtitle, meta.genre, meta.artist, meta.subartist, meta.selLevel, newTime, str, AssignCRC32(meta.folderpath), meta.stagefilepath, meta.bannerpath, meta.backBMPpath,AssignCRC32(meta.parentfolderpath),meta.maxbpm,meta.minbpm,meta.random,meta.longnote,meta.judge,meta.keymode,meta.bga,meta.difficulty,meta.hasTxt,meta.notecount,now,meta.exlevel), sql);
+							meta.hash, meta.title, meta.subtitle, meta.genre, meta.artist, meta.subartist, meta.selLevel, newTime, str, AssignCRC32(meta.folderpath).body, meta.stagefilepath, meta.bannerpath, meta.backBMPpath,AssignCRC32(meta.parentfolderpath),meta.maxbpm,meta.minbpm,meta.random,meta.longnote,meta.judge,meta.keymode,meta.bga,meta.difficulty,meta.hasTxt,meta.notecount,now,meta.exlevel), sql);
 					}
 					else if (flgFolder) {
 						SQL_Run(sqlite3_snprintf(1024, sBuf, "DELETE FROM folder WHERE path=\'%q\'", str), sql);
 						BMSMETA meta;
 						ParseBMSMETA(&meta, str, 1);
 						SQL_Run(sqlite3_snprintf(1024, sBuf, "INSERT INTO folder (path , title , parent , category , info_a , info_b , command , max , date , type , banner , adddate) VALUES(\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d , %d , 2 , %s , %d) ",
-							str, meta.title, AssignCRC32(meta.folderpath), meta.genre, meta.artist, meta.subartist, meta.tag, meta.selLevel, newTime, meta.bannerpath, now), sql);
+							str, meta.title, AssignCRC32(meta.folderpath).body, meta.genre, meta.artist, meta.subartist, meta.tag, meta.selLevel, newTime, meta.bannerpath, now), sql);
 					}
 					else {
 						CSTR folderinfo(str);
@@ -1346,7 +1346,7 @@ int ReloadSongsByQuery(CSTR query, sqlite3 *sql, CONFIG_JUKEBOX *jb) {
 
 	if (cAlready == 0 && cNot == 0) {
 		if(cChange == 0){
-			ErrorLogFmtAdd("曲が見つかりません\n");
+			ErrorLogFmtAdd("曲が見つかりません: %s\n", query.body);
 			return 0;
 		}
 	}
@@ -1613,7 +1613,7 @@ int LoadBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *difficulty,
 			ss->prevList = (SONGDATA*)realloc(ss->prevList, (ss->prevListSize + 1000) * sizeof(SONGDATA));
 			assert(ss->prevList != nullptr);
 			for (int j = ss->prevListSize; j < ss->prevListSize + 1000; j++) {
-				memset(&ss->prevList[j], 0, sizeof(SONGDATA));
+				memset(&ss->prevList[j], 0, sizeof(SONGDATA)); // FIXME: bad memset
 			}
 			ss->prevListSize += 1000;
 		}
@@ -1660,7 +1660,7 @@ int LoadBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *difficulty,
 		return ss->prevListCount;
 	}
 
-	ErrorLogAdd("フォルダが見つかりません。\n");
+	ErrorLogFmtAdd("フォルダが見つかりません。%s...\n", query.body);
 	return -1;
 }
 
@@ -2589,7 +2589,7 @@ int LoadLR2CustomFolder(sqlite3 *sql, CONFIG_JUKEBOX *jb, CSTR scoreDBpath, char
 		SQL_Run("BEGIN", sql);
 		ErrorLogAdd("エラーフォルダの検索を行います。\n");
 
-		sqlite3_snprintf(1024, query, "SELECT * FROM folder WHERE parent = \'%s\'", AssignCRC32("ROOT"));
+		sqlite3_snprintf(1024, query, "SELECT * FROM folder WHERE parent = \'%s\'", AssignCRC32("ROOT").body);
 		SQL_prepare(query, sql, &pStmt);
 		while (sqlite3_step(pStmt) == 100) {
 			CSTR path;
@@ -2629,7 +2629,7 @@ int LoadLR2CustomFolder(sqlite3 *sql, CONFIG_JUKEBOX *jb, CSTR scoreDBpath, char
 		}
 		else {
 			ErrorLogAdd("フォルダ更新チェック(ルートのみ)を行います。\n");
-			sqlite3_snprintf(1024, query, "SELECT path,date FROM folder WHERE parent = \'%s\' OR date = 0", AssignCRC32("ROOT"));
+			sqlite3_snprintf(1024, query, "SELECT path,date FROM folder WHERE parent = \'%s\' OR date = 0", AssignCRC32("ROOT").body);
 			ReloadSongsByQuery(query, sql, jb);
 		}
 

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -490,7 +490,7 @@ int EditTag(SONGDATA *song, sqlite3 *sql) {
 }
 
 //446ab0 //TODO : I need to understand this and rename variables
-int LoadFolderDataFromDB(CSTR query, SONGDATA *song, sqlite3 *sql, int difficulty, int key, int sort, int maxCount, CONFIG_SELECT *cfg_select, char flag) {
+int LoadFolderDataFromDB(CSTR query, SONGDATA *song, sqlite3 *sql, int difficulty, int key, int /*sort*/, int maxCount, CONFIG_SELECT *cfg_select, char flag) {
 	sqlite3_stmt *stmt;
 	SONGDATA* slist;
 	SONGDATA sd;
@@ -954,7 +954,7 @@ int GetSongData(CSTR songMD5, SONGDATA *song, sqlite3 *sql, SONGSELECT *ss) {
 }
 
 //448110
-int WriteCourse(sqlite3 *sql, COURSESELECT course, SONGDATA *song, CSTR passmd5, int connection, int gauge) {
+int WriteCourse(sqlite3 *sql, COURSESELECT course, SONGDATA *song, CSTR passmd5, int connection, int /*gauge*/) {
 
 	char t[1024];
 

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -418,6 +418,7 @@ int EditTag(SONGDATA *song, sqlite3 *sql) {
 
 		sqlite3_snprintf(1024, query, "SELECT adddate FROM song WHERE path = \'%q\'", song->filepath);
 		SQL_prepare(query, sql, &stmt);
+		temp = 0;
 		if (sqlite3_step(stmt) == 100) {
 			temp = sqlite3_column_int(stmt, 0);
 		}
@@ -440,6 +441,7 @@ int EditTag(SONGDATA *song, sqlite3 *sql) {
 
 		sqlite3_snprintf(1024, query, "SELECT difficulty FROM song WHERE path = \'%q\'", song->filepath);
 		SQL_prepare(query, sql, &stmt);
+		temp = 0;
 		if (sqlite3_step(stmt) == 100) {
 			temp = sqlite3_column_int(stmt, 0);
 		}

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -576,6 +576,7 @@ int LoadFolderDataFromDB(CSTR query, SONGDATA *song, sqlite3 *sql, int difficult
 		if( (maxsize - 1001) == slistCount){
 			int newsize = nowsize + sizeof(SONGDATA) * 1000;
 			slist = (SONGDATA*)realloc(slist, newsize);
+			assert(slist != nullptr);
 			if (maxsize - 1000 < maxsize) {
 				memset((void*)((uintptr_t)slist + nowsize), 0, sizeof(SONGDATA) * 1000);
 			}
@@ -1439,6 +1440,7 @@ int SearchCourseFromDB(sqlite3 *sql, SONGSELECT *ss, int keys, int multistagemod
 
 		if (ss->prevListSize - 1 == ss->prevListCount) {
 			ss->prevList = (SONGDATA*)realloc(ss->prevList, (ss->prevListSize + 1000) * sizeof(SONGDATA));
+			assert(ss->prevList != nullptr);
 			for (int i = ss->prevListSize; i < ss->prevListSize + 1000; i++) {
 				memset(&ss->prevList[i], 0, sizeof(SONGDATA));
 			}
@@ -1589,6 +1591,7 @@ int LoadBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *difficulty,
 		if (count != 0 && i == count) break;
 		if (ss->prevListSize - 1 == i) {
 			ss->prevList = (SONGDATA*)realloc(ss->prevList, (ss->prevListSize + 1000) * sizeof(SONGDATA));
+			assert(ss->prevList != nullptr);
 			for (int j = ss->prevListSize; j < ss->prevListSize + 1000; j++) {
 				memset(&ss->prevList[j], 0, sizeof(SONGDATA));
 			}
@@ -1942,6 +1945,7 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 
 			if (count == ss->prevListSize - 1) {
 				ss->prevList = (SONGDATA*)realloc(ss->prevList, (ss->prevListSize + 1000) * sizeof(SONGDATA));
+				assert(ss->prevList != nullptr);
 				for (int i = ss->prevListSize; i < ss->prevListSize + 1000; i++) {
 					memset(&ss->prevList[i], 0, sizeof(SONGDATA));
 				}

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -1153,7 +1153,7 @@ int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 
 	ErrorLogFmtAdd("曲の検索を行います。パス%s\n", root);
 	ErrorLogTabAdd();
-	if (root.right(1).isDiff("\\")) root.add("\\");
+	if (root.right(1).isDiff("/")) root.add("/");
 
 	CSTR searchPath;
 	BMSMETA meta; 
@@ -1192,7 +1192,7 @@ int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 		}
 		else {
 			searchPath = root;
-			searchPath.add(findFileData.cFileName).add("\\");
+			searchPath.add(findFileData.cFileName).add("/");
 			ErrorLogFmtAdd("フォルダを発見しました。　パス:%s\n", searchPath);
 			
 			CSTR folderinfo(searchPath);
@@ -1208,7 +1208,7 @@ int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 				if (SQL_Run(str, sql) == 0) {
 					ErrorLogAdd("再帰検索を行います。\n");
 					CSTR subPath(root);
-					subPath.add(findFileData.cFileName).add("\\");
+					subPath.add(findFileData.cFileName).add("/");
 					count += SearchSongsFromPath(searchPath, sql, subPath);
 				}
 			}
@@ -1217,7 +1217,7 @@ int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 				if (SQL_Run(str, sql) == 0) {
 					ErrorLogAdd("再帰検索を行います。\n");
 					CSTR subPath(root);
-					subPath.add(findFileData.cFileName).add("\\");
+					subPath.add(findFileData.cFileName).add("/");
 					count += SearchSongsFromPath(searchPath, sql, subPath);
 				}
 			}
@@ -1748,7 +1748,7 @@ int GetFolderDataFromPath(CSTR path, sqlite3 *sql) {
 	ErrorLogTabAdd();
 	BMSMETA meta;
 	CSTR searchPath(path);
-	if (searchPath.right(1).isSame("\\")) {
+	if (searchPath.right(1).isSame("/")) {
 		*searchPath.atPos(searchPath.length() - 1) = 0;
 	}
 
@@ -1849,7 +1849,7 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 		isRival = 1;
 		SQL_Run("DETACH rivaldb", sql);
 		CSTR str;
-		cstrSprintf(&str, "ATTACH \'LR2files\\Rival\\%d.db\' AS rivaldb", rivalID);
+		cstrSprintf(&str, "ATTACH \'LR2files/Rival/%d.db\' AS rivaldb", rivalID);
 		SQL_Run(str, sql);
 		ss->rivalID = rivalID;
 		rivalID = 0;
@@ -2483,59 +2483,59 @@ int LoadLR2CustomFolder(sqlite3 *sql, CONFIG_JUKEBOX *jb, CSTR scoreDBpath, char
 		if (flag_direct == 0) {
 			//TODO : make define customfolderoption constant
 			if (jb->customfolder & 1) {
-				jb->path[jb->numOfPath] = "LR2files\\CustomFolder\\RANDOM\\";
+				jb->path[jb->numOfPath] = "LR2files/CustomFolder/RANDOM/";
 				jb->numOfPath++;
 				folderAddCount++;
 			}
 			if (jb->customfolder & 2) {
-				jb->path[jb->numOfPath] = "LR2files\\CustomFolder\\favorite.lr2folder";
+				jb->path[jb->numOfPath] = "LR2files/CustomFolder/favorite.lr2folder";
 				jb->numOfPath++;
 				folderAddCount++;
 			}
 			if (jb->customfolder & 4) {
-				jb->path[jb->numOfPath] = "LR2files\\CustomFolder\\TOP10.lr2folder";
+				jb->path[jb->numOfPath] = "LR2files/CustomFolder/TOP10.lr2folder";
 				jb->numOfPath++;
 				folderAddCount++;
 			}
 			if (jb->customfolder & 8) {
-				jb->path[jb->numOfPath] = "LR2files\\CustomFolder\\PLAYLEVEL\\";
+				jb->path[jb->numOfPath] = "LR2files/CustomFolder/PLAYLEVEL/";
 				jb->numOfPath++;
 				folderAddCount++;
 			}
 			if (jb->customfolder & 0x10) {
-				jb->path[jb->numOfPath] = "LR2files\\CustomFolder\\CLEAR\\";
+				jb->path[jb->numOfPath] = "LR2files/CustomFolder/CLEAR/";
 				jb->numOfPath++;
 				folderAddCount++;
 			}
 			if (jb->customfolder & 0x20) {
-				jb->path[jb->numOfPath] = "LR2files\\CustomFolder\\RANK\\";
+				jb->path[jb->numOfPath] = "LR2files/CustomFolder/RANK/";
 				jb->numOfPath++;
 				folderAddCount++;
 			}
 			if (jb->customfolder & 0x40) {
-				jb->path[jb->numOfPath] = "LR2files\\CustomFolder\\ignore.lr2folder";
+				jb->path[jb->numOfPath] = "LR2files/CustomFolder/ignore.lr2folder";
 				jb->numOfPath++;
 				folderAddCount++;
 			}
 			if (jb->customfolder & 0x80) {
-				jb->path[jb->numOfPath] = "LR2files\\CustomFolder\\INSANE01\\";
+				jb->path[jb->numOfPath] = "LR2files/CustomFolder/INSANE01/";
 				jb->numOfPath++;
-				jb->path[jb->numOfPath] = "LR2files\\CustomFolder\\INSANE02\\";
+				jb->path[jb->numOfPath] = "LR2files/CustomFolder/INSANE02/";
 				jb->numOfPath++;
 				folderAddCount+=2;
 				EnabledInsane = 1;
 			}
-			jb->path[jb->numOfPath] = "LR2files\\CustomFolder\\course1.lr2folder";
+			jb->path[jb->numOfPath] = "LR2files/CustomFolder/course1.lr2folder";
 			jb->numOfPath++;
-			jb->path[jb->numOfPath] = "LR2files\\CustomFolder\\course2.lr2folder";
+			jb->path[jb->numOfPath] = "LR2files/CustomFolder/course2.lr2folder";
 			jb->numOfPath++;
-			jb->path[jb->numOfPath] = "LR2files\\CustomFolder\\course3.lr2folder";
+			jb->path[jb->numOfPath] = "LR2files/CustomFolder/course3.lr2folder";
 			jb->numOfPath++;
 			folderAddCount += 3;
 		}
 
 		sqlite3_open(scoreDBpath,&scoreDB);
-		sqlite3_open("LR2files\\Database\\tag.db", &tagDB);
+		sqlite3_open("LR2files/Database/tag.db", &tagDB);
 		SQL_Run("CREATE TABLE folder(title TEXT ,subtitle TEXT ,category TEXT,info_a TEXT,info_b TEXT,command TEXT,path TEXT primary key,type INTEGER,banner TEXT,parent TEXT,date INTEGER,max INTEGER,adddate INTEGER)", sql);
 		SQL_Run("CREATE TABLE song(hash TEXT ,title TEXT ,subtitle TEXT ,genre TEXT,artist TEXT,subartist TEXT,tag TEXT ,path TEXT primary key ,type INTEGER,folder TEXT,stagefile TEXT,banner TEXT,backbmp TEXT,parent TEXT,level INTEGER,difficulty INTEGER,maxbpm INTEGER,minbpm INTEGER,mode INTEGER,judge INTEGER,longnote INTEGER,bga INTEGER,random INTEGER,date INTEGER,favorite INTEGER,txt INTEGER,karinotes INTEGER,adddate INTEGER,exlevel INTEGER)", sql);
 		SQL_Run("CREATE INDEX hashidx ON song (hash)", sql);
@@ -2555,7 +2555,7 @@ int LoadLR2CustomFolder(sqlite3 *sql, CONFIG_JUKEBOX *jb, CSTR scoreDBpath, char
 			ErrorLogAdd("スコアデータベースの接続に失敗しました。\n");
 			return -1;
 		}
-		if (SQL_Run("ATTACH \'LR2files\\Database\\tag.db\' AS tagdb", sql) != 0) {
+		if (SQL_Run("ATTACH \'LR2files/Database/tag.db\' AS tagdb", sql) != 0) {
 			ErrorLogAdd("タグとかデータベースの接続に失敗しました。\n");
 			return -1;
 		}
@@ -2616,22 +2616,22 @@ int LoadLR2CustomFolder(sqlite3 *sql, CONFIG_JUKEBOX *jb, CSTR scoreDBpath, char
 		ErrorLogAdd("データベースチェックは終了しました。\n");
 
 		if (flag_starter == 0) {
-			SQL_Run("DELETE FROM folder WHERE path LIKE \'LR2files\\Rival\\%\'", sql);
+			SQL_Run("DELETE FROM folder WHERE path LIKE \'LR2files/Rival/%\'", sql);
 
 			for (int i = 0; i < 20; i++) {
 				if (jb->rival[i] < 1) break;
-				cstrSprintf(&jb->path[jb->numOfPath], "LR2files\\Rival\\%d.lr2folder", jb->rival[i]);
+				cstrSprintf(&jb->path[jb->numOfPath], "LR2files/Rival/%d.lr2folder", jb->rival[i]);
 				GetFolderDataFromPath(jb->path[jb->numOfPath], sql);
 				jb->numOfPath++;
 				folderAddCount++;
 			}
 
-			SQL_Run("DELETE FROM folder WHERE path=\'LR2files\\CustomFolder\\newsong.lr2folder\'", sql);
+			SQL_Run("DELETE FROM folder WHERE path=\'LR2files/CustomFolder/newsong.lr2folder\'", sql);
 			sqlite3_snprintf(1024, query, "SELECT * FROM song WHERE adddate > %d", GetNowUnixtime() - jb->titleflash * 3600);
 			sqlite3_stmt *pStmt;
 			SQL_prepare(query, sql, &pStmt);
 			if (sqlite3_step(pStmt) == 100) {
-				jb->path[jb->numOfPath] = "LR2files\\CustomFolder\\newsong.lr2folder";
+				jb->path[jb->numOfPath] = "LR2files/CustomFolder/newsong.lr2folder";
 				GetFolderDataFromPath(jb->path[jb->numOfPath], sql);
 				jb->numOfPath++;
 				folderAddCount++;

--- a/LR2/LR2_statlong.cpp
+++ b/LR2/LR2_statlong.cpp
@@ -1,5 +1,13 @@
 ﻿#include "LR2_statlong.h"
 
+#ifndef _WIN32
+#include <iostream>
+static void MessageBoxA(const char*,const char* title,const char*desc,const char*)
+{
+	std::cout << "\n" << title << "\n\n" << desc << "\n" << std::flush;
+}
+#endif // _WIN32
+
 //445fa0
 CSTR MakePlayerStatHash(PLAYERSTATISTIC *ps) {
 	CSTR tmp;

--- a/LR2/LR2_statlong.cpp
+++ b/LR2/LR2_statlong.cpp
@@ -11,7 +11,7 @@ static void MessageBoxA(const char*,const char* title,const char*desc,const char
 //445fa0
 CSTR MakePlayerStatHash(PLAYERSTATISTIC *ps) {
 	CSTR tmp;
-	cstrSprintf(&tmp, "%d%d%d%d%d%d%d%d%d%d%d%s%d%d%d%d%d%d%d%d%d%d%d", ps->bad, ps->clear, ps->combo, ps->fail, ps->good, ps->great, ps->maxcombo, ps->perfect, ps->playcount, ps->playtime, ps->poor, ps->passMD5,
+	cstrSprintf(&tmp, "%d%d%d%d%d%d%d%d%d%d%d%s%d%d%d%d%d%d%d%d%d%d%d", ps->bad, ps->clear, ps->combo, ps->fail, ps->good, ps->great, ps->maxcombo, ps->perfect, ps->playcount, ps->playtime, ps->poor, ps->passMD5.body,
 		ps->grade9, ps->grade10, ps->grade14, ps->grade5, ps->grade7, ps->gradeversion, ps->trial, ps->trialversion, ps->systemversion, ps->option, 1);
 	return MD5str(tmp);
 }
@@ -21,7 +21,7 @@ int UpdatePlayerStat(PLAYERSTATISTIC *ps, sqlite3 *sql) {
 	char query[1024];
 	CSTR hash = MakePlayerStatHash(ps);
 	sqlite3_snprintf(1024, query, "UPDATE player SET playcount= %d , clear = %d , fail = %d , perfect = %d , great = %d , good = %d , bad = %d , poor = %d , playtime = %d , combo = %d , maxcombo = %d,scorehash=\'%q\' ,grade_7=%d,grade_5=%d,grade_14=%d,grade_10=%d,grade_9=%d,trial = %d , option=%d,systemversion=%d,gradeversion=%d,trialversion=%d",
-		ps->playcount, ps->clear, ps->fail, ps->perfect, ps->great, ps->good, ps->bad, ps->poor, ps->playtime, ps->combo, ps->maxcombo, hash,
+		ps->playcount, ps->clear, ps->fail, ps->perfect, ps->great, ps->good, ps->bad, ps->poor, ps->playtime, ps->combo, ps->maxcombo, hash.body,
 		ps->grade7, ps->grade5, ps->grade14, ps->grade10, ps->grade9, ps->trial, ps->option, ps->systemversion, ps->gradeversion, ps->trialversion);
 	SQL_Run(query, sql);
 	return 1;
@@ -35,13 +35,13 @@ int ReadPlayerScore(CSTR id, CSTR pass, PLAYERSTATISTIC *pstat) {
 	sqlite3 *scoreDB;
 	sqlite3_stmt *stmt;
 
-	cstrSprintf(&dbPath, "LR2files/Database/Score/%s.db", id);
+	cstrSprintf(&dbPath, "LR2files/Database/Score/%s.db", id.body);
 	passMD5 = MD5str(pass);
 	
 	sqlite3_open(dbPath, &scoreDB);
 	ErrorLogFmtAdd("成功\n");
 
-	sqlite3_snprintf(256, str, "SELECT * FROM player WHERE id = \'%s\'", id);
+	sqlite3_snprintf(256, str, "SELECT * FROM player WHERE id = \'%s\'", id.body);
 	query = str;
 
 	SQL_prepare(query, scoreDB, &stmt);
@@ -207,10 +207,10 @@ int UpdateScoreDB(CSTR hash, STATUS *stat, sqlite3 *sql, CSTR *passMD5) {
 	CSTR scoreMD5(MakeScoreHash(stat, passMD5, &hash));
 	sqlite3_exec(sql, "BEGIN", 0, 0, 0);
 	cstrSprintf(&query, "INSERT INTO score (hash,clear ,perfect ,great ,good ,bad ,poor ,totalnotes ,maxcombo ,minbp ,playcount ,clearcount ,failcount ,op_history , rank , rate , clear_db , scorehash , clear_sd , clear_ex , op_best , rseed , complete) VALUES(\'%s\',%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,\'%s\',%d,%d,%d,%d,%d)"
-		, hash, stat->clear, stat->stat_pgreat, stat->stat_great, stat->stat_good, stat->stat_bad, stat->stat_poor, stat->total_notes, stat->stat_maxcombo, stat->minbp, stat->playcount, stat->clearcount, stat->failcount, stat->op_history, stat->rank, stat->rate, stat->clear_db, scoreMD5, stat->clear_sd, stat->clear_ex, stat->op_best, stat->rseed, stat->complete);
+		, hash.body, stat->clear, stat->stat_pgreat, stat->stat_great, stat->stat_good, stat->stat_bad, stat->stat_poor, stat->total_notes, stat->stat_maxcombo, stat->minbp, stat->playcount, stat->clearcount, stat->failcount, stat->op_history, stat->rank, stat->rate, stat->clear_db, scoreMD5.body, stat->clear_sd, stat->clear_ex, stat->op_best, stat->rseed, stat->complete);
 	if (SQL_Run(query, sql)){
 		cstrSprintf(&query, "UPDATE score SET clear=%d ,perfect=%d ,great=%d ,good=%d ,bad=%d ,poor=%d ,totalnotes=%d ,maxcombo=%d ,minbp=%d ,playcount=%d ,clearcount=%d ,failcount=%d ,op_history=%d ,scorehash=\'%s\',rank=%d,rate=%d,clear_db=%d,clear_sd=%d,clear_ex=%d,op_best=%d,rseed=%d,complete=%d WHERE hash = \'%s\'"
-			, stat->clear, stat->stat_pgreat, stat->stat_great, stat->stat_good, stat->stat_bad, stat->stat_poor, stat->total_notes, stat->stat_maxcombo, stat->minbp, stat->playcount, stat->clearcount, stat->failcount, stat->op_history, scoreMD5, stat->rank, stat->rate, stat->clear_db, stat->clear_sd, stat->clear_ex, stat->op_best, stat->rseed, stat->complete, hash);
+			, stat->clear, stat->stat_pgreat, stat->stat_great, stat->stat_good, stat->stat_bad, stat->stat_poor, stat->total_notes, stat->stat_maxcombo, stat->minbp, stat->playcount, stat->clearcount, stat->failcount, stat->op_history, scoreMD5.body, stat->rank, stat->rate, stat->clear_db, stat->clear_sd, stat->clear_ex, stat->op_best, stat->rseed, stat->complete, hash.body);
 		SQL_Run(query, sql);
 	}
 	sqlite3_exec(sql, "COMMIT", 0, 0, 0);

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -330,7 +330,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 					DrawGraph(0, 0, loadingGrHandle, 0);
 				}
 				ScreenFlip();
-				Sleep(500);
+				std::this_thread::sleep_for(std::chrono::milliseconds(500));
 			}
 
 			//mainphase
@@ -1775,7 +1775,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 							ErrorLogAdd("アイコン化が終わるまで待ちます\n");
 							while (ProcessMessage() == 0) {
 								if (IsIconic(GetMainWindowHandle()) == 0) break;
-								Sleep(16);
+								std::this_thread::sleep_for(std::chrono::milliseconds(16));
 							}
 							SetObjectStrings_SongSelect(&gs);
 							for (int i = 0; i < 200; i++) {
@@ -1796,7 +1796,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 						gs.KeyInput.inputID[KEY_INPUT_F1] = 0; //why F1?
 						gs.sSelect.is_buttonIRpage = 0;
 						InitInputStructure2(&gs.KeyInput);
-						Sleep(1000);
+						std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 						if (gs.sSelect.flag_maniacPanel || gs.sSelect.unk4f74) ClsDrawScreen();
 					}
 					else if (gs.KeyInput.inputID[KEY_INPUT_F2] == 2) {
@@ -2099,7 +2099,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 			gs.gameplay.flag_closingPhase = 1;
 			double threadExitTimer = GetTimeWrap();
 			while (gs.gameplay.flag_threadExist) {
-				Sleep(10);
+				std::this_thread::sleep_for(std::chrono::milliseconds(10));
 				if (GetTimeWrap() - threadExitTimer > 5000.0) break;
 			}
 			DxLib_End();

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -219,7 +219,7 @@ int main(int argc, char** argv) {
 			}*/
 		}
 		gs.config.system.thread = 0;
-		cstrSprintf(&pathScoreDB, "LR2files/Database/Score/%s.db", gs.config.player.id);
+		cstrSprintf(&pathScoreDB, "LR2files/Database/Score/%s.db", gs.config.player.id.body);
 		if (gs.is_starter == '\0') {
 			if (IsFileExist(pathScoreDB) == false) {
 				MessageBoxA(NULL, "スコアデータベースが見つかりません。\nconfig.exeで作成して下さい。", "エラー", 0);
@@ -417,13 +417,13 @@ int main(int argc, char** argv) {
 			gs.sSelect.unk4f74 = '\0';
 			if (gs.cmd_directplay && !gs.is_starter) { //logic arranged
 				gs.sSelect.cur = 0;
-				cstrSprintf(&gs.sSelect.stack_query[gs.sSelect.cur], "SELECT * FROM folder WHERE parent = \'%s\'", AssignCRC32("ROOT"));
+				cstrSprintf(&gs.sSelect.stack_query[gs.sSelect.cur], "SELECT * FROM folder WHERE parent = \'%s\'", AssignCRC32("ROOT").body);
 				gs.sSelect.stack_isFolder[gs.sSelect.cur] = 1;
 				gs.sSelect.stack_rivalID[gs.sSelect.cur] = 0;
 				gs.sSelect.stack_searchTitle[gs.sSelect.cur] = "検索語句を入力";
 				gs.sSelect.directory = gs.directoryPath.getDirectory();
 				gs.sSelect.bmsListCount = 1;
-					
+
 				tmp = GetSongDataFromPath(gs.directoryPath, gs.sSelect.bmsList, sql3, &gs.sSelect);
 				if (tmp == -1) return -1;
 				if (tmp == 2) gs.cmd_nosave = 1;
@@ -432,7 +432,7 @@ int main(int argc, char** argv) {
 				if (gs.is_starter) {
 					ErrorLogFmtAdd("スターターモードなので最初のジュークボックスのみ使用します。\n");
 					gs.sSelect.cur = 0;
-					cstrSprintf(&gs.sSelect.stack_query[gs.sSelect.cur], "SELECT * FROM song LEFT JOIN score ON song.hash = score.hash WHERE parent = \'%s\'", AssignCRC32(gs.config.jukebox.path[0]));
+					cstrSprintf(&gs.sSelect.stack_query[gs.sSelect.cur], "SELECT * FROM song LEFT JOIN score ON song.hash = score.hash WHERE parent = \'%s\'", AssignCRC32(gs.config.jukebox.path[0]).body);
 					gs.sSelect.stack_isFolder[gs.sSelect.cur] = 0;
 					gs.sSelect.stack_rivalID[gs.sSelect.cur] = 0;
 					gs.sSelect.stack_searchTitle[gs.sSelect.cur] = "検索語句を入力";
@@ -440,7 +440,7 @@ int main(int argc, char** argv) {
 				}
 				else {
 					gs.sSelect.cur = 0;
-					cstrSprintf(&gs.sSelect.stack_query[gs.sSelect.cur], "SELECT * FROM folder WHERE parent = \'%s\'", AssignCRC32("ROOT"));
+					cstrSprintf(&gs.sSelect.stack_query[gs.sSelect.cur], "SELECT * FROM folder WHERE parent = \'%s\'", AssignCRC32("ROOT").body);
 					gs.sSelect.stack_isFolder[gs.sSelect.cur] = 1;
 					gs.sSelect.stack_rivalID[gs.sSelect.cur] = 0;
 					gs.sSelect.stack_searchTitle[gs.sSelect.cur] = "検索語句を入力";
@@ -673,7 +673,7 @@ int main(int argc, char** argv) {
 					ErrorLogFmtAdd("break\n");
 					break;
 				}
-				
+
 				if (GetTimeWrap() >= startTime + 6) {
 					GetTimeWrap();
 					GetTimeWrap();
@@ -754,7 +754,7 @@ int main(int argc, char** argv) {
 								if (gs.sSelect.toRoot) {
 									gs.sSelect.cur = 0;
 									if (gs.is_starter == 0) {
-										cstrSprintf(&gs.sSelect.stack_query[gs.sSelect.cur], "SELECT * FROM folder WHERE parent = \'%s\'", AssignCRC32("ROOT"));
+										cstrSprintf(&gs.sSelect.stack_query[gs.sSelect.cur], "SELECT * FROM folder WHERE parent = \'%s\'", AssignCRC32("ROOT").body);
 										gs.sSelect.stack_isFolder[gs.sSelect.cur] = 1;
 										gs.sSelect.stack_rivalID[gs.sSelect.cur] = 0;
 										gs.sSelect.stack_searchTitle[gs.sSelect.cur] = "検索語句を入力";
@@ -763,7 +763,7 @@ int main(int argc, char** argv) {
 										SwapBmsList(&gs.sSelect);
 									}
 									else {
-										cstrSprintf(&gs.sSelect.stack_query[gs.sSelect.cur], "SELECT * FROM song LEFT JOIN score ON song.hash = score.hash WHERE parent = \'%s\'", AssignCRC32(gs.config.jukebox.path[0]));
+										cstrSprintf(&gs.sSelect.stack_query[gs.sSelect.cur], "SELECT * FROM song LEFT JOIN score ON song.hash = score.hash WHERE parent = \'%s\'", AssignCRC32(gs.config.jukebox.path[0]).body);
 										gs.sSelect.stack_isFolder[gs.sSelect.cur] = 0;
 										gs.sSelect.stack_rivalID[gs.sSelect.cur] = 0;
 										gs.sSelect.stack_searchTitle[gs.sSelect.cur] = "検索語句を入力";
@@ -854,7 +854,7 @@ int main(int argc, char** argv) {
 							}
 							SetTransColor(0, 255, 0);
 							LoadScene(&gs.skstruct, gs.config.skin.skinFilePath[6], gs.skinData.Data[gs.skinData.skinID[6]].informationP5, 0);
-							
+
 							StopSysSound(&gs);
 							if (gs.config.play.is_extra && gs.audio.sysSound.exdecide.load)
 								PlaySound(&gs.audio, &gs.audio.sysSound.exselect, gs.audio.chnBgm, -1);
@@ -1340,7 +1340,7 @@ int main(int argc, char** argv) {
 							break;
 						case 4: {
 							CSTR skinMD5;
-							cstrSprintf(&skinMD5, "LR2files/SkinCustomize/%s.xml", gs.skstruct.skinMD5);
+							cstrSprintf(&skinMD5, "LR2files/SkinCustomize/%s.xml", gs.skstruct.skinMD5.body);
 							SkinUser tmpSk;
 							ReadSkinCustomize(&tmpSk, skinMD5);
 							tmpSk.adjust.shift_x = gs.skstruct.adjust.shift_x;

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -629,8 +629,8 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 					gs.gameplay.flag_gameinput = 0;
 					gs.gameplay.previewStatus = 0;
 					for (int i = 0; i < 900; i++) {
-						gs.skstruct.op[i] = (GetOptionFlag_dst(&gs, i) > 0);
-						gs.skstruct2.op[i] = (GetOptionFlag_dst(&gs, i) > 0);
+						gs.skstruct.op[i] = GetOptionFlag_dst(&gs, i);
+						gs.skstruct2.op[i] = GetOptionFlag_dst(&gs, i);
 					}
 					for (int i = 900; i < 1000; i++) {
 						gs.skstruct.op[i] = 0;
@@ -2045,8 +2045,8 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 					SetWaitVSyncFlag(gs.config.system.vsync);
 					SetDrawScreen(DX_SCREEN_BACK);
 					for (int i = 0; i < 900; i++) {
-						gs.skstruct.op[i] = (GetOptionFlag_dst(&gs, i) > 0);
-						gs.skstruct2.op[i] = (GetOptionFlag_dst(&gs, i) > 0);
+						gs.skstruct.op[i] = GetOptionFlag_dst(&gs, i);
+						gs.skstruct2.op[i] = GetOptionFlag_dst(&gs, i);
 					}
 					for (int i = 900; i < 1000; i++) {
 						gs.skstruct.op[i] = 0;

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -1,25 +1,34 @@
-﻿#pragma once
-// /source-charset:shift-JIS /execution-charset:shift-JIS not supported in cl.exe on vs08. open your vs08 with locale emulation(cp932)
+﻿// /source-charset:shift-JIS /execution-charset:shift-JIS not supported in cl.exe on vs08. open your vs08 with locale emulation(cp932)
+
 #include "structure.h"
 #include "Engine.h"
 #include "LR2.h"
 #include "Scenes.h"
 
-#include <windows.h>
 #include <filesystem>
 #include <string>
 #include <thread>
 
-#include "DXlib/DxLib.h"
-#include "tinyxml/tinyxml.h"
+#include <DxLib/DxLib.h>
 extern "C" {
-#include "sqlite/sqlite3.h"
+#include <sqlite/sqlite3.h>
 }
 
 #define LR2TITLE "LR2 beta4 version 251121 - testbuild"
 #define LR2VERSIONSTRING "LR2 beta4 version 251121 - testbuild"
 
-int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdLine, int _nCmdShow) {
+#ifdef _WIN32
+
+#include <windows.h>
+
+int main(int, char**);
+int WINAPI WinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPSTR /*lpCmdLine*/, int /*nCmdShow*/)
+{
+	return main(__argc, __argv);
+}
+#endif // _WIN32
+
+int main(int argc, char** argv) {
 #ifdef _DEBUG
 	while (!IsDebuggerPresent()) std::this_thread::sleep_for(std::chrono::milliseconds(200));
 #endif
@@ -107,9 +116,9 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 		gs.audio.replay2avi = false;
 		gs.skstruct.drBuf.isDisabled = '\0';
 		//commandline
-		for (int i = 1; i < __argc; i++) {
+		for (int i = 1; i < argc; i++) {
 			CSTR tStr1;
-			tStr1.assign(__argv[i]);
+			tStr1.assign(argv[i]);
 			CSTR tStr2(tStr1);
 			tStr2.lower();
 			if (IsBmsFile(tStr2)) {

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -16,14 +16,10 @@ extern "C" {
 #include "sqlite/sqlite3.h"
 }
 
-
-
 #define LR2TITLE "LR2 beta4 version 251121 - testbuild"
 #define LR2VERSIONSTRING "LR2 beta4 version 251121 - testbuild"
 
-using namespace std;
-
-int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow) {
+int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdLine, int _nCmdShow) {
 #ifdef _DEBUG
 	while (!IsDebuggerPresent()) std::this_thread::sleep_for(std::chrono::milliseconds(200));
 #endif

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -6,6 +6,7 @@
 #include "Scenes.h"
 
 #include <windows.h>
+#include <filesystem>
 #include <string>
 #include <thread>
 
@@ -40,22 +41,28 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 	int lr1ir;
 	int lr2ir;
 	game gs;
-	char curDir[260];
 
 	const bool use_dx9 = getenv("OPENLR2_NO_DX9") == nullptr; // chown2: crashes on DxLib_Init with DX9 for me
 
 	int tmp;
-	
+
 	//start of code
+	char curDir[260];
 	GetModuleFileName(NULL, (LPCH)curDir, 260);
 	*(char*)(strrchr(curDir, '\\') + 1) = '\x00';
 	SetCurrentDirectory((LPCSTR)curDir);
 	gs.baseDirectory.assign(curDir, 0).add("\\");
 	gs.is_starter = false;
-	CopyFileA("LR2files\\Config\\keyconfig_def.xml", "LR2files\\Config\\keyconfig.xml", 1);
-	CopyFileA("LR2files\\Config\\keyconfig_5_def.xml", "LR2files\\Config\\keyconfig_5.xml", 1);
-	CopyFileA("LR2files\\Config\\keyconfig_p_def.xml", "LR2files\\Config\\keyconfig_p.xml", 1);
-	CopyFileA("LR2files\\Config\\midi_def.xml", "LR2files\\Config\\midi.xml", 1);
+	auto copy_if_not_exists = [](auto&& from, auto&& to_) {
+		std::filesystem::path to = to_;
+		std::error_code ec; // ignore errors
+		if (!std::filesystem::exists(to, ec))
+			std::filesystem::copy(from, to, ec);
+	};
+	copy_if_not_exists("LR2files/Config/keyconfig_def.xml", "LR2files/Config/keyconfig.xml");
+	copy_if_not_exists("LR2files/Config/keyconfig_5_def.xml", "LR2files/Config/keyconfig_5.xml");
+	copy_if_not_exists("LR2files/Config/keyconfig_p_def.xml", "LR2files/Config/keyconfig_p.xml");
+	copy_if_not_exists("LR2files/Config/midi_def.xml", "LR2files/Config/midi.xml");
 	ErrorLogAdd("コンフィグを読み込みます…");
 	
 	if (!ReadConfig(&gs, "LR2files\\Config\\config.xml") && gs.is_starter == false) {
@@ -189,12 +196,15 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 		if (gs.config.play.bga == 3) gs.config.play.bga = 1;
 		if (gs.config.select.disabledifficultyfilter == 1) gs.config.select.ignoredifficultyall = 0;
 		memcpy(&gs.sSelect.filter, &gs.config.select, sizeof(CONFIG_SELECT));
-		cstrSprintf(&newPath, "LR2files/Replay/%s", gs.config.player.id);
-		CreateDirectoryA(newPath, NULL);
-		cstrSprintf(&newPath, "LR2files/Ghost/%s", gs.config.player.id);
-		CreateDirectoryA(newPath, NULL);
-		CreateDirectoryA("LR2files/SkinCustomize", NULL);
-		CreateDirectoryA("screenshot", NULL);
+		{
+			std::error_code ec; // ignore errors
+			cstrSprintf(&newPath, "LR2files/Replay/%s", gs.config.player.id.body);
+			std::filesystem::create_directories(newPath.body, ec);
+			cstrSprintf(&newPath, "LR2files/Ghost/%s", gs.config.player.id.body);
+			std::filesystem::create_directories(newPath.body, ec);
+			std::filesystem::create_directories("LR2files/SkinCustomize", ec);
+			std::filesystem::create_directories("screenshot", ec);
+		}
 		ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig.xml");
 		gs.is_clicked_screenModeChange = 0;
 		gs.flag_Screenshot = 0;
@@ -1544,7 +1554,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 											if ( abs(gs.skstruct.dst_JUDGELINE[1].draw->w - gs.skstruct.image.dst[i].draw[gs.skstruct.image.dst[i].dstCount - 1].w) <= 10.0 
 												&& abs(gs.skstruct.dst_JUDGELINE[1].draw->x - gs.skstruct.image.dst[i].draw[gs.skstruct.image.dst[i].dstCount - 1].x) <= 5.0
 												&& (gs.skstruct.dst_JUDGELINE[1].draw->y >= gs.skstruct.image.dst[i].draw[gs.skstruct.image.dst[i].dstCount - 1].y || gs.skstruct.image.dst[i].draw[gs.skstruct.image.dst[i].dstCount - 1].h < 0.0)) {
-													
+
 												objx = gs.skstruct.adjust.note_2p_x;
 												objy = gs.skstruct.adjust.note_2p_y;
 											}
@@ -1552,7 +1562,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 									}
 								}
 							}
-							
+
 							if (gs.skstruct.image.dst[i].opt4 == 1) {
 								AddDrawingBuffer_Scratch(&gs.skstruct.drBuf, &gs.skstruct.image.src[i], &gs.skstruct.image.dst[i], &gs.timer1, gs.skstruct.scratchAngle_1);
 							}
@@ -1588,7 +1598,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 							}
 						}
 					}
-					
+
 				}
 
 				if (gs.procSelecter == 4 || gs.is_starter) {
@@ -1842,7 +1852,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 							}
 							else if (gs.KeyInput.inputID[KEY_INPUT_DOWN] == 1 && gs.config.select.disabledifficultyfilter == 0) {
 								gs.sSelect.bmsList[gs.sSelect.cur_song].difficulty++;
-								
+
 								if (gs.sSelect.bmsList[gs.sSelect.cur_song].difficulty >= 6)
 									gs.sSelect.bmsList[gs.sSelect.cur_song].difficulty = 1;
 								else if (gs.sSelect.bmsList[gs.sSelect.cur_song].difficulty < 1)

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -26,7 +26,49 @@ int WINAPI WinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPSTR /
 {
 	return main(__argc, __argv);
 }
+
+static std::filesystem::path GetExecutablePath()
+{
+	char fullpath[256] = { 0 };
+	if (!GetModuleFileNameA(nullptr, fullpath, sizeof(fullpath)))
+		return {};
+	return std::filesystem::path(fullpath).parent_path();
+}
+
+#else
+
+#include <iostream>
+
+static void MessageBoxA(const char*, const char* title, const char* desc, const char*)
+{
+	std::cout << "\n" << title << "\n\n" << desc << "\n" << std::flush;
+}
+
+static std::filesystem::path GetExecutablePath()
+{
+	char fullpath[256] = { 0 };
+
+	char process_path[] = "/proc/self/exe";
+	const auto bytes =
+		std::min(readlink(process_path, fullpath, sizeof(fullpath)), static_cast<ssize_t>(sizeof(fullpath) - 1));
+	if (bytes >= 0)
+		fullpath[bytes] = '\0';
+
+	return std::filesystem::path(fullpath).parent_path();
+}
+
+int DxLib::SetMouseDispFlag(int) { return {}; }
+
 #endif // _WIN32
+
+static consteval bool is_linux()
+{
+#ifdef _WIN32
+	return false;
+#else
+	return true;
+#endif
+}
 
 int main(int argc, char** argv) {
 #ifdef _DEBUG
@@ -51,12 +93,9 @@ int main(int argc, char** argv) {
 
 	int tmp;
 
-	//start of code
-	char curDir[260];
-	GetModuleFileName(NULL, (LPCH)curDir, 260);
-	*(char*)(strrchr(curDir, '\\') + 1) = '\x00';
-	SetCurrentDirectory((LPCSTR)curDir);
-	gs.baseDirectory.assign(curDir, 0).add("/");
+	auto curDir = GetExecutablePath();
+	std::filesystem::current_path(curDir);
+	gs.baseDirectory.assign(curDir.string().c_str(), 0).add("/");
 	gs.is_starter = false;
 	auto copy_if_not_exists = [](auto&& from, auto&& to_) {
 		std::filesystem::path to = to_;
@@ -187,7 +226,6 @@ int main(int argc, char** argv) {
 				return -1;
 			}
 			if (gs.is_starter == '\0') {
-				
 				if (ReadPlayerScore(gs.config.player.id, gs.config.player.pass, &gs.gameplay.playerstat) == 0) {
 					return -1;
 				}
@@ -223,11 +261,12 @@ int main(int argc, char** argv) {
 		SetManualTimerFlag(&gs.timer1, 0);
 		gs.timer1.movieFramerate = (double)gs.config.tools.movie_framerate;
 		gs.timer1.movieTimer = 0.0;
-		
+
 		SetGraphMode(640, 480, (gs.config.system.highcolor == 0) ? 32 : 16, 60); //TODO_RESOULUTION
 		if (gs.rec.recMode == 3) {
 			SetGraphMode(256, 256, 32, 60);
 		}
+#ifdef _WIN32
 		SetWindowSizeChangeEnableFlag(1, 1);
 		if (gs.audio.is_fmod_disabled == 0) {
 			SetNotSoundFlag(1);
@@ -268,12 +307,16 @@ int main(int argc, char** argv) {
 		else {
 			SetUseDirectDrawDeviceIndex(gs.config.system.maindisplay);
 		}
+#endif // _WIN32
 
-		CSTR title = LR2TITLE;
-		SetMainWindowText(title);
-		title.fillzero();
-		SetOutApplicationLogValidFlag(gs.config.system.outputlog);
+		if constexpr (!is_linux()) {
+			SetMainWindowText(LR2TITLE); // DxLib-for-Linux on Wayland segfaults on it
+		}
+		// DxLib-for-Linux only writes to stderr when writing to the log file.
+		SetOutApplicationLogValidFlag(gs.config.system.outputlog || is_linux());
+#ifdef _WIN32
 		SetMultiThreadFlag(1);
+#endif // _WIN32
 		if ((gs.is_recordmode == '\0') && (gs.rec.recMode == 0)) {
 			SetWaitVSyncFlag(gs.config.system.vsync);
 		}
@@ -281,16 +324,20 @@ int main(int argc, char** argv) {
 			SetWaitVSyncFlag(1);
 			ErrorLogFmtAdd("動画作成モードなのでVSyncを待ちます。\n");
 		}
+#ifdef _WIN32
 		SetMultiThreadFlag(1);
 		SetUseFPUPreserveFlag(1);
 		SetUseDirectInputFlag(1); //DXLIBVER: not in original, but we need it to make same reaction.
 		if (use_dx9) {
 			SetUseDirect3DVersion(DX_DIRECT3D_9); //DXLIBVER: if not set, it's DX11 (over 3.13e)
 		}
+#endif // _WIN32
 		if (DxLib_Init() != -1) {
 			ChangeFont("", 0);
 			SetLogFontSize(14); //DXLIBVER: change this for further dxlib version
+#ifdef _WIN32
 			SetSysCommandOffFlag(gs.config.system.disablesystemkey, 0);
+#endif // _WIN32
 			SetDrawScreen(DX_SCREEN_BACK);
 			SetAlwaysRunFlag(1);
 			SetMouseDispFlag(0);
@@ -351,7 +398,9 @@ int main(int argc, char** argv) {
 			//mainphase
 			if ((gs.is_recordmode == '\0') && (gs.auto2avi == '\0')) {
 				SetWaitVSyncFlag(gs.config.system.vsync);
+#ifdef _WIN32
 				ChangeWindowMode(gs.config.system.screenmode);
+#endif // _WIN32
 				SetWaitVSyncFlag(gs.config.system.vsync);
 				SetDrawScreen(DX_SCREEN_BACK);
 			}
@@ -608,6 +657,7 @@ int main(int argc, char** argv) {
 			while (true) { //main loop
 				if (ProcessMessage() || !gs.procSelecter || gs.auto2avi) break;
 
+#ifdef _WIN32
 				if (GetWindowModeFlag()) {
 					GetWindowSize(&wSizeX, &wSizeY);
 					if (0 < wSizeX && wSizeX < 9999 && gs.config.system.windowsize_x != wSizeX) {
@@ -617,6 +667,7 @@ int main(int argc, char** argv) {
 						gs.config.system.windowsize_y = wSizeY;
 					}
 				}
+#endif // _WIN32
 				DrawGraph(0, 0, backgroundGrHandle, 0);
 				if (gs.cmd_directplay && gs.procSelecter != 4 && gs.procSelecter != 5 && gs.procSelecter != 13 && gs.procPhase != 2 && gs.procPhase != 3) {
 					ErrorLogFmtAdd("break\n");
@@ -1763,18 +1814,22 @@ int main(int argc, char** argv) {
 							}
 							SetGraphMode(640, 480, (gs.config.system.highcolor == 0 ? 32 : 16), 60); //TODO_RESOULUTION
 							SetWaitVSyncFlag(gs.config.system.vsync);
+#ifdef _WIN32
 							ChangeWindowMode(gs.config.system.screenmode);
+#endif // _WIN32
 							SetWaitVSyncFlag(gs.config.system.vsync);
 							SetDrawScreen(DX_SCREEN_BACK);
 							LoadScene(&gs.skstruct, gs.config.skin.skinFilePath[5], gs.skinData.Data[gs.skinData.skinID[5]].informationP5, 0);
 							SetMouseDispFlag(0);
 							gs.is_clicked_screenModeChange = 0;
+#ifdef _WIN32
 							if (gs.config.system.screenmode == 0) {
 								ChangeWindowMode(1);
 								ErrorLogAdd("ウインドウを閉じます\n");
 								CloseWindow(GetMainWindowHandle());
 								ErrorLogAdd("成功\n");
 							}
+#endif // _WIN32
 							if (gs.config.network.lr2ir == 1) {
 								//same as below
 								ErrorLogAdd("IRを出します\n");
@@ -1789,7 +1844,9 @@ int main(int argc, char** argv) {
 						if (gs.config.system.screenmode == 0) {
 							ErrorLogAdd("アイコン化が終わるまで待ちます\n");
 							while (ProcessMessage() == 0) {
+#ifdef _WIN32
 								if (IsIconic(GetMainWindowHandle()) == 0) break;
+#endif // _WIN32
 								std::this_thread::sleep_for(std::chrono::milliseconds(16));
 							}
 							SetObjectStrings_SongSelect(&gs);
@@ -1801,7 +1858,9 @@ int main(int argc, char** argv) {
 							}
 							SetGraphMode(640, 480, (gs.config.system.highcolor == 0 ? 32 : 16), 60); //TODO_RESOULUTION
 							SetWaitVSyncFlag(gs.config.system.vsync);
+#ifdef _WIN32
 							ChangeWindowMode(gs.config.system.screenmode);
+#endif // _WIN32
 							SetWaitVSyncFlag(gs.config.system.vsync);
 							SetDrawScreen(DX_SCREEN_BACK);
 							LoadScene(&gs.skstruct, gs.config.skin.skinFilePath[5], gs.skinData.Data[gs.skinData.skinID[5]].informationP5, 0);
@@ -2050,7 +2109,9 @@ int main(int argc, char** argv) {
 					}
 					SetGraphMode(640, 480, (gs.config.system.highcolor == 0 ? 32 : 16), 60); //TODO_RESOULUTION
 					SetWaitVSyncFlag(gs.config.system.vsync);
+#ifdef _WIN32
 					ChangeWindowMode(gs.config.system.screenmode);
+#endif // _WIN32
 					SetWaitVSyncFlag(gs.config.system.vsync);
 					SetDrawScreen(DX_SCREEN_BACK);
 					for (int i = 0; i < 900; i++) {
@@ -2067,6 +2128,7 @@ int main(int argc, char** argv) {
 					gs.is_clicked_screenModeChange = 0;
 					SetObjectStrings_SongSelect(&gs);
 				}
+#ifdef _WIN32
 				else if(GetWindowModeFlag() != gs.config.system.screenmode){
 					for (int i = 0; i < 200; i++) {
 						gs.skstruct.caption[i].fillzero();
@@ -2083,6 +2145,7 @@ int main(int argc, char** argv) {
 					gs.config.system.screenmode = GetWindowModeFlag();
 					SetObjectStrings_SongSelect(&gs);
 				}
+#endif // _WIN32
 				SetMouseDispFlag( (gs.KeyInput.mouse_oldX < 640 && gs.KeyInput.mouse_oldY < 480) ? 0:1  ); //TODO_RESOULUTION
 				if ( (gs.procSelecter == 2 || gs.procSelecter == 9) && gs.KeyInput.inputID[KEY_INPUT_ESCAPE]
 					 && (GetTimeLapse(4,&gs.timer1) < 0.0 || GetTimeLapse(4, &gs.timer1) > 100.0) 

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -47,7 +47,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 	GetModuleFileName(NULL, (LPCH)curDir, 260);
 	*(char*)(strrchr(curDir, '\\') + 1) = '\x00';
 	SetCurrentDirectory((LPCSTR)curDir);
-	gs.baseDirectory.assign(curDir, 0).add("\\");
+	gs.baseDirectory.assign(curDir, 0).add("/");
 	gs.is_starter = false;
 	auto copy_if_not_exists = [](auto&& from, auto&& to_) {
 		std::filesystem::path to = to_;
@@ -60,8 +60,8 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 	copy_if_not_exists("LR2files/Config/keyconfig_p_def.xml", "LR2files/Config/keyconfig_p.xml");
 	copy_if_not_exists("LR2files/Config/midi_def.xml", "LR2files/Config/midi.xml");
 	ErrorLogAdd("コンフィグを読み込みます…");
-	
-	if (!ReadConfig(&gs, "LR2files\\Config\\config.xml") && gs.is_starter == false) {
+
+	if (!ReadConfig(&gs, "LR2files/Config/config.xml") && gs.is_starter == false) {
 		MessageBoxA(NULL, "コンフィグファイルが見つかりません。", "エラー", NULL);
 		return -1;
 	}
@@ -81,17 +81,17 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 			gs.config.play.hsfix = 4;
 			gs.config.player.passMD5.assign("STARTERMODE");
 			gs.config.player.id.assign("STARTERMODE");
-			gs.config.jukebox.newsongfolder.assign(".\\");
+			gs.config.jukebox.newsongfolder.assign("./");
 			gs.config.jukebox.titleflash = 0;
 			gs.config.select.sort = 1;
 			gs.config.select.key = 1;
 			gs.config.jukebox.numOfPath = 1;
-			gs.config.jukebox.path[0].assign("BeatVocaloids\\");
+			gs.config.jukebox.path[0].assign("BeatVocaloids/");
 		}
 		lr1ir = gs.config.network.lr1ir;
 		lr2ir = gs.config.network.lr2ir;
 		gs.flag_showFPS = 0;
-		ReadMIDI(&gs, "LR2files\\Config\\midi.xml");
+		ReadMIDI(&gs, "LR2files/Config/midi.xml");
 		if (gs.config.system.softwarerendering == 1) {
 			SetUse3DFlag(0);
 		}
@@ -201,10 +201,10 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 			std::filesystem::create_directories("LR2files/SkinCustomize", ec);
 			std::filesystem::create_directories("screenshot", ec);
 		}
-		ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig.xml");
+		ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
 		gs.is_clicked_screenModeChange = 0;
 		gs.flag_Screenshot = 0;
-		ReadOptionstrFile(gs.txtStruct.option_str, "LR2files\\Config\\optionstr.csv");
+		ReadOptionstrFile(gs.txtStruct.option_str, "LR2files/Config/optionstr.csv");
 		gs.audio.is_fmod_disabled = gs.config.sound.disablefmod;
 		if (gs.config.sound.disablefmod != 0) {
 			gs.config.select.preview = 0;
@@ -314,7 +314,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 			SetDrawScreen(DX_SCREEN_BACK);
 
 			memcpy(gs.config.jukebox.rival, gs.net.rivals, 4 * 20);
-			sqlite3_open(gs.is_starter ? "LR2files\\Database.db" : "LR2files\\Database\\song.db", &sql3);
+			sqlite3_open(gs.is_starter ? "LR2files/Database.db" : "LR2files/Database/song.db", &sql3);
 			LoadLR2CustomFolder(sql3, &gs.config.jukebox, pathScoreDB, gs.is_starter, gs.cmd_directplay);
 			if ( gs.cmd_directplay == false && gs.config.network.lr2ir == 1 && (((unsigned char)gs.config.jukebox.customfolder & 0x80) != 0)) {
 				gs.net.GetInsaneList();
@@ -524,7 +524,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 			InitSound(&gs.audio,gs.config.sound.bufferlength,gs.config.sound.numbuffers,gs.config.sound.disabledsp,gs.config.sound.output,gs.config.sound.driver);
 			ReadLR2SoundSet(&gs, gs.config.skin.skinFilePath[10], 0);
 			if (gs.is_starter == false) {
-				if (LoadSound(&gs.audio, &gs.gameplay.muon, CSTR("LR2files\\Config\\muon.wav"), 1, gs.config.sound.disabledsp, 0) == -1) {
+				if (LoadSound(&gs.audio, &gs.gameplay.muon, CSTR("LR2files/Config/muon.wav"), 1, gs.config.sound.disabledsp, 0) == -1) {
 					ErrorLogAdd("muon.wavがありません\n");
 					gs.procSelecter = 0;
 				}
@@ -651,7 +651,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 								memcpy(&gs.config.play, &gs.gameplay.targetCfg, sizeof(CONFIG_PLAY));
 							}
 							gs.gameplay.ghostBattle = '\0';
-							ReadKeyConfig(&gs, (gs.config.select.control == 0) ? "LR2files\\Config\\keyconfig.xml" : "LR2files\\Config\\keyconfig_p.xml");
+							ReadKeyConfig(&gs, (gs.config.select.control == 0) ? "LR2files/Config/keyconfig.xml" : "LR2files/Config/keyconfig_p.xml");
 							DeleteGraph(gs.skstruct.GrHandle[100]);
 							gs.skstruct.GrHandle[100] = -1;
 							DeleteGraph(gs.skstruct.GrHandle[101]);
@@ -841,13 +841,13 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 								if (gs.sSelect.bmsList[gs.sSelect.cur_song].keymode == 5) {
 									LoadScene(&gs.skstruct, gs.config.skin.skinFilePath[13], gs.skinData.Data[gs.skinData.skinID[13]].informationP5, 0);
 									if (gs.skinData.Data[gs.skinData.skinID[13]].type != SKINTYPE_7KEYSBATTLE)
-										ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig.xml");
+										ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
 									else 
-										ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig_5.xml");
+										ReadKeyConfig(&gs, "LR2files/Config/keyconfig_5.xml");
 								}
 								else {
 									LoadScene(&gs.skstruct, gs.config.skin.skinFilePath[12], gs.skinData.Data[gs.skinData.skinID[12]].informationP5, 0);
-									ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig.xml");
+									ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
 								}
 							}
 							else if (gs.config.select.control == 1 && (gs.sSelect.metaSelected.keymode == 5 || gs.sSelect.metaSelected.keymode == 7)) {
@@ -857,7 +857,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 								else if (gs.config.play.battle == 1) {
 									LoadScene(&gs.skstruct, gs.config.skin.skinFilePath[14], gs.skinData.Data[gs.skinData.skinID[14]].informationP5, 0);
 								}
-								ReadKeyConfig(&gs,"LR2files\\Config\\keyconfig_p.xml");
+								ReadKeyConfig(&gs,"LR2files/Config/keyconfig_p.xml");
 							}
 							else {
 								switch (gs.sSelect.metaSelected.keymode) {
@@ -865,23 +865,23 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 										if (gs.config.play.battle == 0) {
 											LoadScene(&gs.skstruct, gs.config.skin.skinFilePath[1], gs.skinData.Data[gs.skinData.skinID[1]].informationP5, 0);
 											if (gs.skinData.Data[gs.skinData.skinID[1]].type != SKINTYPE_5KEYS)
-												ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig.xml");
+												ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
 											else
-												ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig_5.xml");
+												ReadKeyConfig(&gs, "LR2files/Config/keyconfig_5.xml");
 										}
 										else if (gs.config.play.battle == 1) {
 											LoadScene(&gs.skstruct, gs.config.skin.skinFilePath[13], gs.skinData.Data[gs.skinData.skinID[13]].informationP5, 0);
 											if (gs.skinData.Data[gs.skinData.skinID[13]].type != SKINTYPE_7KEYSBATTLE)
-												ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig.xml");
+												ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
 											else
-												ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig_5.xml");
+												ReadKeyConfig(&gs, "LR2files/Config/keyconfig_5.xml");
 										}
 										else if (gs.config.play.battle == 2 || gs.config.play.battle == 3) {
 											LoadScene(&gs.skstruct, gs.config.skin.skinFilePath[3], gs.skinData.Data[gs.skinData.skinID[3]].informationP5, 0);
 											if (gs.skinData.Data[gs.skinData.skinID[3]].type != SKINTYPE_10KEYS)
-												ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig.xml");
+												ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
 											else
-												ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig_5.xml");
+												ReadKeyConfig(&gs, "LR2files/Config/keyconfig_5.xml");
 										}
 										break;
 
@@ -895,13 +895,13 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 										else if (gs.config.play.battle == 2 || gs.config.play.battle == 3) {
 											LoadScene(&gs.skstruct, gs.config.skin.skinFilePath[2], gs.skinData.Data[gs.skinData.skinID[2]].informationP5, 0);
 										}
-										ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig.xml");
+										ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
 										break;
 
 									case 9:
 										if (gs.config.play.battle == 3) {
 											LoadScene(&gs.skstruct, gs.config.skin.skinFilePath[0], gs.skinData.Data[gs.skinData.skinID[0]].informationP5, 0);
-											ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig.xml");
+											ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
 											break;
 										}
 										else if (gs.config.play.battle == 0 || gs.config.play.battle == 2) {
@@ -910,30 +910,30 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 										else if (gs.config.play.battle == 1) {
 											LoadScene(&gs.skstruct, gs.config.skin.skinFilePath[14], gs.skinData.Data[gs.skinData.skinID[14]].informationP5, 0);
 										}
-										ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig_p.xml");
+										ReadKeyConfig(&gs, "LR2files/Config/keyconfig_p.xml");
 										break;
 
 									case 10:
 										if (gs.config.play.battle == 0) {
 											LoadScene(&gs.skstruct, gs.config.skin.skinFilePath[3], gs.skinData.Data[gs.skinData.skinID[3]].informationP5, 0);
 											if (gs.skinData.Data[gs.skinData.skinID[3]].type == SKINTYPE_10KEYS)
-												ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig_5.xml"); 
+												ReadKeyConfig(&gs, "LR2files/Config/keyconfig_5.xml"); 
 											else
-												ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig.xml");
+												ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
 										}
 										else if (gs.config.play.battle == 1 || gs.config.play.battle == 2) {
 											LoadScene(&gs.skstruct, gs.config.skin.skinFilePath[13], gs.skinData.Data[gs.skinData.skinID[13]].informationP5, 0);
 											if (gs.skinData.Data[gs.skinData.skinID[13]].type == SKINTYPE_7KEYSBATTLE)
-												ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig_5.xml");
+												ReadKeyConfig(&gs, "LR2files/Config/keyconfig_5.xml");
 											else
-												ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig.xml");
+												ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
 										}
 										else if (gs.config.play.battle == 3) {
 											LoadScene(&gs.skstruct, gs.config.skin.skinFilePath[1], gs.skinData.Data[gs.skinData.skinID[1]].informationP5, 0);
 											if (gs.skinData.Data[gs.skinData.skinID[1]].type == SKINTYPE_5KEYS)
-												ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig_5.xml");
+												ReadKeyConfig(&gs, "LR2files/Config/keyconfig_5.xml");
 											else
-												ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig.xml");
+												ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
 										}
 										break;
 
@@ -947,14 +947,14 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 										else if(gs.config.play.battle == 3) {
 											LoadScene(&gs.skstruct, gs.config.skin.skinFilePath[0], gs.skinData.Data[gs.skinData.skinID[0]].informationP5, 0);
 										}
-										ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig.xml");
+										ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
 										break;
 								}
 							}
 
 							if (gs.config.play.m_lunaris) {
 								LoadScene(&gs.skstruct, gs.config.skin.skinFilePath[0], gs.skinData.Data[gs.skinData.skinID[0]].informationP5, 0);
-								ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig.xml");
+								ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
 								gs.gameplay.isAutoplay = 0;
 							}
 							for (int i = 0; i < gs.skstruct.num_of_ImageFont; i++) {
@@ -983,7 +983,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 							break;
 						case 8:
 							LoadScene(&gs.skstruct, gs.config.skin.skinFilePath[0], gs.skinData.Data[gs.skinData.skinID[0]].informationP5, 0);
-							ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig.xml");
+							ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
 							LUNARIS_START(&gs);
 							break;
 						case 9:
@@ -1280,7 +1280,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 							break;
 						case 4: {
 							CSTR skinMD5;
-							cstrSprintf(&skinMD5, "LR2files\\SkinCustomize\\%s.xml", gs.skstruct.skinMD5);
+							cstrSprintf(&skinMD5, "LR2files/SkinCustomize/%s.xml", gs.skstruct.skinMD5);
 							SkinUser tmpSk;
 							ReadSkinCustomize(&tmpSk, skinMD5);
 							tmpSk.adjust.shift_x = gs.skstruct.adjust.shift_x;
@@ -1340,7 +1340,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 								ErrorLogAdd("BMSの音を初期化しました\n");
 							}
 
-							ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig.xml");
+							ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
 							if (gs.gameplay.replay.status == 2) {
 								ReleaseReplayBuffer(&gs.gameplay.replay);
 								gs.audio.param.eq_gain[0] = gs.gameplay.replay.aud.eq_gain[0];
@@ -1442,7 +1442,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 							}
 							break;
 						case 6:
-							ReadKeyConfig(&gs, "LR2files\\Config\\keyconfig.xml");
+							ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
 							break;
 						case 7:
 							ClearSkinGraph(&gs.skstruct2);
@@ -2088,8 +2088,8 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 			//phase_exit game
 			if (gs.is_recordmode) {
 				RecordBmsSound(&gs, gs.directoryFilename);
-				remove("LR2files\\movie_temp.mp3");
-				remove("LR2files\\movie_temp.wav");
+				remove("LR2files/movie_temp.mp3");
+				remove("LR2files/movie_temp.wav");
 			}
 			gs.net.WaitAndInitRanking();
 			gs.gameplay.flag_closingPhase = 1;
@@ -2146,8 +2146,8 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE _hPrevInstance, LPSTR _lpCmdL
 			gs.config.network.lr1ir = lr1ir;
 			gs.config.network.lr2ir = lr2ir;
 			if ( gs.auto2avi == 0 && gs.is_recordmode == 0 && gs.rec.recMode == 0) {
-				WriteConfigXml(&gs, "LR2files\\Config\\config.xml");
-				WriteMidiXml(&gs, "LR2files\\Config\\midi.xml");
+				WriteConfigXml(&gs, "LR2files/Config/config.xml");
+				WriteMidiXml(&gs, "LR2files/Config/midi.xml");
 			}
 			CloseMIDI();
 			for (int i = 0; i < 6480; i++) {

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1811,7 +1811,7 @@ void SubProcI_Select(game *g, sqlite3 *sql) {
 				else if (GetTimeLapse(175, &g->timer1) > 120.0) {
 					ResetTimeLapse(175, &g->timer1);
 					SetTimeLapse(176, &g->timer1);
-					g->sSelect.prevListCount = min(g->net.rankingData.rankingCount, 999);
+					g->sSelect.prevListCount = std::min(g->net.rankingData.rankingCount, 999);
 					for (int i = 0; i < g->sSelect.prevListCount; i++) {
 						InitSongData(&g->sSelect.prevList[i]);
 						COPY_SONGDATA(&g->sSelect.prevList[i], &g->sSelect.bmsList[g->sSelect.cur_song]);

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1910,19 +1910,19 @@ void SubProcI_Select(game *g, sqlite3 *sql) {
 		if (g->KeyInput.inputID[KEY_INPUT_F8] == 1) {
 			if (g->sSelect.stack_query[g->sSelect.cur].findStrPos("parent") != -1) {
 				SetBmsFilter(g, sql);
-				g->sSelect.unk4fa4[0] = sqlite3_snprintf(1024, buf, "SELECT path,date FROM song WHERE parent = \'%s\'", g->sSelect.stack_query[g->sSelect.cur].right(9).left(8));
+				g->sSelect.unk4fa4[0] = sqlite3_snprintf(1024, buf, "SELECT path,date FROM song WHERE parent = \'%s\'", g->sSelect.stack_query[g->sSelect.cur].right(9).left(8).body);
 				if (g->sSelect.bmsList[g->sSelect.cur_song].keymode < 1 || g->sSelect.cur < 1) {
 					g->sSelect.reloadType = 3;
-					g->sSelect.unk4fa4[1] = sqlite3_snprintf(1024, buf, "SELECT path,date FROM folder WHERE parent = \'%s\'", g->sSelect.stack_query[g->sSelect.cur].right(9).left(8));
-					g->sSelect.unk4fa4[2] = sqlite3_snprintf(1024, buf, "SELECT path, date FROM song WHERE parent = \'%s\'", AssignCRC32(g->sSelect.bmsList[g->sSelect.cur_song].filepath));
-					g->sSelect.unk4fa4[3] = sqlite3_snprintf(1024, buf, "SELECT path,date FROM folder WHERE parent = \'%s\'", AssignCRC32(g->sSelect.bmsList[g->sSelect.cur_song].filepath));
+					g->sSelect.unk4fa4[1] = sqlite3_snprintf(1024, buf, "SELECT path,date FROM folder WHERE parent = \'%s\'", g->sSelect.stack_query[g->sSelect.cur].right(9).left(8).body);
+					g->sSelect.unk4fa4[2] = sqlite3_snprintf(1024, buf, "SELECT path, date FROM song WHERE parent = \'%s\'", AssignCRC32(g->sSelect.bmsList[g->sSelect.cur_song].filepath).body);
+					g->sSelect.unk4fa4[3] = sqlite3_snprintf(1024, buf, "SELECT path,date FROM folder WHERE parent = \'%s\'", AssignCRC32(g->sSelect.bmsList[g->sSelect.cur_song].filepath).body);
 				}
 				else {
 					g->sSelect.reloadType = 2;
-					g->sSelect.unk4fa4[1] = sqlite3_snprintf(1024, buf, "SELECT path,date FROM folder WHERE parent = \'%s\'", g->sSelect.stack_query[g->sSelect.cur].right(9).left(8));
-					g->sSelect.unk4fa4[2] = sqlite3_snprintf(1024, buf, "SELECT path,date FROM folder WHERE parent = \'%s\'", g->sSelect.stack_query[g->sSelect.cur - 1].right(9).left(8));
+					g->sSelect.unk4fa4[1] = sqlite3_snprintf(1024, buf, "SELECT path,date FROM folder WHERE parent = \'%s\'", g->sSelect.stack_query[g->sSelect.cur].right(9).left(8).body);
+					g->sSelect.unk4fa4[2] = sqlite3_snprintf(1024, buf, "SELECT path,date FROM folder WHERE parent = \'%s\'", g->sSelect.stack_query[g->sSelect.cur - 1].right(9).left(8).body);
 				}
-				g->sSelect.unk4fb4 = sqlite3_snprintf(1024, buf, "SELECT difficulty,folder,mode,path FROM song WHERE parent = \'%s\'", g->sSelect.stack_query[g->sSelect.cur].right(9).left(8));
+				g->sSelect.unk4fb4 = sqlite3_snprintf(1024, buf, "SELECT difficulty,folder,mode,path FROM song WHERE parent = \'%s\'", g->sSelect.stack_query[g->sSelect.cur].right(9).left(8).body);
 				g->sSelect.filter_clicked = 4;
 			}
 
@@ -2331,8 +2331,8 @@ void SubProcI_Select(game *g, sqlite3 *sql) {
 					if (g->sSelect.bmsList[g->sSelect.cur_song].tag.length() > 2 && g->sSelect.bmsList[g->sSelect.cur_song].tag.isDiff("(null)")) {
 						g->sSelect.queryCount = 3;
 						g->sSelect.curQuery[0] = sqlite3_snprintf(1024, buf, "SELECT * FROM song LEFT JOIN score ON song.hash = score.hash WHERE %s", g->sSelect.bmsList[g->sSelect.cur_song].tag);
-						g->sSelect.curQuery[2] = sqlite3_snprintf(1024, buf, "SELECT * FROM folder WHERE parent = \'%s\'", AssignCRC32(g->sSelect.bmsList[g->sSelect.cur_song].filepath));
-						g->sSelect.curQuery[1] = sqlite3_snprintf(1024, buf, "SELECT * FROM song LEFT JOIN score ON song.hash = score.hash WHERE parent = \'%s\'", AssignCRC32(g->sSelect.bmsList[g->sSelect.cur_song].filepath));
+						g->sSelect.curQuery[2] = sqlite3_snprintf(1024, buf, "SELECT * FROM folder WHERE parent = \'%s\'", AssignCRC32(g->sSelect.bmsList[g->sSelect.cur_song].filepath.body).body);
+						g->sSelect.curQuery[1] = sqlite3_snprintf(1024, buf, "SELECT * FROM song LEFT JOIN score ON song.hash = score.hash WHERE parent = \'%s\'", AssignCRC32(g->sSelect.bmsList[g->sSelect.cur_song].filepath).body);
 						(g->sSelect).unk4fb8[0] = 0;
 						(g->sSelect).unk4fc0 = 1;
 						(g->sSelect).unk4fb8[1] = 0;
@@ -2345,11 +2345,11 @@ void SubProcI_Select(game *g, sqlite3 *sql) {
 							g->sSelect.reloadType = 1;
 						}
 						g->sSelect.queryCount = 2;
-						g->sSelect.unk4fa4[1] = sqlite3_snprintf(1024, buf, "SELECT path,date FROM folder WHERE parent = \'%s\'", AssignCRC32(g->sSelect.bmsList[g->sSelect.cur_song].filepath));
-						g->sSelect.unk4fa4[0] = sqlite3_snprintf(1024, buf, "SELECT path,date FROM song WHERE parent = \'%s\'", AssignCRC32(g->sSelect.bmsList[g->sSelect.cur_song].filepath));
-						g->sSelect.unk4fb4 = sqlite3_snprintf(1024, buf, "SELECT difficulty,folder,mode,path FROM song WHERE parent = \'%s\'", AssignCRC32(g->sSelect.bmsList[g->sSelect.cur_song].filepath));
-						g->sSelect.curQuery[1] = sqlite3_snprintf(1024, buf, "SELECT * FROM folder WHERE parent = \'%s\'", AssignCRC32(g->sSelect.bmsList[g->sSelect.cur_song].filepath));
-						g->sSelect.curQuery[0] = sqlite3_snprintf(1024, buf, "SELECT * FROM song LEFT JOIN score ON song.hash = score.hash WHERE parent = \'%s\'", AssignCRC32(g->sSelect.bmsList[g->sSelect.cur_song].filepath));
+						g->sSelect.unk4fa4[1] = sqlite3_snprintf(1024, buf, "SELECT path,date FROM folder WHERE parent = \'%s\'", AssignCRC32(g->sSelect.bmsList[g->sSelect.cur_song].filepath).body);
+						g->sSelect.unk4fa4[0] = sqlite3_snprintf(1024, buf, "SELECT path,date FROM song WHERE parent = \'%s\'", AssignCRC32(g->sSelect.bmsList[g->sSelect.cur_song].filepath).body);
+						g->sSelect.unk4fb4 = sqlite3_snprintf(1024, buf, "SELECT difficulty,folder,mode,path FROM song WHERE parent = \'%s\'", AssignCRC32(g->sSelect.bmsList[g->sSelect.cur_song].filepath).body);
+						g->sSelect.curQuery[1] = sqlite3_snprintf(1024, buf, "SELECT * FROM folder WHERE parent = \'%s\'", AssignCRC32(g->sSelect.bmsList[g->sSelect.cur_song].filepath).body);
+						g->sSelect.curQuery[0] = sqlite3_snprintf(1024, buf, "SELECT * FROM song LEFT JOIN score ON song.hash = score.hash WHERE parent = \'%s\'", AssignCRC32(g->sSelect.bmsList[g->sSelect.cur_song].filepath).body);
 						g->sSelect.unk4fb8[1] = 1;
 						g->sSelect.unk4fb8[0] = 0;
 						g->sSelect.unk4fc4[0] = 0;

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1586,7 +1586,7 @@ void ThreadProc_RankingAutoUpdate(void *param) { // TODO: take game&
 	SetTimeLapse(177, &g->timer1);
 	g->net.IRstatus = 3;
 	while (GetTimeLapse(177, &g->timer1) <g->net.waitTime) {
-		Sleep(4);
+		std::this_thread::sleep_for(std::chrono::milliseconds(4));
 		if (g->net.waitForHandle || (isIR2 && (g->KeyInput.p1_buttonInput[4] == 2 || g->KeyInput.p2_buttonInput[4] == 2))) {
 			g->sSelect.isRankingAutoUpdateThread = 0;
 			ResetTimeLapse(177, &g->timer1);

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -604,7 +604,7 @@ int LoadFontForSongs(game *gs, char flag) {
 
 //40b320
 int ShowReadmes(game *g) {
-
+#ifdef _WIN32
 	CSTR search;
 	HANDLE hFindFile;
 	WIN32_FIND_DATA FindFileData;
@@ -685,6 +685,10 @@ int ShowReadmes(game *g) {
 
 	g->txtStruct.readme.y = g->skstruct.src_README[0].op1 * g->txtStruct.readme.lines;
 	return 1;
+#else
+	// TODO: reimplement with std::filesystem
+	return {};
+#endif // _WIN32
 }
 
 //40b720
@@ -710,7 +714,11 @@ int ShowReadme(game *g, CSTR path) {
 
 	CSTR fBuf(0x400);
 
+#ifdef _WIN32
 	fopen_s(&pFile, g->txtStruct.readme.path, "r");
+#else
+	pFile = fopen(g->txtStruct.readme.path, "r");
+#endif // _WIN32
 
 	char *pFbuf = fBuf.outstr();
 	if (pFile != NULL) {
@@ -1741,7 +1749,9 @@ int ProcS_Select(game *g) {
 	
 	SetObjectString(30, g->sSelect.stack_searchTitle[g->sSelect.cur], g->txtStruct.objectStr);
 	SetTarget(g);
+#ifdef WIN32
 	DeleteKeyInput(g->txtStruct.hKeyInput);
+#endif // _WIN32
 	g->txtStruct.st_text_num = -1;
 	g->sSelect.metaSelected.artist = g->sSelect.bmsList[g->sSelect.cur_song].artist;
 	g->sSelect.metaSelected.filepath = g->sSelect.bmsList[g->sSelect.cur_song].filepath;

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1451,7 +1451,7 @@ void CheckNewSong(glb_dbgame *glb) {
 	sqlite3_stmt *pStmt;
 	char buf[1024];
 	int filDiff, filKey;
-	int err = 0;
+	bool err = false;
 
 	std::unique_lock l{g_db_lock};
 	glb->pGame->sSelect.searchFocused = 2;

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -81,7 +81,7 @@ void ThreadProc_LoadBanner(void *param) { // TODO: take game&
 }
 
 //4021a0
-int SetBmsFilter(game *g, sqlite3 *sql){
+int SetBmsFilter(game *g, sqlite3 */*sql*/){
 
 	g->sSelect.searchType = 0;
 	g->sSelect.searchFocused = 1;
@@ -980,7 +980,6 @@ CSTR GetMissonString(int missionLevel, int line) {
 			else 
 				return "";
 	}
-	return "";
 }
 
 

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1474,11 +1474,11 @@ void CheckNewSong(glb_dbgame *glb) {
 		if (err) {
 			ErrorLogAdd("未設定の#DIFFICULTYを設定します。\n");
 			SetUndefinedDifficulty(glb->pSql);
-			sqlite3_exec(glb->pSql, "DELETE FROM folder WHERE path=\'LR2files\\CustomFolder\\newsong.lr2folder\'", 0, 0, 0);
+			sqlite3_exec(glb->pSql, "DELETE FROM folder WHERE path=\'LR2files/CustomFolder/newsong.lr2folder\'", 0, 0, 0);
 			sqlite3_snprintf(1024, buf, "SELECT * FROM song WHERE adddate > %d", GetNowUnixtime() - jb.titleflash * 3600);
 			sqlite3_prepare(glb->pSql, buf, -1, &pStmt, NULL);
 			if (sqlite3_step(pStmt) == 100) {
-				jb.path[jb.numOfPath] = "LR2files\\CustomFolder\\newsong.lr2folder";
+				jb.path[jb.numOfPath] = "LR2files/CustomFolder/newsong.lr2folder";
 				GetFolderDataFromPath(jb.path[jb.numOfPath], glb->pSql);
 			}
 			sqlite3_finalize(pStmt);

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -3041,12 +3041,14 @@ int InitBmsList(SONGSELECT *ss) {
 	ss->bmsListSize = 1000;
 	ss->cur = 0;
 	ss->bmsList = (SONGDATA*)malloc(sizeof(SONGDATA) * 1000);
+	assert(ss->bmsList != nullptr);
 	for (int i = 0; i < ss->bmsListSize; i++) {
 		memset(&ss->bmsList[i], 0, sizeof(SONGDATA));
 	}
 
 	ss->prevListSize = 1000;
 	ss->prevList = (SONGDATA*)malloc(sizeof(SONGDATA) * 1000);
+	assert(ss->prevList != nullptr);
 	for (int i = 0; i < ss->prevListSize; i++) {
 		memset(&ss->prevList[i], 0, sizeof(SONGDATA));
 	}

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -276,7 +276,6 @@ int ApplyJudgeMine(int judge, game *g, int _player, int lane, int damage) {
 int DrawNotes(game *g, skstruct *sk, Timer *T, CONFIG_PLAY *cfg) {
 	//TODO : refactor, test maniac mode
 	DSTdraw tDdraw;
-	int key;
 
 	SoundGetCurrentTime(&g->audio, &g->gameplay.muon);
 	NONE_004b6770();

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -6,9 +6,17 @@
 #define pi2 6.2831853
 #define pi_half 1.570796
 
-#include <process.h> //beginthread
 #include "Engine.h"
 #include "LR2.h"
+
+#ifndef _WIN32
+#include <iostream>
+#define GetMainWindowHandle() nullptr
+static void MessageBoxA(const char*,const char* title,const char*desc,const char*)
+{
+	std::cout << "\n" << title << "\n\n" << desc << "\n" << std::flush;
+}
+#endif // _WIN32
 
 static int PerformGAS(gameplay& gameplay, int playerIdx, CONFIG_PLAY& cfg) {
 	PLAYERSTATUS& player = gameplay.player[playerIdx];

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1657,7 +1657,7 @@ void ProcGameThread(game *g) {
 	g->gameplay.flag_closingPhase = 0;
 	
 	while (g->procPhase == 0 || GetTimeLapse(0,&g->timer1) < g->skstruct.loadstart) {
-		Sleep(16);
+		std::this_thread::sleep_for(std::chrono::milliseconds(16));
 		if (g->gameplay.flag_closingPhase) {
 			g->gameplay.flag_threadExist = 0;
 			break;
@@ -1672,7 +1672,7 @@ void ProcGameThread(game *g) {
 	}
 
 	while (GetTimeLapse(0, &g->timer1) < g->skstruct.loadstart + g->skstruct.loadend || g->gameplay.bmsResourceLoaded == 0) {
-		Sleep(16);
+		std::this_thread::sleep_for(std::chrono::milliseconds(16));
 		if (g->gameplay.flag_closingPhase) {
 			g->gameplay.flag_threadExist = 0;
 			break;
@@ -1685,7 +1685,7 @@ void ProcGameThread(game *g) {
 		|| g->KeyInput.inputID[2] || g->KeyInput.inputID[3] || g->KeyInput.inputID[4] || g->KeyInput.inputID[5] || g->KeyInput.inputID[6] || g->KeyInput.inputID[7] || g->KeyInput.inputID[8] || g->KeyInput.inputID[9]	|| g->KeyInput.inputID[11] 
 		|| g->KeyInput.p1_buttonInput[12] || g->KeyInput.p1_buttonInput[13] || g->KeyInput.p2_buttonInput[12] || g->KeyInput.p2_buttonInput[13]) {
 
-		Sleep(16);
+		std::this_thread::sleep_for(std::chrono::milliseconds(16));
 		ReactInput(g);
 		if (g->gameplay.flag_closingPhase) {
 			g->gameplay.flag_threadExist = 0;

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -381,6 +381,7 @@ int DrawNotes(game *g, skstruct *sk, Timer *T, CONFIG_PLAY *cfg) {
 			speed = cfg->hiSpeed[1];
 		}
 		
+		if (sk->dst_LINE[0].draw == nullptr) break; // Empty skin
 		if ((sk->horizontal == 0 && sk->dst_LINE[0].draw->y + (songtimer - g->gameplay.bmsobj_line.notes[i].bmsTiming)* speed * g->gameplay.speedmultiplier * (cfg->basespeed / 100.0) / 600.0 > drawStartHeight)
 			|| (sk->horizontal == 1 && (g->gameplay.bmsobj_line.notes[i].bmsTiming - songtimer)* speed * g->gameplay.speedmultiplier * (cfg->basespeed / 100.0) / 640.0 > drawStartHeight)) { 
 						

--- a/LR2/Scene06_Keyconfig.cpp
+++ b/LR2/Scene06_Keyconfig.cpp
@@ -50,13 +50,13 @@ int ProcI_Keyconfig(game *g) {
 			g->config.input.buttonMap[g->KeyInput.config_button_inMap][g->KeyInput.config_key] = (g->KeyInput.inputID[KEY_INPUT_DELETE] == 1)? 0 : fndkey;
 			PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 			if (g->KeyInput.config_keymode == 0) {
-				WriteKeyConfig(g, "LR2files\\Config\\keyconfig.xml", 7);
+				WriteKeyConfig(g, "LR2files/Config/keyconfig.xml", 7);
 			}
 			else if(g->KeyInput.config_keymode == 1){
-				WriteKeyConfig(g, "LR2files\\Config\\keyconfig_p.xml", 9);
+				WriteKeyConfig(g, "LR2files/Config/keyconfig_p.xml", 9);
 			}
 			else if (g->KeyInput.config_keymode == 2) {
-				WriteKeyConfig(g, "LR2files\\Config\\keyconfig_5.xml", 5);
+				WriteKeyConfig(g, "LR2files/Config/keyconfig_5.xml", 5);
 			}
 			ProcS_Keyconfig(g);
 		}
@@ -66,16 +66,16 @@ int ProcI_Keyconfig(game *g) {
 		memset(g->config.input.buttonMap, 0, 16 * 40 * sizeof(int));
 
 		if (g->KeyInput.config_keymode == 0) {
-			ReadKeyConfig(g, "LR2files\\Config\\keyconfig_def.xml");
-			WriteKeyConfig(g, "LR2files\\Config\\keyconfig.xml", 7);
+			ReadKeyConfig(g, "LR2files/Config/keyconfig_def.xml");
+			WriteKeyConfig(g, "LR2files/Config/keyconfig.xml", 7);
 		}
 		else if (g->KeyInput.config_keymode == 1) {
-			ReadKeyConfig(g, "LR2files\\Config\\keyconfig_p_def.xml");
-			WriteKeyConfig(g, "LR2files\\Config\\keyconfig_p.xml", 9);
+			ReadKeyConfig(g, "LR2files/Config/keyconfig_p_def.xml");
+			WriteKeyConfig(g, "LR2files/Config/keyconfig_p.xml", 9);
 		}
 		else if (g->KeyInput.config_keymode == 2) {
-			ReadKeyConfig(g, "LR2files\\Config\\keyconfig_5_def.xml");
-			WriteKeyConfig(g, "LR2files\\Config\\keyconfig_5.xml", 5);
+			ReadKeyConfig(g, "LR2files/Config/keyconfig_5_def.xml");
+			WriteKeyConfig(g, "LR2files/Config/keyconfig_5.xml", 5);
 		}
 		ProcS_Keyconfig(g);
 	}

--- a/LR2/Scene07_Skinselect.cpp
+++ b/LR2/Scene07_Skinselect.cpp
@@ -277,8 +277,8 @@ int MakeSkinPreview(game *g, skstruct *sk, SkinManage *sm) {
 	}
 	//enable
 	for (int i = 0; i < 900; i++) {
-		g->skstruct.op[i] = (GetOptionFlag_dst(g, i) > 0);
-		g->skstruct2.op[i] = (GetOptionFlag_dst(g, i) > 0);
+		g->skstruct.op[i] = GetOptionFlag_dst(g, i);
+		g->skstruct2.op[i] = GetOptionFlag_dst(g, i);
 	}
 	for (int i = 0; i < 100; i++) {
 		g->skstruct.op[900 + i] = 0;
@@ -438,7 +438,7 @@ int ProcS_SkinSelect(game *g) {
 		SetObjectString(110 + i, skd.customs[d.previewCustomID + i].op_label[skd.customs[d.previewCustomID + i].dst_op_selected - skd.customs[d.previewCustomID + i].dst_op_start], g->txtStruct.objectStr);
 	}
 	for (int i = 0; i < 1000; i++) {
-		g->skstruct2.op[i] = (GetOptionFlag_dst(g, i) > 0);
+		g->skstruct2.op[i] = GetOptionFlag_dst(g, i);
 	}
 	MakeSkinPreview(g, &g->skstruct2, &d);
 	PlayPreviewSample(g);

--- a/LR2/Scene07_Skinselect.cpp
+++ b/LR2/Scene07_Skinselect.cpp
@@ -285,7 +285,7 @@ int MakeSkinPreview(game *g, skstruct *sk, SkinManage *sm) {
 		g->skstruct2.op[900 + i] = 0;
 	}
 	DeleteGraph(sk->GrHandle[100]);
-	sk->GrHandle[100] = LoadGraph("LR2files\\Config\\title.bmp", 0);
+	sk->GrHandle[100] = LoadGraph("LR2files/Config/title.bmp", 0);
 	LoadScene(sk, sm->Data[sm->previewID].skinFile, 0, 1);
 	return 0;
 }
@@ -307,60 +307,60 @@ int PlayPreviewSample(game *g) {
 	ReleaseBGA(g);
 	switch (g->skinData.select) {
 		default: //case 0:?
-			ReadKeyConfig(g, "LR2files\\Config\\keyconfig.xml");
+			ReadKeyConfig(g, "LR2files/Config/keyconfig.xml");
 			g->sSelect.metaSelected.keymode = 7;
 			InitGameplay(&g->gameplay, &tCfg.play);
-			ParseBmsFile(&g->gameplay, "LR2files\\Config\\sample_7.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
-			LoadBmsResource(&g->gameplay, "LR2files\\Config\\sample_7.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
+			ParseBmsFile(&g->gameplay, "LR2files/Config/sample_7.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
+			LoadBmsResource(&g->gameplay, "LR2files/Config/sample_7.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
 			break;
 
 		case 1:
 			if (g->skinData.Data[g->skinData.skinID[1]].type == SKINTYPE_7KEYS) 
-				ReadKeyConfig(g, "LR2files\\Config\\keyconfig.xml");
+				ReadKeyConfig(g, "LR2files/Config/keyconfig.xml");
 			else 
-				ReadKeyConfig(g, "LR2files\\Config\\keyconfig_5.xml");
+				ReadKeyConfig(g, "LR2files/Config/keyconfig_5.xml");
 			g->sSelect.metaSelected.keymode = 5;
 			InitGameplay(&g->gameplay, &tCfg.play);
-			ParseBmsFile(&g->gameplay, "LR2files\\Config\\sample_5.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
-			LoadBmsResource(&g->gameplay, "LR2files\\Config\\sample_5.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
+			ParseBmsFile(&g->gameplay, "LR2files/Config/sample_5.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
+			LoadBmsResource(&g->gameplay, "LR2files/Config/sample_5.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
 			break;
 
 		case 2:
-			ReadKeyConfig(g, "LR2files\\Config\\keyconfig.xml");
+			ReadKeyConfig(g, "LR2files/Config/keyconfig.xml");
 			g->sSelect.metaSelected.keymode = 14;
 			InitGameplay(&g->gameplay, &tCfg.play);
-			ParseBmsFile(&g->gameplay, "LR2files\\Config\\sample_14.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
-			LoadBmsResource(&g->gameplay, "LR2files\\Config\\sample_14.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
+			ParseBmsFile(&g->gameplay, "LR2files/Config/sample_14.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
+			LoadBmsResource(&g->gameplay, "LR2files/Config/sample_14.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
 			break;
 
 		case 3:
 			if (g->skinData.Data[g->skinData.skinID[3]].type == SKINTYPE_14KEYS)
-				ReadKeyConfig(g, "LR2files\\Config\\keyconfig.xml");
+				ReadKeyConfig(g, "LR2files/Config/keyconfig.xml");
 			else
-				ReadKeyConfig(g, "LR2files\\Config\\keyconfig_5.xml");
+				ReadKeyConfig(g, "LR2files/Config/keyconfig_5.xml");
 			g->sSelect.metaSelected.keymode = 10;
 			InitGameplay(&g->gameplay, &tCfg.play);
-			ParseBmsFile(&g->gameplay, "LR2files\\Config\\sample_10.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
-			LoadBmsResource(&g->gameplay, "LR2files\\Config\\sample_10.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
+			ParseBmsFile(&g->gameplay, "LR2files/Config/sample_10.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
+			LoadBmsResource(&g->gameplay, "LR2files/Config/sample_10.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
 			break;
 
 		case 4:
-			ReadKeyConfig(g, "LR2files\\Config\\keyconfig_p.xml");
+			ReadKeyConfig(g, "LR2files/Config/keyconfig_p.xml");
 			g->sSelect.metaSelected.keymode = 9;
 			InitGameplay(&g->gameplay, &tCfg.play);
-			ParseBmsFile(&g->gameplay, "LR2files\\Config\\sample_9.pms", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
-			LoadBmsResource(&g->gameplay, "LR2files\\Config\\sample_9.pms", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
+			ParseBmsFile(&g->gameplay, "LR2files/Config/sample_9.pms", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
+			LoadBmsResource(&g->gameplay, "LR2files/Config/sample_9.pms", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
 			break;
 
 		case 13:
 			if (g->skinData.Data[g->skinData.skinID[13]].type == SKINTYPE_5KEYSBATTLE)
-				ReadKeyConfig(g, "LR2files\\Config\\keyconfig.xml");
+				ReadKeyConfig(g, "LR2files/Config/keyconfig.xml");
 			else
-				ReadKeyConfig(g, "LR2files\\Config\\keyconfig_5.xml");
+				ReadKeyConfig(g, "LR2files/Config/keyconfig_5.xml");
 			g->sSelect.metaSelected.keymode = 5;
 			InitGameplay(&g->gameplay, &tCfg.play);
-			ParseBmsFile(&g->gameplay, "LR2files\\Config\\sample_5.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
-			LoadBmsResource(&g->gameplay, "LR2files\\Config\\sample_5.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
+			ParseBmsFile(&g->gameplay, "LR2files/Config/sample_5.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
+			LoadBmsResource(&g->gameplay, "LR2files/Config/sample_5.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
 			break;
 	}
 
@@ -410,7 +410,7 @@ int ProcS_SkinSelect(game *g) {
 	int &n = d.previewID;
 	SkinHeader &skd = d.Data[n];
 
-	cstrSprintf(&path, "LR2files\\SkinCustomize\\%s.xml", MD5str(skd.skinFile));
+	cstrSprintf(&path, "LR2files/SkinCustomize/%s.xml", MD5str(skd.skinFile));
 	ReadSkinCustomize(&sku, path);
 
 	for (int i = 0; i < 20; i++) {

--- a/LR2/Scene09_Po4menu.cpp
+++ b/LR2/Scene09_Po4menu.cpp
@@ -3,7 +3,7 @@
 #include "LR2.h"
 
 //422210
-int ProcI_PO4Menu(game *g, sqlite3 *sql) { //not tested
+int ProcI_PO4Menu(game *g, sqlite3 */*sql*/) { //not tested
 
 	int selectedBar = g->sSelect.listSelectedBarFromScreenTop;
 

--- a/LR2/Scene11_Po4select.cpp
+++ b/LR2/Scene11_Po4select.cpp
@@ -253,7 +253,7 @@ int ProcI_PO4Select(game *g, sqlite3 *sql) { //not tested
 						return 1;
 					}
 
-					cstrSprintf(&g->sSelect.stack_query[g->sSelect.cur], "SELECT * FROM song LEFT JOIN score ON song.hash = score.hash WHERE parent = \'%s\'", AssignCRC32(g->config.jukebox.path[0]));
+					cstrSprintf(&g->sSelect.stack_query[g->sSelect.cur], "SELECT * FROM song LEFT JOIN score ON song.hash = score.hash WHERE parent = \'%s\'", AssignCRC32(g->config.jukebox.path[0]).body);
 					g->sSelect.stack_isFolder[g->sSelect.cur] = 0;
 					g->sSelect.stack_rivalID[g->sSelect.cur] = 0;
 					g->sSelect.stack_searchTitle[g->sSelect.cur] = "検索語句を入力";

--- a/LR2/dbgtool.cpp
+++ b/LR2/dbgtool.cpp
@@ -1,18 +1,18 @@
 ﻿#include "dbgtool.h"
-#include <stdio.h>
+
+#include <fstream>
 
 int dump(char* filename, void* from, int size){
+	char newname[260];
+	snprintf(newname,260,"%s.LR2dmp",filename);
 
-    FILE* pFile;
-    char newname[260];
-    snprintf(newname,260,"%s.LR2dmp",filename);
-    
-    fopen_s(&pFile,filename,"wb");
-    if (!pFile) return -1;
+	std::ofstream file{newname};
+	if (!file.good()) {
+		return -1;
+	}
 
-    fwrite(from, size, 1, pFile);
+	// cast safety: you can always cast to char* to inspect values as bytes
+	file.write(reinterpret_cast<const char*>(from), size);
 
-    fclose(pFile);
-
-    return 0;
+	return 0;
 }

--- a/LR2/strclass.cpp
+++ b/LR2/strclass.cpp
@@ -2,6 +2,10 @@
 
 #include "strclass.h"
 
+#include <cstring>
+#include <string>
+#include <string_view>
+
 typedef unsigned char byte;
 
 //43ad60
@@ -24,7 +28,6 @@ int CSTR::length() {
 
 //43adb0
 DWORD CSTR::CRC32() {
-	char cVar1;
 	char *pcVar2;
 	int pcVar3;
 	unsigned int uVar4;
@@ -112,7 +115,6 @@ bool CSTR::resize(size_t size) {
 CSTR& CSTR::add(const char *str, int len) {
 	int size;
 	int size2;
-	char ch;
 
 	if (len == 0) {
 		len = strlen(str);
@@ -210,50 +212,6 @@ uint CSTR::checkValidPos(int *pos, int *len) {
 	return 0;
 }
 
-//43afc0
-CSTR& CSTR::replace(int pos, int len1, const char *str2, int len2) {
-	char *_Src;
-	int iVar1;
-	char cVar2;
-	int _Size;
-	bool bVar3;
-	uint uVar4;
-	size_t sVar5;
-	char *pcVar6;
-
-	uVar4 = checkValidPos(&pos, &len1);
-	if (uVar4 != 0) {
-		/*if (body == NULL) {
-			sVar5 = 0;
-		}
-		else {
-			sVar5 = _msize(body);
-		}*/
-		sVar5 = msize();
-		_Size = len2;
-		iVar1 = (uVar4 - len1) + 1 + len2;
-		if ((iVar1 <= (int)sVar5) || (bVar3 = resize(iVar1), bVar3 != false)) {
-			iVar1 = pos;
-			_Src = body + pos + len1;
-
-			/*len1 = (int)(_Src + 1);
-			pcVar6 = _Src;
-			do {
-				cVar2 = *pcVar6;
-				pcVar6 = pcVar6 + 1;
-			} while (cVar2 != '\0');
-
-			memmove(body + pos + _Size, _Src, (size_t)(pcVar6 + (1 - len1)));
-			memmove(body + iVar1, str2, _Size);*/
-
-			memmove(body + pos + _Size, _Src, strlen(_Src) + 1);
-			memmove(body + iVar1, str2, _Size);
-		}
-	}
-	return *this;
-}
-
-#include <string>
 inline void replace_all(std::string& str, std::string_view from, std::string_view to)
 {
 	for (size_t pos = str.find(from); pos != std::string::npos;)
@@ -265,33 +223,6 @@ inline void replace_all(std::string& str, std::string_view from, std::string_vie
 
 //43b060
 CSTR& CSTR::replace(const char *str1, const char *str2) {
-	//char cVar1;
-	//char *pcVar2;
-	//char *pcVar3;
-	//char *_Str1;
-	//int iVar4;
-	//int len1;
-	//int len2;
-
-	//if (body != NULL) {
-	//	/*pcVar2 = str1;
-	//	do {
-	//		cVar1 = *pcVar2;
-	//		pcVar2 = pcVar2 + 1;
-	//	} while (cVar1 != '\0');*/
-	//	len1 = strlen(str1);
-	//	/*pcVar3 = str2;
-	//	do {
-	//		cVar1 = *pcVar3;
-	//		pcVar3 = pcVar3 + 1;
-	//	} while (cVar1 != '\0');*/
-	//	len2 = strlen(str2);
-	//	_Str1 = strchr(body, (int)*str1);
-	//	while (_Str1 != NULL && !strncmp(_Str1, str1, len1)) {
-	//		replace((int)(_Str1 + -(int)body), len1, str2, len2);
-	//		_Str1 = strchr(_Str1 + len2, (int)*str1);
-	//	}
-	//}
 	std::string string = this->body;
 	replace_all(string, str1, str2);
 	this->assign(string.c_str());
@@ -300,8 +231,6 @@ CSTR& CSTR::replace(const char *str1, const char *str2) {
 
 //43b100
 void CSTR::resize2(int size) {
-	char *pcVar1;
-
 	if (size != 0) {
 		if (body != NULL) {
 			body = (char *)realloc(body, size);
@@ -368,30 +297,19 @@ CSTR& CSTR::nullAtPos(int pos) {
 
 //43b230
 int CSTR::lastSpaceCount() {
-	char cVar1;
-	char *pStr;
 	int len;
-	char *pcVar2;
-	char *pBody;
-
-	pBody = body;
-	if (pBody == (char *)0x0) {
+	if (body == nullptr) {
 		len = 0;
 	}
 	else {
-		/*pStr = pBody;
-		do {
-			cVar1 = *pStr;
-			pStr = pStr + 1;
-		} while (cVar1 != '\0');
-		len = (int)(pStr + -(int)(pBody + 1));*/
-		len = strlen(pBody);
+		len = strlen(body);
 	}
-	if (pBody && len) {
-		for (pcVar2 = pBody + len - 1; ((pBody <= pcVar2 && (*pcVar2 == ' ')) || (*pcVar2 == '\t')); pcVar2--) {
+	if (body && len) {
+		char* pcVar2;
+		for (pcVar2 = body + len - 1; ((body <= pcVar2 && (*pcVar2 == ' ')) || (*pcVar2 == '\t')); pcVar2--) {
 
 		}
-		return pBody - pcVar2 + len - 1;
+		return body - pcVar2 + len - 1;
 	}
 	return 0;
 }
@@ -460,7 +378,6 @@ char * cstrSprintf(CSTR *str, const char *format, ...) {
 
 //43b330
 int CSTR::toFile(const char *filepath) {
-	char cVar1;
 	char *_Str;
 	FILE *_File;
 	char *pcVar2;
@@ -575,8 +492,6 @@ CSTR::CSTR() {
 //43b650 copy construct
 CSTR::CSTR(const CSTR &str, int len) {
 	char *pStr;
-	char ch;
-	char *cur;
 
 	pStr = str.body;
 	if (pStr == NULL) {
@@ -598,9 +513,6 @@ CSTR::CSTR(const CSTR &str, int len) {
 
 //43b6c0
 CSTR::CSTR(const char *str, int len) {
-	char *pStr;
-	char ch;
-
 	if (str == NULL) {
 		this->body = NULL;
 		this->body = (char *)calloc(1, 0x40);
@@ -608,12 +520,6 @@ CSTR::CSTR(const char *str, int len) {
 	}
 
 	if (len == 0) {
-		/*pStr = str;
-		do {
-			ch = *pStr;
-			pStr = pStr + 1;
-		} while (ch != '\0');
-		len = (int)(pStr + -(int)(str + 1));*/
 		len = strlen(str);
 	}
 	else if (len < 0) {
@@ -661,26 +567,18 @@ CSTR CSTR::makeCRCstr() {
 
 //43b7e0
 CSTR& CSTR::assign(const char *str, int len) {
-	char cVar1;
-	bool bVar2;
-	size_t sVar3;
-	char *pcVar4;
-
 	if (str == NULL) {
 		fillzero();
 		return *this;
 	}
-	else {
-		if (len == 0) {
-			len = strlen(str);
-		}
+	if (len == 0) {
+		len = strlen(str);
+	}
+	size_t sVar3 = msize();
+	if ((len + 1 <= (int)sVar3) || resize(len + 1) != false) {
 		sVar3 = msize();
-
-		if ((len + 1 <= (int)sVar3) || resize(len + 1) != false) {
-			sVar3 = msize();
-			memset(this->body, 0, sVar3);
-			strncpy(this->body, str, len);
-		}
+		memset(this->body, 0, sVar3);
+		strncpy(this->body, str, len);
 	}
 	return *this;
 }
@@ -695,159 +593,11 @@ int CSTR::icmp(CSTR *param_1) {
 
 //43b8b0
 CSTR CSTR::left(int len) {
-	//char cVar1;
-	//CSTR *pCVar2;
-	//char *pcVar3;
-	//int pcVar4;
-	//char *pstr;
-	//CSTR ret;
-
-	//pCVar2 = new CSTR(body, len);
-	//pcVar3 = pCVar2->body;
-	//if (pcVar3 == (char *)0x0) {
-	//	pcVar3 = (char *)calloc(1, 0x40);
-	//	ret.body = pcVar3;
-	//}
-	//else {
-	//	/*pcVar4 = pcVar3;
-	//	do {
-	//		cVar1 = *pcVar4;
-	//		pcVar4 = pcVar4 + 1;
-	//	} while (cVar1 != '\0');*/
-	//	pcVar4 = strlen(pcVar3);
-	//	pstr = (char *)calloc(1, (size_t)(pcVar4 + 1));
-	//	ret.body = pstr;
-	//	if (pstr != (char *)0x0) {
-	//		strncpy(pstr, pcVar3, pcVar4);
-	//	}
-	//}
-	//delete(pCVar2);
-
-	//return (ret);
-
 	return CSTR(body, len);
 }
 
 //43b940
 CSTR CSTR::right(int len) {
-	//char cVar1;
-	//int bodylen;
-	//char *pcVar2;
-	//CSTR *pCVar3;
-	//char *pStr1;
-	//char *pcVar4;
-	//CSTR ret;
-
-	//if (-1 < len) {
-	//	/*pStr1 = this->body;
-	//	if (pStr1 == (char *)0x0) {
-	//		pcVar2 = (char *)0x0;
-	//	}
-	//	else {
-	//		pcVar2 = pStr1;
-	//		do {
-	//			cVar1 = *pcVar2;
-	//			pcVar2 = pcVar2 + 1;
-	//		} while (cVar1 != '\0');
-	//		pcVar2 = pcVar2 + -(int)(pStr1 + 1);
-	//	}*/
-	//	bodylen = length();
-	//	if (len <= bodylen) {
-	//		/*if (pStr1 == (char *)0x0) {
-	//			pcVar2 = (char *)0x0;
-	//		}
-	//		else {
-	//			pcVar2 = pStr1;
-	//			do {
-	//				cVar1 = *pcVar2;
-	//				pcVar2 = pcVar2 + 1;
-	//			} while (cVar1 != '\0');
-	//			pcVar2 = pcVar2 + -(int)(pStr1 + 1);
-	//		}*/
-	//		pCVar3 = new CSTR(body - len + length(), len);
-	//		pStr1 = pCVar3->body;
-	//		if (pStr1 == (char *)0x0) {
-	//			pStr1 = (char *)calloc(1, 0x40);
-	//			ret.body = pStr1;
-	//		}
-	//		else {
-	//			/*pcVar2 = pStr1;
-	//			do {
-	//				cVar1 = *pcVar2;
-	//				pcVar2 = pcVar2 + 1;
-	//			} while (cVar1 != '\0');
-	//			pcVar4 = (char *)calloc(1, (size_t)(pcVar2 + -(int)(pStr1 + 1) + 1));
-	//			obuf->body = pcVar4;
-	//			if (pcVar4 != (char *)0x0) {
-	//				strncpy(pcVar4, pStr1, pcVar2 + -(int)(pStr1 + 1));
-	//			}*/
-	//			pcVar4 = (char *)calloc(1, (size_t)(pCVar3->length() + 1));
-	//			ret.body = pcVar4;
-	//			if (pcVar4 != (char *)0x0) {
-	//				strncpy(pcVar4, pStr1, pCVar3->length());
-	//			}
-	//		}
-
-	//		/*if (pCVar3 == NULL) {
-	//			return obuf;
-	//		}*/
-	//		delete(pCVar3);
-	//		return (ret);
-	//	}
-	//}
-	//pStr1 = this->body;
-	//if (pStr1 == (char *)0x0) {
-	//	pcVar4 = (char *)calloc(1, 0x40);
-	//}
-	//else {
-	//	//pcVar2 = pStr1;
-	//	//do {
-	//	//	cVar1 = *pcVar2;
-	//	//	pcVar2 = pcVar2 + 1;
-	//	//} while (cVar1 != '\0');
-	//	//pcVar4 = (char *)calloc(1, (size_t)(pcVar2 + -(int)(pStr1 + 1) + 1));
-	//	//if (pcVar4 == (char *)0x0) {
-	//	//	pStr1 = (char *)_calloc(1, 0x40);
-	//	//	obuf->body = pStr1;
-	//	//	return obuf;
-	//	//}
-	//	//strncpy(pcVar4, pStr1, pcVar2 + -(int)(pStr1 + 1));
-	//	pcVar4 = (char *)calloc(1, length() + 1);
-	//	if (pcVar4 == (char *)0x0) {
-	//		pStr1 = (char *)calloc(1, 0x40);
-	//		ret.body = pStr1;
-	//		return (ret);
-	//	}
-	//	strncpy(pcVar4, pStr1, length());
-	//}
-
-	//if (pcVar4 != (char *)0x0) {
-	//	/*pStr1 = pcVar4;
-	//	do {
-	//		cVar1 = *pStr1;
-	//		pStr1 = pStr1 + 1;
-	//	} while (cVar1 != '\0');
-	//	pcVar2 = (char *)calloc(1, (size_t)(pStr1 + -(int)(pcVar4 + 1) + 1));
-	//	obuf->body = pcVar2;
-	//	if (pcVar2 != (char *)0x0) {
-	//		strncpy(pcVar2, pcVar4, pStr1 + -(int)(pcVar4 + 1));
-	//	}
-	//	free(pcVar4);
-	//	return obuf;*/
-	//	pcVar2 = (char *)calloc(1, strlen(pcVar4) + 1);
-	//	ret.body = pcVar2;
-	//	if (pcVar2 != (char *)0x0) {
-	//		strncpy(pcVar2, pcVar4, strlen(pcVar4));
-	//	}
-	//	free(pcVar4);
-	//	return (ret);
-	//}
-	///*pStr1 = (char *)_calloc(1, 0x40);
-	//obuf->body = pStr1;*/
-	//ret = CSTR();
-	//return (ret);
-
-	
 	if (len > -1 && length() >= len) {
 		return CSTR(body - len + length(), len);
 	}
@@ -856,112 +606,11 @@ CSTR CSTR::right(int len) {
 
 //43bac0
 CSTR CSTR::getSliced(int pos, int len) {
-	/*CSTR oBuf;
-	char cVar1;
-	uint uVar2;
-	char *pcVar3;
-	char *pcVar4;
-	char *pcVar5;
-
-	uVar2 = checkValidPos(&pos, &len);
-	if (uVar2) {
-		CSTR pCVar6 = CSTR(body + pos, len);
-		pcVar3 = pCVar6.body;
-		if (pcVar3 == (char *)0x0) {
-			pcVar3 = (char *)calloc(1, 0x40);
-			oBuf.body = pcVar3;
-		}
-		else {
-			pcVar5 = (char *)calloc(1, (size_t)(pCVar6.length() + 1));
-			oBuf.body = pcVar5;
-			if (pcVar5 != (char *)0x0) {
-				strncpy(pcVar5, pcVar3, pCVar6.length());
-			}
-		}
-		return oBuf;
-	}
-	pcVar3 = (char *)calloc(1, 1);
-	if (pcVar3 != (char *)0x0) {
-		strncpy(pcVar3, "", 0);
-		pcVar4 = pcVar3;
-		do {
-			cVar1 = *pcVar4;
-			pcVar4 = pcVar4 + 1;
-		} while (cVar1 != '\0');
-
-		pcVar5 = (char *)calloc(1, strlen(pcVar3) + 1);
-		oBuf.body = pcVar5;
-		if (pcVar5 != (char *)0x0) {
-			strncpy(pcVar5, pcVar3, strlen(pcVar3));
-		}
-		free(pcVar3);
-		return oBuf;
-	}
-	pcVar3 = (char *)calloc(1, 0x40);
-	oBuf.body = pcVar3;
-	return oBuf;*/
-
-	CSTR oBuf;
-	char cVar1;
-	uint uVar2;
-	char *pcVar3;
-	char *pcVar4;
-	char *pcVar5;
-
 	if (checkValidPos(&pos, &len)) {
 		return CSTR(body + pos, len);
 	}
 	return CSTR("", 0); //more simple than original code, deleting some repeated code.
 }
-//CSTR& CSTR::getSliced(CSTR *oBuf, int pos, int len) {
-//	char cVar1;
-//	uint uVar2;
-//	char *pcVar3;
-//	char *pcVar4;
-//	char *pcVar5;
-//	CSTR pCVar6;
-//
-//	uVar2 = checkValidPos(&pos, &len);
-//	if (uVar2) {
-//		pCVar6 = CSTR(body + pos, len);
-//		pcVar3 = pCVar6.body;
-//		if (pcVar3 == (char *)0x0) {
-//			pcVar3 = (char *)calloc(1, 0x40);
-//			oBuf->body = pcVar3;
-//		}
-//		else {
-//			pcVar5 = (char *)calloc(1, (size_t)(pCVar6.length() + 1));
-//			oBuf->body = pcVar5;
-//			if (pcVar5 != (char *)0x0) {
-//				strncpy(pcVar5, pcVar3, pCVar6.length());
-//			}
-//		}
-//		/*if ((CSTR)pCVar6 != (CSTR)0x0) {
-//			free((void *)pCVar6);
-//		}*/
-//		return *oBuf;
-//	}
-//	pcVar3 = (char *)calloc(1, 1);
-//	if (pcVar3 != (char *)0x0) {
-//		strncpy(pcVar3, "", 0);
-//		pcVar4 = pcVar3;
-//		do {
-//			cVar1 = *pcVar4;
-//			pcVar4 = pcVar4 + 1;
-//		} while (cVar1 != '\0');
-//
-//		pcVar5 = (char *)calloc(1, strlen(pcVar3) + 1);
-//		oBuf->body = pcVar5;
-//		if (pcVar5 != (char *)0x0) {
-//			strncpy(pcVar5, pcVar3, strlen(pcVar3));
-//		}
-//		free(pcVar3);
-//		return *oBuf;
-//	}
-//	pcVar3 = (char *)calloc(1, 0x40);
-//	oBuf->body = pcVar3;
-//	return *oBuf;
-//}
 
 //43bbf0
 CSTR& CSTR::assign(const CSTR *iBuf) {
@@ -1037,17 +686,10 @@ CSTR& CSTR::lastCut(int len) {
 
 //43bef0
 CSTR& CSTR::trimWhiteSpace() {
-	char cVar1;
-	int lSpaceCount;
-	char *pcVar3;
-	char *pcVar4;
-	int bodylen;
 	int fSpaceCount;
-	//CSTR tempCSTR;
-
-	//fSpaeCount = frontSpaceCount()
-	pcVar4 = body;
-	pcVar3 = pcVar4;
+	char cVar1;
+	char *pcVar4 = body;
+	char *pcVar3 = pcVar4;
 	if (pcVar4 == (char *)0x0) {
 		fSpaceCount = 0;
 	}
@@ -1056,21 +698,10 @@ CSTR& CSTR::trimWhiteSpace() {
 		}
 		fSpaceCount = static_cast<int>(pcVar3 - pcVar4);
 	}
-	/*if (pcVar4 == (char *)0x0) {
-		bodylen = 0;
-	}
-	else {
-		pcVar3 = pcVar4 + 1;
-		do {
-			cVar1 = *pcVar4;
-			pcVar4 = pcVar4 + 1;
-		} while (cVar1 != '\0');
-		bodylen = (int)(pcVar4 + -(int)pcVar3);
-	}*/
-	bodylen = length();
+	int bodylen = length();
 
-	lSpaceCount = lastSpaceCount();
-	//tempCSTR = getSliced(fSpaceCount, bodylen - lSpaceCount - fSpaceCount);//getSliced(&tempCSTR, fSpaceCount, bodylen - lSpaceCount - fSpaceCount);
+	int lSpaceCount = lastSpaceCount();
+	//CSTR tempCSTR = getSliced(fSpaceCount, bodylen - lSpaceCount - fSpaceCount);//getSliced(&tempCSTR, fSpaceCount, bodylen - lSpaceCount - fSpaceCount);
 	assign(getSliced(fSpaceCount, bodylen - lSpaceCount - fSpaceCount).body, 0);
 	//if ((CSTR)tempCSTR != (CSTR)0x0) {
 	//	_free(tempCSTR);

--- a/LR2/strclass.cpp
+++ b/LR2/strclass.cpp
@@ -1,10 +1,11 @@
-#pragma once
-
 #include "strclass.h"
 
 #include <cstring>
+#include <span>
 #include <string>
 #include <string_view>
+#include <cstdarg>
+#include <cctype>
 
 typedef unsigned char byte;
 
@@ -276,7 +277,9 @@ char* CSTR::writeAtPos(int pos, char ch) {
 //43b1d0
 CSTR& CSTR::upper() {
 	if (body) {
-		_strupr(body);
+		for (auto& c : std::span{body, strlen(body)}) {
+			c = std::toupper(c);
+		}
 	}
 	return *this;
 }
@@ -284,7 +287,9 @@ CSTR& CSTR::upper() {
 //43b1f0
 CSTR& CSTR::lower() {
 	if (body) {
-		_strlwr(body);
+		for (auto& c : std::span{body, strlen(body)}) {
+			c = std::tolower(c);
+		}
 	}
 	return *this;
 }

--- a/LR2/strclass.cpp
+++ b/LR2/strclass.cpp
@@ -1,5 +1,8 @@
 #pragma once
+
 #include "strclass.h"
+
+typedef unsigned char byte;
 
 //43ad60
 CSTR::CSTR(int size) {

--- a/LR2/strclass.cpp
+++ b/LR2/strclass.cpp
@@ -388,29 +388,25 @@ int CSTR::lastSpaceCount() {
 		for (pcVar2 = pBody + len - 1; ((pBody <= pcVar2 && (*pcVar2 == ' ')) || (*pcVar2 == '\t')); pcVar2--) {
 
 		}
-		return (int)pBody - (int)pcVar2 + len - 1;
+		return pBody - pcVar2 + len - 1;
 	}
 	return 0;
 }
 
 //43b280
 int CSTR::findStrPos(const char *str) {
-	char *pcVar1;
 	if (body) {
-		pcVar1 = strstr(body, str);
-		if (pcVar1) {
-			return (int)(pcVar1 - (int)body);
+		if (char *chrPos = strstr(body, str); chrPos) {
+			return static_cast<int>(chrPos - body);
 		}
 	}
 	return -1;
 }
 
 int CSTR::findChrBackPos(const char ch) {
-	char* chrPos;
 	if (body) {
-		chrPos = strrchr(body, ch);
-		if (chrPos) {
-			return (int)(chrPos - (int)body);
+		if (char* chrPos = strrchr(body, ch); chrPos) {
+			return static_cast<int>(chrPos - body);
 		}
 	}
 	return -1;
@@ -643,16 +639,14 @@ CSTR CSTR::makeCRCstr() {
 	sprintf(local_4, "%x", dVar2);
 	str = local_4;
 	if (local_4 == NULL) {
-		pcVar3 = (int)calloc(1, 0x40);
-		ret = (char*)pcVar3;
-		return ret;
+		return (char*)calloc(1, 0x40);
 	}
 	CVar4 = local_4;
 	do {
 		cVar1 = *CVar4;
 		CVar4 = CVar4 + 1;
 	} while (cVar1 != '\0');
-	pcVar3 = (int)CVar4 - (int)(local_4 + 1);
+	pcVar3 = CVar4 - (local_4 + 1);
 	pstr = (char *)calloc(1, (size_t)(pcVar3 + 1));
 	ret = pstr;
 	if (pstr != (char *)0x0) {
@@ -679,7 +673,7 @@ CSTR& CSTR::assign(const char *str, int len) {
 		}
 		sVar3 = msize();
 
-		if (((int)(char *)(len + 1) <= (int)sVar3) || resize(len + 1) != false) {
+		if ((len + 1 <= (int)sVar3) || resize(len + 1) != false) {
 			sVar3 = msize();
 			memset(this->body, 0, sVar3);
 			strncpy(this->body, str, len);
@@ -1057,7 +1051,7 @@ CSTR& CSTR::trimWhiteSpace() {
 	else {
 		for (; ((cVar1 = *pcVar3, cVar1 != '\0' && (cVar1 == ' ')) || (cVar1 == '\t')); pcVar3++) {
 		}
-		fSpaceCount = (int)(pcVar3 + -(int)pcVar4);
+		fSpaceCount = static_cast<int>(pcVar3 - pcVar4);
 	}
 	/*if (pcVar4 == (char *)0x0) {
 		bodylen = 0;

--- a/LR2/strclass.cpp
+++ b/LR2/strclass.cpp
@@ -359,7 +359,7 @@ char * cstrSprintf(CSTR *str, const char *format, ...) {
 	do {
 		_Size = bSize + 0x80;
 		va_start(ap, format);
-		iVar1 = _vsnprintf(str->body, bSize - 1, format, ap);
+		iVar1 = vsnprintf(str->body, bSize - 1, format, ap);
 		va_end(ap);
 		if (-1 < iVar1) {
 			return (char *)str;

--- a/LR2/strclass.cpp
+++ b/LR2/strclass.cpp
@@ -9,6 +9,19 @@
 
 typedef unsigned char byte;
 
+#ifndef _WIN32
+
+#include <malloc.h>
+#include <strings.h>
+static unsigned long long _msize(void* ptr) {
+	return malloc_usable_size(ptr);
+}
+static int _stricmp(const char* s1, const char* s2) {
+	return strcasecmp(s1,s2);
+}
+
+#endif // _WIN32
+
 //43ad60
 CSTR::CSTR(int size) {
 	body = (char*)calloc(1, size);
@@ -590,7 +603,7 @@ CSTR& CSTR::assign(const char *str, int len) {
 
 //43b890
 int CSTR::icmp(CSTR *param_1) {
-	if (body != (char *)0x0) {
+	if (body != nullptr) {
 		return _stricmp(body, param_1->body);
 	}
 	return 0;

--- a/LR2/strclass.h
+++ b/LR2/strclass.h
@@ -1,9 +1,9 @@
 #pragma once
 #pragma warning(disable:4996)
-#include <windows.h>
 #include <stdio.h>
 #include <malloc.h>
 typedef unsigned int uint;
+using DWORD = unsigned long;
 
 class CSTR {
 	public:

--- a/LR2/strclass.h
+++ b/LR2/strclass.h
@@ -18,7 +18,6 @@ class CSTR {
 		//CSTR* add(const char *str, int len);
 		CSTR& add(const char *str, int len);
 		uint checkValidPos(int *pos, int *len);
-		CSTR& replace(int pos, int len1, const char *str2, int len2);
 		CSTR& replace(const char *str1, const char *str2);
 		void resize2(int size);
 		CSTR& fillzero();

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1,13 +1,16 @@
 #pragma once
-#include <winsock2.h>
-#include <Windows.h>
-#include <vfw.h>
-#include <vector>
+
 #include <array>
 #include <mutex>
 #include <thread>
-#include "FMOD/fmod.h"
+
 #include "strclass.h"
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <Windows.h>
+#include <vfw.h>
+#endif // _WIN32
 
 #ifdef _MSC_VER
 #pragma warning (push)
@@ -36,6 +39,12 @@ typedef unsigned long long    undefined8;
 typedef unsigned short    ushort;
 //typedef short    wchar_t;
 typedef unsigned short    word;
+
+#ifndef _WIN32
+using LPCSTR = const char*;
+using HANDLE = void*;
+using HWND = HANDLE;
+#endif // _WIN32
 
 typedef enum SKINTYPE {
 	SKINTYPE_7KEYS = 0,
@@ -638,13 +647,16 @@ typedef struct RANKINGPLAYER RANKINGPLAYER, *PRANKINGPLAYER;
 typedef uchar BYTE;
 
 struct RECORDING {
-	HDC srcHDC; /* struct_entry */
 	double framerate;
+	int writeSamplePos;
+	int curFrame;
+	int recMode; /* 1:auto2avi 2:replay2avi 3:bga2avi 4:movie */
+
+#ifdef WIN32
+	HDC srcHDC; /* struct_entry */
 	int bitdepth;
 	CSTR filename;
 	uint framelen;
-	int writeSamplePos;
-	int curFrame;
 	COMPVARS compvars; /* from vfw.h */
 	BITMAPINFOHEADER bmiHeader;
 	PAVISTREAM pAVIstream; /* from vfw.h */
@@ -654,7 +666,7 @@ struct RECORDING {
 	HDC dstHDC;
 	HBITMAP hBIT;
 	HGDIOBJ hGDI;
-	int recMode; /* 1:auto2avi 2:replay2avi 3:bga2avi 4:movie */
+#endif
 
 	RECORDING();
 	bool RefreshCurFrame();
@@ -1470,7 +1482,9 @@ struct Timer {
 };
 
 struct NETWORK {
+#ifdef _WIN32
 	WSADATA wsa;
+#endif // _WIN32
 	int isOnline;
 	int rankUpdateDelayLevel;
 	int waitTime;

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -9,6 +9,11 @@
 #include "FMOD/fmod.h"
 #include "strclass.h"
 
+#ifdef _MSC_VER
+#pragma warning (push)
+#pragma warning (disable: 26495) // 'always initialize a member variable' - usually zeroed with memset
+#endif
+
 struct sqlite3;
 
 typedef unsigned char   undefined;
@@ -1652,3 +1657,7 @@ struct CHARTCONVERTER {
 	int assist2p;
 	int playlevel;
 };
+
+#ifdef _MSC_VER
+#pragma warning (pop)
+#endif

--- a/OpenLR2_vs22.vcxproj
+++ b/OpenLR2_vs22.vcxproj
@@ -198,6 +198,7 @@
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -223,6 +224,7 @@
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -249,6 +251,7 @@
       <FloatingPointModel>Precise</FloatingPointModel>
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -273,6 +276,7 @@
       <FloatingPointModel>Precise</FloatingPointModel>
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -295,6 +299,7 @@
       <FloatingPointModel>Precise</FloatingPointModel>
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -319,6 +324,7 @@
       <FloatingPointModel>Precise</FloatingPointModel>
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/OpenLR2_vs22.vcxproj
+++ b/OpenLR2_vs22.vcxproj
@@ -189,7 +189,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)lib\FMOD;$(ProjectDir)lib\DxLib;$(ProjectDir)lib\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -214,7 +214,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)lib\FMOD;$(ProjectDir)lib\DxLib;$(ProjectDir)lib\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -241,7 +241,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)lib\FMOD;$(ProjectDir)lib\DxLib;$(ProjectDir)lib\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -265,7 +265,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)lib\FMOD;$(ProjectDir)lib\DxLib;$(ProjectDir)lib\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -287,7 +287,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)lib\FMOD;$(ProjectDir)lib\DxLib;$(ProjectDir)lib\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -311,7 +311,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)lib\FMOD;$(ProjectDir)lib\DxLib;$(ProjectDir)lib\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>

--- a/SkinEditor/example_sdl3_sdlrenderer3.vcxproj
+++ b/SkinEditor/example_sdl3_sdlrenderer3.vcxproj
@@ -95,6 +95,7 @@
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -113,6 +114,7 @@
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -135,6 +137,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -158,6 +161,7 @@
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/SkinEditor/example_sdl3_sdlrenderer3.vcxproj
+++ b/SkinEditor/example_sdl3_sdlrenderer3.vcxproj
@@ -96,6 +96,7 @@
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -115,6 +116,7 @@
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -138,6 +140,7 @@
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -162,6 +165,7 @@
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/SkinEditor/main.cpp
+++ b/SkinEditor/main.cpp
@@ -30,7 +30,7 @@
 
 SDL_Renderer* renderer;
 
-int WinMain(HINSTANCE hInst, HINSTANCE hInstPrev, PSTR cmdline, int cmdshow)
+int WINAPI WinMain(HINSTANCE /*hInst*/, HINSTANCE /*hInstPrev*/, PSTR /*cmdline*/, int /*cmdshow*/)
 {
     FreeConsole();
     // Setup SDL
@@ -98,7 +98,7 @@ int WinMain(HINSTANCE hInst, HINSTANCE hInstPrev, PSTR cmdline, int cmdshow)
     //io.Fonts->AddFontFromFileTTF("../../misc/fonts/DroidSans.ttf");
     //io.Fonts->AddFontFromFileTTF("../../misc/fonts/Roboto-Medium.ttf");
     //io.Fonts->AddFontFromFileTTF("../../misc/fonts/Cousine-Regular.ttf");
-    ImFont* font = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\ArialUni.ttf");
+    //ImFont* font = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\ArialUni.ttf");
     //IM_ASSERT(font != nullptr);
 
     // Our state

--- a/SkinEditor/skin.cpp
+++ b/SkinEditor/skin.cpp
@@ -295,7 +295,7 @@ int LR2SEDrawLoop(game* g, int gHandle) {
 				ErrorLogAdd("アイコン化が終わるまで待ちます\n");
 				while (ProcessMessage() == 0) {
 					if (IsIconic(GetMainWindowHandle()) == 0) break;
-					Sleep(16);
+					std::this_thread::sleep_for(std::chrono::milliseconds(16));
 				}
 				SetObjectStrings_SongSelect(g);
 				for (int i = 0; i < 200; i++) {
@@ -316,7 +316,7 @@ int LR2SEDrawLoop(game* g, int gHandle) {
 			g->KeyInput.inputID[KEY_INPUT_F1] = 0; //why F1?
 			g->sSelect.is_buttonIRpage = 0;
 			InitInputStructure2(&g->KeyInput);
-			Sleep(1000);
+			std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 			if (g->sSelect.flag_maniacPanel || g->sSelect.unk4f74) ClsDrawScreen();
 		}
 		else if (g->KeyInput.inputID[KEY_INPUT_F2] == 2) {


### PR DESCRIPTION
A bunch of commit types:
- general small issue fixes
- fix or shut up MSVC warnings
- refactor code into better standard compliance
- port things to Linux

Changes should be pretty readable if you go through commits one by one.

This lets the project build on Linux (CMake port aside, not included in this PR), but the game doesn't work without issues yet.
Future work:
- Handle backslashes in file paths better
- Implement missing functions
- Reduce the #ifdef _WIN32 noise
- Fix DxLib-for-Linux (not in this patch) rendering canvas size
- Fix remaining CSTR usage in variadics