### PR TITLE
Quickrestart

### DIFF
--- a/LR2/En_audio.cpp
+++ b/LR2/En_audio.cpp
@@ -619,9 +619,11 @@ int LoadSound(AUDIO *aud, SOUNDDATA *sound, CSTR filepath, int loop, int disable
 	}
 
 	if (sound->load == 1) {
-		if (filepath.isSame(&sound->filename)) return 1;
+		if (filepath.isSame(&sound->filename) && previewFlag == sound->streaming) return 1;
 		ReleaseSound(aud, sound);
 	}
+
+	sound->streaming = previewFlag;
 
 	if (aud->is_fmod_disabled != 1) {
 		FMOD_MODE mode = 0;

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -1872,8 +1872,6 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 	ErrorLogFmtAdd("RANDOMSEEDは%dです。\n", gp->randomseed);
 	SRand(gp->randomseed);
 
-	for (int i = 0; i < 1296; i++) gp->keysound[i].load = 0;
-
 	CSTR dir = filename.getDirectory();
 
 	for (int i = 0; i < 1296; i++) BPMslot[i] = -1.0;

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1107,6 +1107,21 @@ int ProcNoteOnTiming(game *g, int lane, int keypress, int timing, int player) {
 	return 1;
 }
 
+static void QuickRestart(game& game, bool newRandom) {
+	game.procPhase = 0;
+	game.procSelecter = 4;
+	game.gameplay.flag_retry = newRandom ? 0 : 1;
+	game.gameplay.randomseed = newRandom ? 0 : game.gameplay.randomseed;
+
+	if ((game.gameplay.courseType == 0 || game.gameplay.courseType == 2) && game.gameplay.courseStageNow != 0) {
+		game.gameplay.courseStageNow = 0;
+		game.gameplay.flag_retry = 0;
+	}
+
+	for (int i = 0; i < 6480; i++) {
+		StopSound(&game.audio, &game.gameplay.keysound[i]);
+	}
+}
 
 //419650
 int ProcI_Play(game *g) {
@@ -1148,15 +1163,23 @@ int ProcI_Play(game *g) {
 		return 1;
 	}
 
+	auto proc_quickrestart = [](game& game) {
+		if (game.gameplay.replay.status == 2 || game.config.play.m_lunaris != 0) return;
+		if (game.KeyInput.p1_buttonInput[12] == 1 || game.KeyInput.p2_buttonInput[12] == 1) return QuickRestart(game, true);
+		if (game.KeyInput.p1_buttonInput[13] == 1 || game.KeyInput.p2_buttonInput[13] == 1) return QuickRestart(game, false);
+	};
+
 	if (g->procPhase == 2) {
 		timeLimit = g->skstruct.fadeout;
 		gameTime = GetTimeLapse(2, &g->timer1);
 		if (timeLimit < gameTime || timeLimit == 0) g->procSelecter = 5;
+		proc_quickrestart(*g);
 	}
 	else if (g->procPhase == 3) {
 		timeLimit = g->skstruct.close;
 		gameTime = GetTimeLapse(3, &g->timer1);
 		if (timeLimit < gameTime || timeLimit == 0) g->procSelecter = 5;
+		proc_quickrestart(*g);
 	}
 	return 1;
 }

--- a/LR2/Scene05_Result.cpp
+++ b/LR2/Scene05_Result.cpp
@@ -192,7 +192,21 @@ int Proc_Result(game *g, skstruct *sk, Timer *T) {
 	return 1;
 }
 
-//409300
+static void QuickRestart(game& game, bool newRandom) {
+	game.procSelecter = 4;
+	game.gameplay.flag_retry = newRandom ? 0 : 1;
+	game.gameplay.randomseed = newRandom ? 0 : game.gameplay.randomseed;
+
+	if ((game.gameplay.courseType == 0 || game.gameplay.courseType == 2) && game.gameplay.courseStageNow != 0) {
+		game.gameplay.courseStageNow = 0;
+		game.gameplay.flag_retry = 0;
+	}
+
+	for (int i = 0; i < 6480; i++) {
+		StopSound(&game.audio, &game.gameplay.keysound[i]);
+	}
+}
+
 char fWaitHiScoreUpdateInput = 0;
 int ProcI_Result(game *g) {
 
@@ -285,10 +299,10 @@ int ProcI_Result(game *g) {
 				g->KeyInput.p2_buttonInput[1] == 2 || g->KeyInput.p2_buttonInput[3] == 2 || g->KeyInput.p2_buttonInput[5] == 2 || g->KeyInput.p2_buttonInput[7] == 2) 
 				&& (g->KeyInput.p1_buttonInput[2] == 2 || g->KeyInput.p1_buttonInput[4] == 2 || g->KeyInput.p1_buttonInput[6] == 2 ||
 					g->KeyInput.p2_buttonInput[2] == 2 || g->KeyInput.p2_buttonInput[4] == 2 || g->KeyInput.p2_buttonInput[6] == 2) 
-				&& g->gameplay.replay.status != 2 && g->config.play.m_lunaris == 0 && (g->gameplay.courseType == -1 || g->gameplay.courseType == 1)) {
+				&& g->gameplay.replay.status != 2 && g->config.play.m_lunaris == 0) {
 
-				g->procSelecter = 4;
-				g->gameplay.flag_retry = 1;
+				if (g->KeyInput.p1_buttonInput[2] == 2 || g->KeyInput.p2_buttonInput[2] == 2) QuickRestart(*g, true);
+				else QuickRestart(*g, false);
 
 				if (g->skstruct.flag_flip) {
 					//same as FlipScore();, but no errorlog

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -619,6 +619,7 @@ struct RAWSOUND {
 
 struct SOUNDDATA {
 	char load;
+	bool streaming = false;
 	char loop;
 	CSTR filename;
 	uint length;


### PR DESCRIPTION
implements quick restart feature, available at play scene and select scene.

You can restart from play scene on fade-out animation (phase 2) if you press START to restart with new random, or SELECT to start with the same random.

On result scene you can restart with new random holding <WHITEKEY>+2, or <WHITEKEY>+4/6 for same random. 

Should work on courses, g-battle and anything else.

Also fixes the memory leak from starting the chart after the preview is loaded, because it's essential for avoiding reloading keysounds on quickrestart using START on play scene. Because preview keysounds are loaded in streaming mode (slow), streaming flag triggers a reload now even if the same keysound is being loaded.