### PR TITLE
Fixes

### DIFF
--- a/LR2/En_audio.cpp
+++ b/LR2/En_audio.cpp
@@ -236,6 +236,7 @@ const char* GetFMODerror(int errCode){
 
 //4b7f30
 int IsAltSoundExist(CSTR *filepath){
+	// TODO: .flac, like in FindAltSound
 	const char *str;
 	CSTR tStr(*filepath); //somewhat starnge
 
@@ -1167,18 +1168,16 @@ int InitSound(AUDIO *aud, uint bufferLength, int numBuffer, char fDisable, int o
 #endif // _WIN32
 
 		FMOD_System_GetNumDrivers(aud->fmodSys, &numDrivers);
-		if (driver > numDrivers - 1) {
+		if (driver + 1 > numDrivers) {
 			driver = 0;
 		}
 		if (FMOD_System_GetDriverInfo(aud->fmodSys, driver, driverName, sizeof(driverName), nullptr, nullptr, nullptr, nullptr) == FMOD_OK) {
 			ErrorLogFmtAdd("PLAYBACK DRIVER:%s\n", driverName);
 		} else {
-			ErrorLogFmtAdd("FMOD_System_GetDriverInfo failed");
+			ErrorLogFmtAdd("FMOD_System_GetDriverInfo failed\n");
 		}
 		FMOD_System_SetDriver(aud->fmodSys, driver);
-		ErrorLogAdd("バッファサイズの設定を行います...");
-		//FMOD_System_GetHardwareChannels(aud->fmodSys, &chn2D, &chn3D, &chnTotal);
-		//ErrorLogFmtAdd("2Dチャンネル%d 3Dチャンネル%d 合計%d\n", chn2D, chn3D, chnTotal);
+		ErrorLogAdd("バッファサイズの設定を行います...\n");
 		FMOD_System_CreateChannelGroup(aud->fmodSys, "bgm", &aud->chnBgm);
 		FMOD_System_CreateChannelGroup(aud->fmodSys, "key", &aud->chnKey);
 		FMOD_System_GetMasterChannelGroup(aud->fmodSys, &aud->chnMaster);

--- a/LR2/En_fileutil.cpp
+++ b/LR2/En_fileutil.cpp
@@ -17,26 +17,6 @@
 //437c90
 //437cf0
 int makeFileHash(LPCSTR filepath, LPCSTR oBuf) {
-	//HANDLE hFile;
-	//hFile = CreateFileA(filepath, GENERIC_READ, 0, 0, OPEN_EXISTING, FILE_FLAG_SEQUENTIAL_SCAN | FILE_ATTRIBUTE_NORMAL, NULL);
-	//if (hFile == (HANDLE)-1) return -1;
-
-	////not original code
-	//BY_HANDLE_FILE_INFORMATION FileInformation;
-	//GetFileInformationByHandle(hFile, &FileInformation);
-	//unsigned int size = FileInformation.nFileSizeLow;
-	//char* buffer = (char*)malloc(size);
-	//DWORD readsize;
-	//if (buffer != NULL) {
-	//	ReadFile(hFile, buffer, size, &readsize, 0);
-	//	CloseHandle(hFile);
-	//	
-	//	MD5byte(&buffer, readsize, (char*)oBuf);
-
-	//	free(buffer);
-	//}
-	//return 1;
-
 	FILE* pFile;
 	pFile = fopen(filepath, "rb");
 	if (!pFile)  return -1;
@@ -45,6 +25,9 @@ int makeFileHash(LPCSTR filepath, LPCSTR oBuf) {
 
 	sprintf((char*)oBuf, "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x", md5buf[0], md5buf[1], md5buf[2], md5buf[3],
 		md5buf[4], md5buf[5], md5buf[6], md5buf[7], md5buf[8], md5buf[9], md5buf[10], md5buf[11], md5buf[12], md5buf[13], md5buf[14], md5buf[15]);
+
+	free(md5buf);
+
 	return 1;
 }
 

--- a/LR2/En_fileutil.cpp
+++ b/LR2/En_fileutil.cpp
@@ -82,7 +82,7 @@ time_t GetFileUnixtime(CSTR str) {
 	LPWIN32_FIND_DATAA lpFindFileData = (LPWIN32_FIND_DATAA)&FindFileData;
 	HANDLE hFindFile = FindFirstFileA(str, lpFindFileData);
 	if (hFindFile == (HANDLE)-1) {
-		ErrorLogFmtAdd("ファイルのLR2TIME取得エラー:%sが見つからない\n", str);
+		ErrorLogFmtAdd("ファイルのLR2TIME取得エラー:%sが見つからない\n", str.body);
 		return -1;
 	}
 

--- a/LR2/En_recordmovie.cpp
+++ b/LR2/En_recordmovie.cpp
@@ -3,6 +3,7 @@
 #include <cstring>
 
 #include "structure.h"
+#include "filesystem.h"
 
 #include <DxLib/DxLib.h>
 
@@ -173,7 +174,7 @@ bool RECORDING::PrepareAVIRecord(double framerate, int bit, CSTR filename, uint 
 	this->curFrame = 0;
 
 	remove(filename);
-	CSTR dat("LR2files/Config/compvars.dat");
+	CSTR dat(fs::make_preferred("LR2files/Config/compvars.dat").data());
 
 	if (dat.canOpenFile()) {
 		FILE* pFile = fopen(dat, "rb");
@@ -186,7 +187,7 @@ bool RECORDING::PrepareAVIRecord(double framerate, int bit, CSTR filename, uint 
 		memset(&this->compvars, 0, sizeof(COMPVARS));
 		this->compvars.cbSize = 64;
 		if (ICCompressorChoose(NULL,0,NULL,NULL,&this->compvars,NULL) == 0) return false;
-		FILE *pFile = fopen("LR2files/Config/compvars.dat", "wb");
+		FILE *pFile = fopen(fs::make_preferred("LR2files/Config/compvars.dat").data(), "wb");
 		fwrite(&this->compvars, sizeof(COMPVARS), 1, pFile);
 		fclose(pFile);
 		MessageBoxA(NULL, "圧縮設定が保存されました。\n設定の変更はJUKEBOXタブ→詳細設定→動画圧縮設定で行えます。", "報告", 0);

--- a/LR2/En_recordmovie.cpp
+++ b/LR2/En_recordmovie.cpp
@@ -383,7 +383,9 @@ int Mp3toWavF(FILE *iFile, FILE *oFile) { //TODO : need test
 		ErrorLogAdd("ファイルに書けません。\n");
 		return 0; 
 	}
-	
+
+	// FIXME: missing fclose(iFile); fclose(oFile);
+
 	return 1;
 }
 

--- a/LR2/LR2_audio.cpp
+++ b/LR2/LR2_audio.cpp
@@ -4,6 +4,8 @@
 #include "LR2_skinobject.h"
 #include "LR2_configsave.h"
 
+#include "filesystem.h"
+
 //4011f0
 int FxByMIDI(game *g) {
 	bool change = false;
@@ -335,7 +337,7 @@ int ReadLR2SoundSet(game *g, CSTR filepath, char reFlag) {
 	if (g->audio.is_fmod_disabled == 0) FMOD_System_Update(g->audio.fmodSys);
 
 	CSTR path;
-	cstrSprintf(&path, "LR2files/SkinCustomize/%s.xml", MD5str(filepath));
+	cstrSprintf(&path, fs::make_preferred("LR2files/SkinCustomize/%s.xml").data(), MD5str(filepath));
 	ReadSkinCustomize(&sku, path);
 	
 	CSTR dir(filepath.getDirectory());

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -734,6 +734,9 @@ int InitGameplay_retry(gameplay *gp, AUDIO *snd, game *g) {
 
 //4ad7e0
 double RealTimeToBMSTime(gameplay *gp, double time){
+	if (gp->bpmt_count == 0) {
+		return {};
+	}
 
 	if (time <= gp->bpmt_data[0].realtime) {
 		return gp->bpmt_data[0].converted;

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -1,6 +1,7 @@
 ﻿#include "LR2_bmsload.h"
 #include "Engine.h"
 #include "LR2_replay.h"
+#include "filesystem.h"
 
 #include <algorithm>
 
@@ -3957,19 +3958,19 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 	if (gp->soundonly == 1 && bgaFlag && (cfg->play.bga == 3 || cfg->play.bga == 1 || (cfg->play.bga == 2 && gp->isAutoplay)) && cfg->play.autojudge != 2) {
 		DeleteGraph(gp->bgaHandle[1295]);
 		gp->bgaHandle[1295] = -1;
-		CSTR defaultMovieFile = GetRandomFile("LR2files/Movie/*.mpg", 0);
+		CSTR defaultMovieFile = GetRandomFile(fs::make_preferred("LR2files/Movie/*.mpg").data(), 0);
 		if (defaultMovieFile.isDiff("ERROR")) gp->bgaHandle[1295] = LoadGraph(defaultMovieFile);
 		if (gp->bgaHandle[1295] == -1) {
-			defaultMovieFile = GetRandomFile("LR2files/Movie/*.avi", 0);
+			defaultMovieFile = GetRandomFile(fs::make_preferred("LR2files/Movie/*.avi").data(), 0);
 			if (defaultMovieFile.isDiff("ERROR")) gp->bgaHandle[1295] = LoadGraph(defaultMovieFile);
 			if (gp->bgaHandle[1295] == -1) {
-				defaultMovieFile = GetRandomFile("LR2files/Movie/*.wmv", 0);
+				defaultMovieFile = GetRandomFile(fs::make_preferred("LR2files/Movie/*.wmv").data(), 0);
 				if (defaultMovieFile.isDiff("ERROR")) gp->bgaHandle[1295] = LoadGraph(defaultMovieFile);
 				if (gp->bgaHandle[1295] == -1) {
-					defaultMovieFile = GetRandomFile("LR2files/Movie/*.mp4", 0);
+					defaultMovieFile = GetRandomFile(fs::make_preferred("LR2files/Movie/*.mp4").data(), 0);
 					if (defaultMovieFile.isDiff("ERROR")) gp->bgaHandle[1295] = LoadGraph(defaultMovieFile);
 					if (gp->bgaHandle[1295] == -1) {
-						defaultMovieFile = GetRandomFile("LR2files/Movie/*.ogv", 0);
+						defaultMovieFile = GetRandomFile(fs::make_preferred("LR2files/Movie/*.ogv").data(), 0);
 						if (defaultMovieFile.isDiff("ERROR")) gp->bgaHandle[1295] = LoadGraph(defaultMovieFile);
 					}
 				}

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -478,7 +478,7 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 
 	int Rtmp, Gtmp, Btmp;
 
-	ErrorLogAdd("BMSの画像とサウンドをロードします");
+	ErrorLogAdd("BMSの画像とサウンドをロードします\n");
 
 	if ((cfg->play).autojudge == 2) { //silent
 		gp->loadObject_loaded = gp->loadObject_total;

--- a/LR2/LR2_configsave.cpp
+++ b/LR2/LR2_configsave.cpp
@@ -92,6 +92,8 @@ int ReadKeyConfig(game *game, const char *FilePath) {
 	ReadXml_Int_Multi("keyconfig", "key32", "id", (game->config).input.buttonMap[0x20], hXml);
 	ReadXml_Int_Multi("keyconfig", "key33", "id", (game->config).input.buttonMap[0x21], hXml);
 
+	delete hXml;
+
 	return 1;
 }
 
@@ -890,9 +892,7 @@ int ReadSkinCustomize(SkinUser *sku, char *FilePath) {
 	////0~39 repeat
 	//ReadXml_Str("skincustomize", "customfile", "filename_0", CSTR(""), &sku->customize_filename[0], hXml);
 
-	if (hXml) {
-		delete(hXml);
-	}
+	delete(hXml);
 
 	return 1;
 }

--- a/LR2/LR2_configsave.cpp
+++ b/LR2/LR2_configsave.cpp
@@ -1,10 +1,27 @@
 ﻿#include "LR2_configsave.h"
 
+#include <filesystem>
+#include <iterator>
+
 static void adjust_input_filepath(CSTR& path)
 {
 #ifndef _WIN32
 	path.replace("\\", "/");
 #endif // _WIN32
+}
+
+static void adjust_trailing_slash(CSTR& path)
+{
+	if (path.length() == 0)
+		return;
+	for (int i = path.length() - 1; i >= 0; i--) {
+		if (path.body[i] != '\\' && path.body[i] != '/') { // find_last_of
+			break;
+		}
+		path.body[i] = '\0';
+	}
+	*path.atPos(path.length()) = /* path += */ std::filesystem::path::preferred_separator;
+	*path.atPos(path.length()) = /* path += */ '\0';
 }
 
 //43c220
@@ -14,25 +31,21 @@ int Read_JukeboxPath(CONFIG_JUKEBOX *box, TiXmlDocument *xml){
 	}
 	box->numOfPath = 0;
 
-	TiXmlElement *cur;
-	if ((cur = xml->FirstChildElement("config")) && (cur = cur->FirstChildElement("jukebox")) &&
-		(cur = cur->FirstChildElement("path")) && cur->ToElement()) {
+	if (TiXmlElement *cur; (cur = xml->FirstChildElement("config")) &&
+				(cur = cur->FirstChildElement("jukebox")) &&
+				(cur = cur->FirstChildElement("path")) &&
+				cur->ToElement()) {
 
-		cstrSprintf(&box->path[0], "%s", cur->ToElement()->GetText());
-		CSTR tp2;
-		tp2.assign(&box->path[0]);
-		if (tp2.right(2).isSame("\\\\")) {
-			tp2.left(tp2.length() - 1);
-			box->path[0].assign(tp2.outstr());
-		}
-		adjust_input_filepath(box->path[0]);
-		box->numOfPath = 1;
-
-		while (box->numOfPath < 1000 && (cur = cur->NextSiblingElement()) && cur->ToElement()) {
-			cstrSprintf(&box->path[box->numOfPath], "%s", cur->ToElement()->GetText());
+		do {
+			box->path[box->numOfPath] = cur->ToElement()->GetText();
+			if (box->path[box->numOfPath].length() == 0) {
+				continue;
+			}
 			adjust_input_filepath(box->path[box->numOfPath]);
+			adjust_trailing_slash(box->path[box->numOfPath]);
 			box->numOfPath++;
-		}
+		} while (box->numOfPath < std::size(box->path) &&
+			(cur = cur->NextSiblingElement()) && cur->ToElement());
 
 		return 1;
 	}

--- a/LR2/LR2_gameloop.cpp
+++ b/LR2/LR2_gameloop.cpp
@@ -414,10 +414,10 @@ void ReactInput(game *g) {
 		g->timer2.rhythmTick = g->timer1.rhythmTick;
 	}
 	if (g->KeyInput.inputID[KEY_INPUT_F6] == 1) {
-		g->flag_Screenshot = 1;
+		g->flag_Screenshot = true;
 	}
 	if (g->KeyInput.inputID[KEY_INPUT_F7] == 1) {
-		g->flag_showFPS = (g->flag_showFPS == 0);
+		g->flag_showFPS = !g->flag_showFPS;
 	}
 }
 

--- a/LR2/LR2_ghost.cpp
+++ b/LR2/LR2_ghost.cpp
@@ -84,7 +84,7 @@ int PLAYSCORE::ResizeJudgeQueue(size_t size){
 		this->judge_queue_count = 1000;
 	}
 	this->judge_queue = (char *)realloc(this->judge_queue, size);
-	for (int i = this->judge_queue_count; i < this->judge_queue_count + size; i++) {
+	for (int i = this->judge_queue_count; i < size; i++) {
 		this->judge_queue[i] = -1;
 	}
 	this->judge_queue_count = this->judge_queue_count + size;
@@ -94,7 +94,7 @@ int PLAYSCORE::ResizeJudgeQueue(size_t size){
 //4a8740
 int PLAYSCORE::AddJudgeQueue(char judge){
 	if (this->judgecount == this->judge_queue_count) {
-		ResizeJudgeQueue(1000);
+		ResizeJudgeQueue(this->judge_queue_count + 1000);
 	}
 	this->judge_queue[this->judgecount] = judge;
 	this->judgecount = this->judgecount + 1;

--- a/LR2/LR2_ghost.cpp
+++ b/LR2/LR2_ghost.cpp
@@ -1,38 +1,15 @@
-﻿#include "Engine.h"
-
-//4a8550
-PLAYSCORE::PLAYSCORE() {
-	name.fillzero();
-	totalnotes = 0;
-	nownote = 0;
-	exscore = 0;
-	rate = 0;
-	judgecount = 0;
-	judgeExpect[0] = 0;
-	judge[0] = 0;
-	judgeExpect[1] = 0;
-	judge[1] = 0;
-	judgeExpect[2] = 0;
-	judge[2] = 0;
-	judgeExpect[3] = 0;
-	judge[3] = 0;
-	judgeExpect[4] = 0;
-	judge[4] = 0;
-	judgeExpect[5] = 0;
-	judge[5] = 0;
-	ghostReadCount = 0;
-	judge_queue_count = 0;
-	judge_queue = NULL;
-}
+﻿#include "LR2_ghost.h"
+#include "structure.h"
 
 //4a8600
 int PLAYSCORE::InitJudgeQueue(void){
+	// TODO: replace this->judge_queue with std::vector, then remove this function
 	this->name.fillzero();
 	this->totalnotes = 0;
 	this->nownote = 0;
 	this->exscore = 0;
 	this->rate = 0;
-	this->judgecount = 0;
+	this->judge_queue_len = 0;
 	this->judgeExpect[0] = 0;
 	this->judge[0] = 0;
 	this->judgeExpect[1] = 0;
@@ -46,48 +23,43 @@ int PLAYSCORE::InitJudgeQueue(void){
 	this->judgeExpect[5] = 0;
 	this->judge[5] = 0;
 	this->ghostReadCount = 0;
-	this->judge_queue_count = 0;
-	if (this->judge_queue != NULL) {
-		free(this->judge_queue);
-	}
+	this->judge_queue_capacity = 0;
+	free(this->judge_queue);
 	this->judge_queue = NULL;
-	this->judge_queue_count = 0;
+	this->judge_queue_capacity = 0;
 	return 0;
 }
 
 //4a8660
 int PLAYSCORE::ResetJudgeQueue(int size){
-
-	if (this->judge_queue != NULL) {
-		free(this->judge_queue);
-	}
+	free(this->judge_queue);
 	this->judge_queue = NULL;
-	this->judge_queue_count = 0;
+	this->judge_queue_capacity = 0;
 	this->judge_queue = (char *)malloc(size);
 	for (int i = 0; i < size; i++) {
 		this->judge_queue[i] = -1;
 	}
-	this->judge_queue_count = size;
+	this->judge_queue_capacity = size;
 	return 1;
 }
 
 //4a86c0
 int PLAYSCORE::ResizeJudgeQueue(size_t size){
 	this->judge_queue = (char *)realloc(this->judge_queue, size);
-	for (int i = this->judge_queue_count; i < size; i++) {
+	for (int i = this->judge_queue_capacity; i < size; i++) {
 		this->judge_queue[i] = -1;
 	}
-	this->judge_queue_count = this->judge_queue_count + size;
+	this->judge_queue_capacity = this->judge_queue_capacity + size;
 	return 1;
 }
 
 //4a8740
 int PLAYSCORE::AddJudgeQueue(char judge){
-	if (this->judgecount == this->judge_queue_count) {
-		ResizeJudgeQueue(this->judge_queue_count + 1000);
+	if (this->judge_queue_len == this->judge_queue_capacity) {
+		ResizeJudgeQueue(this->judge_queue_capacity + 1000);
 	}
-	this->judge_queue[this->judgecount] = judge;
-	this->judgecount = this->judgecount + 1;
+	this->judge_queue[this->judge_queue_len] = judge;
+	this->judge_queue_len = this->judge_queue_len + 1;
 	return 1;
 }
 
@@ -100,13 +72,13 @@ int PLAYSCORE::DealJudgeFromQueue(void){
 	if (this->totalnotes < 1) {
 		return 1;
 	}
-	if (this->judge_queue_count != 0) {
-		note = this->judgecount;
+	if (this->judge_queue_capacity != 0) {
+		note = this->judge_queue_len;
 		ret = 1;
-		if ((note != this->judge_queue_count) && (val = this->judge_queue[note], val != 0xff)) {
+		if ((note != this->judge_queue_capacity) && (val = this->judge_queue[note], val != 0xff)) {
 			if ((val != 0) && (val < 6)) {
 				this->judge[val]++;
-				this->judgecount++;
+				this->judge_queue_len++;
 				this->nownote++;
 				this->rate = this->judge[4] + this->judge[5] * 2;
 				return ret;
@@ -114,7 +86,7 @@ int PLAYSCORE::DealJudgeFromQueue(void){
 			if (val == 0) {
 				this->judge[1]++;
 				this->rate = this->judge[4] + this->judge[5] * 2;
-				this->judgecount++;
+				this->judge_queue_len++;
 				ret = 0;
 			}
 		}
@@ -135,13 +107,13 @@ int PLAYSCORE::DealJudgeFromQueue(void){
 
 //4a8870
 char PLAYSCORE::GetJudgeFromQueue(void){
-	if (this->judge_queue_count == 0) {
+	if (this->judge_queue_capacity == 0) {
 		return -1;
 	}
-	if (this->judgecount <= 0) {
+	if (this->judge_queue_len <= 0) {
 		return *this->judge_queue;
 	}
-	return this->judge_queue[this->judgecount + -1];
+	return this->judge_queue[this->judge_queue_len + -1];
 }
 
 //4a88a0
@@ -204,13 +176,13 @@ int PLAYSCORE::SetGhost(int exscore, int notes, CSTR name){
 
 //4a8a90 
 CSTR PLAYSCORE::EncodeGhostData(void) {
-	if (this->judgecount == 0) return "GHOST_ERROR";
+	if (this->judge_queue_len == 0) return "GHOST_ERROR";
 
 	int rep = 0;
 	CSTR buf;
-	CSTR data(this->judgecount + 3);
+	CSTR data(this->judge_queue_len + 3);
 	char last = this->judge_queue[0];
-	for (int i = 0; i < judgecount; i++) {
+	for (int i = 0; i < judge_queue_len; i++) {
 		if (last == this->judge_queue[i]) {
 			rep++;
 		}
@@ -482,7 +454,7 @@ CSTR PLAYSCORE::EncodeGhostData(void) {
 	this->nownote = 0;
 	this->exscore = 0;
 	this->rate = 0;
-	this->judgecount = 0;
+	this->judge_queue_len = 0;
 	this->judgeExpect[0] = 0;
 	this->judge[0] = 0;
 	this->judgeExpect[1] = 0;
@@ -496,12 +468,10 @@ CSTR PLAYSCORE::EncodeGhostData(void) {
 	this->judgeExpect[5] = 0;
 	this->judge[5] = 0;
 	this->ghostReadCount = 0;
-	this->judge_queue_count = 0;
-	if (this->judge_queue != NULL) {
-		free(this->judge_queue);
-	}
+	this->judge_queue_capacity = 0;
+	free(this->judge_queue);
 	this->judge_queue = NULL;
-	this->judge_queue_count = 0;
+	this->judge_queue_capacity = 0;
 
 	return str;
 }
@@ -689,43 +659,15 @@ int PLAYSCORE::DecodeGhostData(CSTR data) {
 		rep--;
 	}
 
-	this->name.fillzero();
-	this->totalnotes = 0;
-	this->nownote = 0;
-	this->exscore = 0;
-	this->rate = 0;
-	this->judgecount = 0;
-	this->judgeExpect[0] = 0;
-	this->judge[0] = 0;
-	this->judgeExpect[1] = 0;
-	this->judge[1] = 0;
-	this->judgeExpect[2] = 0;
-	this->judge[2] = 0;
-	this->judgeExpect[3] = 0;
-	this->judge[3] = 0;
-	this->judgeExpect[4] = 0;
-	this->judge[4] = 0;
-	this->judgeExpect[5] = 0;
-	this->judge[5] = 0;
-	this->ghostReadCount = 0;
-	this->judge_queue_count = 0;
-	if (this->judge_queue != NULL) {
-		free(this->judge_queue);
-	}
-	this->judge_queue = NULL;
-	this->judge_queue_count = 0;
-	if (this->judge_queue != NULL) {
-		free(this->judge_queue);
-	}
-	this->judge_queue = NULL;
-	this->judge_queue_count = 0;
-	this->judge_queue = (char *)malloc(decode.length() + 1);
+	InitJudgeQueue();
+
+	this->judge_queue = static_cast<char *>(calloc(1, decode.length() + 1));
 
 	for (int i = 0; i < decode.length() + 1; i++) {
 		this->judge_queue[i] = -1;
 	}
 
-	this->judge_queue_count = decode.length() + 1;
+	this->judge_queue_capacity = decode.length() + 1;
 
 	for (int i = 0; i < decode.length(); i++) {
 		this->judge_queue[i] = *decode.atPos(i) + -0x40;

--- a/LR2/LR2_ghost.cpp
+++ b/LR2/LR2_ghost.cpp
@@ -787,29 +787,38 @@ int WriteGhostInDatabase(sqlite3 *sql, CSTR songMD5, PLAYSCORE *score) {
 	ErrorLogAdd("データベースにゴーストを書き込みます\n");
 
 	CSTR ghostdata = score->EncodeGhostData();
-	CSTR query;
-	cstrSprintf(&query, "UPDATE score SET ghost = \'%s\' WHERE hash = \'%s\'", ghostdata.body, songMD5.body);
-	SQL_Run(query, sql);
+
+	sqlite3_stmt *pStmt;
+	sqlite3_prepare_v3(sql, "UPDATE score SET ghost = ? WHERE hash = ?", 0, 0, &pStmt, nullptr);
+	sqlite3_bind_text(pStmt, 1, ghostdata.body, ghostdata.length(), nullptr);
+	sqlite3_bind_text(pStmt, 2, songMD5.body, songMD5.length(), nullptr);
+	sqlite3_step(pStmt);
+	sqlite3_finalize(pStmt);
+
 	ErrorLogAdd("ゴーストの書き込みが終了しました\n");
 	return 0;
 }
 
-//4449f0
-int ReadGhostToScore(sqlite3 *sql, CSTR songMD5, PLAYSCORE *score) {
-
-	char query[1024];
-	sqlite3_stmt *pStmt;
-	CSTR ghostdata;
-
+CSTR ReadGhost(sqlite3 *sql, CSTR songMD5) {
 	ErrorLogAdd("データベースからゴーストを読み込みます\n");
 
-	sqlite3_snprintf(0x400, query, "SELECT ghost FROM score WHERE hash = \'%q\'", songMD5.body);
-	SQL_prepare(query, sql, &pStmt);
+	sqlite3_stmt *pStmt;
+	sqlite3_prepare_v3(sql, "SELECT ghost FROM score WHERE hash = ?", 0, 0, &pStmt, nullptr);
+	sqlite3_bind_text(pStmt, 1, songMD5.body, songMD5.length(), nullptr);
 
-	if (sqlite3_step(pStmt) == 100) {
-		ghostdata = SQL_GetColumn(0, pStmt);
+	CSTR ghostdata;
+	if (sqlite3_step(pStmt) == SQLITE_ROW) {
+		ghostdata.resize(sqlite3_column_bytes(pStmt, 1));
+		// Cast safety: it's safe to cast from unsigned char* to char*
+		ghostdata = reinterpret_cast<const char*>(sqlite3_column_text(pStmt, 1));
 	}
 	sqlite3_finalize(pStmt);
+
+	return ghostdata;
+}
+
+int ReadGhostToScore(sqlite3 *sql, CSTR songMD5, PLAYSCORE *score) {
+	CSTR ghostdata = ReadGhost(sql, songMD5);
 
 	if (ghostdata.length() == 0) {
 		score->InitJudgeQueue();
@@ -818,24 +827,4 @@ int ReadGhostToScore(sqlite3 *sql, CSTR songMD5, PLAYSCORE *score) {
 	
 	score->DecodeGhostData(ghostdata);
 	return 1;
-}
-
-//444b80
-CSTR ReadGhost(sqlite3 *sql, CSTR songMD5) {
-
-	char query[1024];
-	sqlite3_stmt *pStmt;
-	CSTR ghostdata;
-
-	ErrorLogAdd("データベースからゴーストを読み込みます\n");
-
-	sqlite3_snprintf(0x400, query, "SELECT ghost FROM score WHERE hash = \'%q\'", songMD5.body);
-	SQL_prepare(query, sql, &pStmt);
-
-	if (sqlite3_step(pStmt) == 100) {
-		ghostdata = SQL_GetColumn(0, pStmt);
-	}
-	sqlite3_finalize(pStmt);
-
-	return ghostdata;
 }

--- a/LR2/LR2_ghost.cpp
+++ b/LR2/LR2_ghost.cpp
@@ -73,16 +73,6 @@ int PLAYSCORE::ResetJudgeQueue(int size){
 
 //4a86c0
 int PLAYSCORE::ResizeJudgeQueue(size_t size){
-
-	if (this->judge_queue == NULL) {
-		this->judge_queue = NULL;
-		this->judge_queue_count = 0;
-		this->judge_queue = (char *)malloc(1000);
-		for (int i = 0; i < 1000; i++) {
-			this->judge_queue[i] = -1;
-		}
-		this->judge_queue_count = 1000;
-	}
 	this->judge_queue = (char *)realloc(this->judge_queue, size);
 	for (int i = this->judge_queue_count; i < size; i++) {
 		this->judge_queue[i] = -1;
@@ -132,20 +122,10 @@ int PLAYSCORE::DealJudgeFromQueue(void){
 	}
 	if (this->nownote > 0) {
 		this->judge[0] = ((this->nownote + 1) * this->judgeExpect[0]) / this->totalnotes;
-	}
-	if (this->nownote > 0) {
 		this->judge[1] = ((this->nownote + 1) * this->judgeExpect[1]) / this->totalnotes;
-	}
-	if (this->nownote > 0) {
 		this->judge[2] = ((this->nownote + 1) * this->judgeExpect[2]) / this->totalnotes;
-	}
-	if (this->nownote > 0) {
 		this->judge[3] = ((this->nownote + 1) * this->judgeExpect[3]) / this->totalnotes;
-	}
-	if (this->nownote > 0) {
 		this->judge[4] = ((this->nownote + 1) * this->judgeExpect[4]) / this->totalnotes;
-	}
-	if (this->nownote > 0) {
 		this->judge[5] = ((this->nownote + 1) * this->judgeExpect[5]) / this->totalnotes;
 	}
 	this->rate = this->judge[4] + this->judge[5] * 2;
@@ -211,7 +191,6 @@ int PLAYSCORE::SetDefaultGhost(int target, int notes){
 
 //4a89d0
 int PLAYSCORE::SetGhost(int exscore, int notes, CSTR name){
-
 	ErrorLogFmtAdd("exスコアからゴーストを設定します...");
 	InitJudgeQueue();
 	this->totalnotes = notes;
@@ -225,7 +204,6 @@ int PLAYSCORE::SetGhost(int exscore, int notes, CSTR name){
 
 //4a8a90 
 CSTR PLAYSCORE::EncodeGhostData(void) {
-	
 	if (this->judgecount == 0) return "GHOST_ERROR";
 
 	int rep = 0;
@@ -530,7 +508,6 @@ CSTR PLAYSCORE::EncodeGhostData(void) {
 
 //4a96b0
 int PLAYSCORE::DecodeGhostData(CSTR data) {
-	
 	CSTR decode;
 
 	for (int i = 0; i < data.length(); i++) {
@@ -807,8 +784,8 @@ int PLAYSCORE::SetScore(PLAYERSTATUS *pstat, char flagExpect) {
 
 //4448f0
 int WriteGhostInDatabase(sqlite3 *sql, CSTR songMD5, PLAYSCORE *score) {
-
 	ErrorLogAdd("データベースにゴーストを書き込みます\n");
+
 	CSTR ghostdata = score->EncodeGhostData();
 	CSTR query;
 	cstrSprintf(&query, "UPDATE score SET ghost = \'%s\' WHERE hash = \'%s\'", ghostdata.body, songMD5.body);

--- a/LR2/LR2_ghost.h
+++ b/LR2/LR2_ghost.h
@@ -1,21 +1,6 @@
 ﻿#include "structure.h"
 #include "Engine.h"
 
-
-// class function declare is in structure.h
-// 	PLAYSCORE();
-// 	int InitJudgeQueue(void);
-// 	int ResetJudgeQueue(int size);
-// 	int ResizeJudgeQueue(size_t size);
-// 	int AddJudgeQueue(char judge);
-// 	int DealJudgeFromQueue(void);
-// 	char GetJudgeFromQueue(void);
-// 	int SetDefaultGhost(int target, int notes);
-// 	int SetGhost(int exscore, int notes, CSTR name);
-// 	CSTR EncodeGhostData(void);
-// 	int DecodeGhostData(CSTR data);
-// 	int SetScore(PLAYERSTATUS *pstat, char flagExpect);
-
 int WriteGhostInDatabase(sqlite3 * sql, CSTR songMD5, PLAYSCORE * score);
 int ReadGhostToScore(sqlite3 * sql, CSTR songMD5, PLAYSCORE * score);
 CSTR ReadGhost(sqlite3 * sql, CSTR songMD5);

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -503,6 +503,7 @@ CSTR UrlEncode(CSTR in) {
 
 //4bb820
 RANKING::RANKING() {
+	// FIXME: replace with std::vector. Currently this leaks memory.
 	ranking = (RANKINGPLAYER*)malloc(sizeof(RANKINGPLAYER) * 1000);
 	assert(ranking != nullptr);
 	rankingCount = 0;

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -5,6 +5,7 @@
 #include "En_dbio.h"
 #include "En_fileutil.h"
 #include "En_timer.h"
+#include "filesystem.h"
 
 #ifdef _WIN32
 #include <shellapi.h>
@@ -246,7 +247,7 @@ int CheckRivaldataNew(int rivalID) {
 	sqlite3_stmt *pStmt;
 	CSTR path;
 	int ret = 0;
-	cstrSprintf(&path, "LR2files/Rival/%d.db", rivalID);
+	cstrSprintf(&path, fs::make_preferred("LR2files/Rival/%d.db").data(), rivalID);
 	
 	if (!IsFileExist(path)) return 0;
 
@@ -270,11 +271,11 @@ int ParseRivalData(long ID) {
 	TiXmlElement *cur, *val;
 	sqlite3 *pRivalDB;
 
-	cstrSprintf(&path, "LR2files/Rival/%d.db", ID);
+	cstrSprintf(&path, fs::make_preferred("LR2files/Rival/%d.db").data(), ID);
 	sqlite3_open(path, &pRivalDB);
 	SQL_Run("CREATE TABLE rival(hash TEXT primary key,r_clear INTEGER,r_totalnotes INTEGER,r_maxcombo INTEGER,r_perfect INTEGER,r_great INTEGER,r_good INTEGER,r_bad INTEGER,r_poor INTEGER,r_minbp INTEGER,r_option INTEGER,r_lastupdate INGEGER)", pRivalDB);
 	
-	cstrSprintf(&path, "LR2files/Rival/%d.xml", ID);
+	cstrSprintf(&path, fs::make_preferred("LR2files/Rival/%d.xml").data(), ID);
 	hXml = new TiXmlDocument(path);
 	if (hXml->LoadFile(TIXML_ENCODING_UNKNOWN) == false) {
 		if (hXml) {
@@ -400,7 +401,7 @@ int ParseRivalData(long ID) {
 
 	CSTR cfolder;
 	cstrSprintf(&cfolder, "#COMMAND __RIVAL__\n#MAXTRACKS %d\n#CATEGORY ライバルフォルダ\n#TITLE %s\n#INFORMATION_A %sのプレイした曲を表示します\n#INFORMAION_B\n", ID, name.body, name.body);
-	cstrSprintf(&path, "LR2files/Rival/%d.lr2folder", ID);
+	cstrSprintf(&path, fs::make_preferred("LR2files/Rival/%d.lr2folder").data(), ID);
 	cfolder.toFile(path);
 	printfDx("ID%06d:ライバルデータ[%s]を更新しました。更新スコア数%d\n", ID, name.body, count);
 	return 1;
@@ -416,7 +417,7 @@ int NETWORK::GetInsaneList() {
 	cstrSprintf(&this->param," ");
 	this->target_URL = "http://www.dream-pro.info/~lavalse/LR2IR/2/getinsanelist.cgi";
 	if (HTTPrequest() == 1) {
-		this->httpResult.toFile("LR2files/Database/exlevel.xml");
+		this->httpResult.toFile(fs::make_preferred("LR2files/Database/exlevel.xml").data());
 		printfDx("発狂難度リストをダウンロードしました。\n");
 		ErrorLogFmtAdd("発狂難度リストをダウンロードしました。\n");
 	}
@@ -426,7 +427,7 @@ int NETWORK::GetInsaneList() {
 	}
 	ScreenFlip();
 
-	hXml = new TiXmlDocument("LR2files/Database/exlevel.xml");
+	hXml = new TiXmlDocument(fs::make_preferred("LR2files/Database/exlevel.xml").data());
 	if (hXml->LoadFile(TIXML_ENCODING_UNKNOWN) == false) {
 		if (hXml) {
 			delete(hXml);
@@ -454,7 +455,7 @@ int NETWORK::GetInsaneList() {
 
 	CSTR query;
 	CSTR hash;
-	sqlite3_open("LR2files/Database/song.db", &pSongDB);
+	sqlite3_open(fs::make_preferred("LR2files/Database/song.db").data(), &pSongDB);
 	SQL_Run("BEGIN", pSongDB);
 	while (cur) {
 		if (TiXmlElement *val = cur->FirstChildElement("hash"); val && val->ToElement()) {
@@ -672,10 +673,10 @@ int NETWORK::GetRanking(CSTR hash, char flagInit) {
 	
 	ErrorLogAdd("IRxmlをダウンロードします\n");
 	if (hash.length() <= 50) {
-		cstrSprintf(&path, "LR2files/Ir/%s.xml", hash.body);
+		cstrSprintf(&path, fs::make_preferred("LR2files/Ir/%s.xml").data(), hash.body);
 	}
 	else {
-		cstrSprintf(&path, "LR2files/Ir/%s.xml", AssignCRC32(hash).body);
+		cstrSprintf(&path, fs::make_preferred("LR2files/Ir/%s.xml").data(), AssignCRC32(hash).body);
 	}
 
 	if (flagInit) this->rankingData.Init();
@@ -698,9 +699,9 @@ int NETWORK::GetRanking(CSTR hash, char flagInit) {
 //4bc4c0
 int NETWORK::GetRivalInfo(int rivalID) {
 	CSTR pathXML;
-	cstrSprintf(&pathXML, "LR2files/Rival/%d.xml", rivalID);
+	cstrSprintf(&pathXML, fs::make_preferred("LR2files/Rival/%d.xml").data(), rivalID);
 	CSTR pathDB;
-	cstrSprintf(&pathDB, "LR2files/Rival/%d.db", rivalID);
+	cstrSprintf(&pathDB, fs::make_preferred("LR2files/Rival/%d.db").data(), rivalID);
 	cstrSprintf(&this->param, "id=%d&lastupdate=%d", rivalID, CheckRivaldataNew(rivalID));
 	this->target_URL = "http://www.dream-pro.info/~lavalse/LR2IR/2/getplayerxml.cgi";
 	if (this->HTTPrequest() == 1) {
@@ -969,7 +970,7 @@ int SaveIRID(int IRID, CSTR ID) {
 
 	CSTR scorefile;
 	sqlite3 *pDb;
-	cstrSprintf(&scorefile, "LR2files/Database/Score/%s.db", ID.body);
+	cstrSprintf(&scorefile, fs::make_preferred("LR2files/Database/Score/%s.db").data(), ID.body);
 	sqlite3_open(scorefile, &pDb);
 	CSTR query;
 	cstrSprintf(&query, "UPDATE player SET irid = %d", IRID);

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -675,7 +675,7 @@ int NETWORK::GetRanking(CSTR hash, char flagInit) {
 		cstrSprintf(&path, "LR2files/Ir/%s.xml", hash.body);
 	}
 	else {
-		cstrSprintf(&path, "LR2files/Ir/%s.xml", hash.makeCRCstr().body);
+		cstrSprintf(&path, "LR2files/Ir/%s.xml", AssignCRC32(hash).body);
 	}
 
 	if (flagInit) this->rankingData.Init();

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -576,7 +576,7 @@ int NETWORK::HTTPrequest() {
 		ioctlsocket(s, 0x8004667e, &argp);
 
 		request.fillzero();
-		cstrSprintf(&request, "POST %s HTTP/1.0\r\nContent-Length:%d\n\n%s", this->target_URL, this->param.length(), this->param);
+		cstrSprintf(&request, "POST %s HTTP/1.0\r\nContent-Length:%d\n\n%s", this->target_URL.body, this->param.length(), this->param.body);
 
 		if (send(s, request, request.length() + 1, 0) < 0) {
 			cstrSprintf(&this->request_debug, "データの送信に失敗しました : %d\n", WSAGetLastError());

--- a/LR2/LR2_makemp3.cpp
+++ b/LR2/LR2_makemp3.cpp
@@ -79,7 +79,6 @@ int Proc_Auto2avi(game *g, CSTR /*directory*/, CSTR filename) {
 
 	for (int i = 0; i < g->gameplay.bmsobj.count; i++) {
 		double len = 0;
-		g->gameplay.bmsobj.notes[i].op;
 		if (g->gameplay.bmsobj.notes[i].op == 1 || (10 <= g->gameplay.bmsobj.notes[i].op  && g->gameplay.bmsobj.notes[i].op < 30)) {
 			if (i + 1 < g->gameplay.bmsobj.count) {
 				double endtime = g->gameplay.keysound[(int)g->gameplay.bmsobj.notes[i].val].length;
@@ -130,7 +129,6 @@ int RecordBmsSound(game *g, CSTR oPath) {
 	ProcessMessage();
 	if (g->rec.recMode != 2) {
 		g->gameplay.song_runtime += startTime;
-		g->config.tools.mp3_volume;
 		GetSoundBuffer(&g->audio, g->gameplay.song_runtime, g->config.tools.mp3_volume);
 
 		for (int i = 0; i < g->gameplay.bmsobj.count; i++) {

--- a/LR2/LR2_makemp3.cpp
+++ b/LR2/LR2_makemp3.cpp
@@ -1,6 +1,7 @@
 ﻿#include "LR2_makemp3.h"
 #include "Engine.h"
 #include "LR2_bmsload.h"
+#include "filesystem.h"
 
 #ifndef _WIN32
 #include <iostream>
@@ -107,7 +108,7 @@ int Proc_Auto2avi(game *g, CSTR /*directory*/, CSTR filename) {
 	CSTR ext = filename.right(3).lower();
 	if(ext.isSame("mp3")) {
 		CSTR tPath = g->baseDirectory;
-		tPath.add("LR2files/temp.wav");
+		tPath.add(fs::make_preferred("LR2files/temp.wav").data());
 		WriteSoundFile(&g->audio, tPath, 0);
 		RunMP3Encoder(&g->config, tPath, filename, 1, 0);
 	}
@@ -162,11 +163,11 @@ int RecordBmsSound(game *g, CSTR oPath) {
 	CSTR wavPath;
 	if (g->config.tools.movie_audio == 0) {
 		wavPath = g->baseDirectory;
-		wavPath.add("LR2files/movie_temp.wav");
+		wavPath.add(fs::make_preferred("LR2files/movie_temp.wav").data());
 		WriteSoundFile(&g->audio, wavPath, GetTimeWrap()*44100.0 / 1000.0 * 2);
 
 		CSTR mp3Path(g->baseDirectory);
-		mp3Path.add("LR2files/movie_temp.mp3");
+		mp3Path.add(fs::make_preferred("LR2files/movie_temp.mp3").data());
 		if (RunMP3Encoder(&g->config, wavPath, mp3Path, 1, 1) == 1) {
 			g->rec.InsertAudioToMovie(mp3Path, true);
 		}
@@ -176,7 +177,7 @@ int RecordBmsSound(game *g, CSTR oPath) {
 	}
 	else if (g->config.tools.movie_audio == 1) {
 		wavPath = g->baseDirectory;
-		wavPath.add("LR2files/movie_temp.wav");
+		wavPath.add(fs::make_preferred("LR2files/movie_temp.wav").data());
 		WriteSoundFile(&g->audio, wavPath, GetTimeWrap()*44100.0 / 1000.0 * 2);
 		g->rec.InsertAudioToMovie(wavPath, true);
 	}

--- a/LR2/LR2_replay.cpp
+++ b/LR2/LR2_replay.cpp
@@ -1,5 +1,6 @@
 ﻿#include "LR2_replay.h"
 #include "Engine.h"
+#include "filesystem.h"
 
 #include <filesystem>
 #include <system_error>
@@ -13,20 +14,20 @@ int MoveReplayFile(CSTR songMD5, CSTR localID) {
 	{
 		CSTR path;
 
-		cstrSprintf(&path, "LR2files/Replay/%s/c", localID.body);
+		cstrSprintf(&path, fs::make_preferred("LR2files/Replay/%s/c").data(), localID.body);
 		std::error_code ec; // ignore errors
 		std::filesystem::create_directories(path.body, ec);
 
-		cstrSprintf(&path, "LR2files/Replay/%s/c/%s", localID.body, songMD5.body);
+		cstrSprintf(&path, fs::make_preferred("LR2files/Replay/%s/c/%s").data(), localID.body, songMD5.body);
 		std::filesystem::create_directories(path.body, ec);
 	}
 
 	CSTR pathFrom;
 	int stage = 0;
-	cstrSprintf(&pathFrom, "LR2files/Replay/%s/__%d.lr2rep", localID.body, stage);
+	cstrSprintf(&pathFrom, fs::make_preferred("LR2files/Replay/%s/__%d.lr2rep").data(), localID.body, stage);
 	while (pathFrom.canOpenFile()) {
 		CSTR pathTo;
-		cstrSprintf(&pathTo, "LR2files/Replay/%s/c/%s/%d.lr2rep", localID.body, songMD5.body, stage);
+		cstrSprintf(&pathTo, fs::make_preferred("LR2files/Replay/%s/c/%s/%d.lr2rep").data(), localID.body, songMD5.body, stage);
 #ifdef _WIN32
 		MoveFileA(pathFrom, pathTo); //TOFIX : if file already exists at pathTo, it fails.
 #else // TODO: consolidate these two. Didn't check what fs::rename does if target already exists.
@@ -36,7 +37,7 @@ int MoveReplayFile(CSTR songMD5, CSTR localID) {
 		ErrorLogFmtAdd("リプレイの移動 stage%d\n", stage);
 
 		stage++;
-		cstrSprintf(&pathFrom, "LR2files/Replay/%s/__%d.lr2rep", localID.body, stage);
+		cstrSprintf(&pathFrom, fs::make_preferred("LR2files/Replay/%s/__%d.lr2rep").data(), localID.body, stage);
 	}
 	ErrorLogFmtAdd("リプレイの移動終了 stage%d\n", stage);
 
@@ -53,7 +54,7 @@ int LoadReplayFileCourse(REPLAY *rp, CSTR songMD5, int stage, CSTR localID){
 	}
 
 	CSTR path;
-	cstrSprintf(&path, "LR2files/Replay/%s/c/%s/%d.lr2rep", localID.body, songMD5.body, stage);
+	cstrSprintf(&path, fs::make_preferred("LR2files/Replay/%s/c/%s/%d.lr2rep").data(), localID.body, songMD5.body, stage);
 
 	if (!IsFileExist(path)) return 0;
 
@@ -91,7 +92,7 @@ int LoadReplayFile(REPLAY *rp, CSTR songMD5, CSTR localID) {
 	}
 
 	CSTR path;
-	cstrSprintf(&path, "LR2files/Replay/%s/%s.lr2rep", localID.body, songMD5.body);
+	cstrSprintf(&path, fs::make_preferred("LR2files/Replay/%s/%s.lr2rep").data(), localID.body, songMD5.body);
 
 	if (!IsFileExist(path)) return 0;
 
@@ -128,7 +129,7 @@ int SaveReplay(REPLAY *rp, CSTR songMD5, CSTR localID) {
 	}
 
 	CSTR path;
-	cstrSprintf(&path, "LR2files/Replay/%s/%s.lr2rep", localID.body, songMD5.body);
+	cstrSprintf(&path, fs::make_preferred("LR2files/Replay/%s/%s.lr2rep").data(), localID.body, songMD5.body);
 	pFile = fopen(path, "wb");
 	if (pFile == NULL) {
 		ErrorLogAdd("リプレイデータの保存に失敗しました。\n");

--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -1,6 +1,7 @@
 ﻿#include "LR2_skinload.h"
 #include "LR2_skindraw.h"
 #include "LR2_configsave.h"
+#include "filesystem.h"
 
 //49a770
 bool IsMultibyte(byte ch){
@@ -489,9 +490,9 @@ int InitSkin(skstruct *sk, int /*unused*/, char font) {
 	if (sk->GrHandle[GrH_BackBMP] == -1) sk->GrHandle[GrH_BackBMP] = MakeGraph(640, 480);
 	if (sk->GrHandle[GrH_Banner] == -1) sk->GrHandle[GrH_Banner] = MakeGraph(300, 80);
 	DeleteGraph(sk->GrHandle[110]);
-	sk->GrHandle[110] = LoadGraph("LR2files/Config/black.bmp");
+	sk->GrHandle[110] = LoadGraph(fs::make_preferred("LR2files/Config/black.bmp").data());
 	DeleteGraph(sk->GrHandle[111]);
-	sk->GrHandle[111] = LoadGraph("LR2files/Config/white.bmp");
+	sk->GrHandle[111] = LoadGraph(fs::make_preferred("LR2files/Config/white.bmp").data());
 	sk->reloadbanner = 0;
 	for (int i = 0; i < 10; i++) {
 		InitSRC(&sk->src_BAR_RANK[i]);
@@ -1851,7 +1852,7 @@ int LoadScene(skstruct* sk, CSTR skinfile, int p5, char font) {
 	CSTR tStr;
 	InitSkin(sk, p5, font);
 	sk->skinMD5.assign(MD5str(skinfile));
-	cstrSprintf(&tStr, "LR2files/SkinCustomize/%s.xml",sk->skinMD5.body);
+	cstrSprintf(&tStr, fs::make_preferred("LR2files/SkinCustomize/%s.xml").data(),sk->skinMD5.body);
 	ReadSkinCustomize(&tsku, tStr);
 	(sk->adjust).shift_x = tsku.adjust.shift_x;
 	(sk->adjust).shift_y = tsku.adjust.shift_y;

--- a/LR2/LR2_skinmanage.cpp
+++ b/LR2/LR2_skinmanage.cpp
@@ -34,7 +34,7 @@ int SetFirstSkin_5k(SkinManage *sm, SKINTYPE type, CSTR *skinName){
 	sm->skinID[type] = -1;
 	for (int i = 0; i < sm->Count; i++) {
 		if (sm->Data[i].skinFile.isSame(skinName) &&
-			(sm->Data[i].type == type || (sm->Data[i].type == type - 1 && (type == SKINTYPE_5KEYS || type == SKINTYPE_10KEYS || type == SKINTYPE_7KEYSBATTLE)))) {
+			(sm->Data[i].type == type || (sm->Data[i].type == type - 1 && (type == SKINTYPE_5KEYS || type == SKINTYPE_10KEYS || type == SKINTYPE_5KEYSBATTLE)))) {
 			sm->skinID[type] = i;
 			ErrorLogFmtAdd("SetFirstSkin 正しくスキン番号を設定しました。種別%d パス%s 番号%d\n", type, skinName->body, i);
 			return 1;
@@ -42,7 +42,7 @@ int SetFirstSkin_5k(SkinManage *sm, SKINTYPE type, CSTR *skinName){
 	}
 	ErrorLogFmtAdd("SetFirstSkin()で該当のタイプのスキンが見つかりませんでした。種別%d パス%s\n", type, skinName->body);
 	for (int i = 0; i < sm->Count; i++) {
-		if (sm->Data[i].type == type || (sm->Data[i].type == type -1 && (type == SKINTYPE_5KEYS || type == SKINTYPE_10KEYS || type == SKINTYPE_7KEYSBATTLE) )) {
+		if (sm->Data[i].type == type || (sm->Data[i].type == type -1 && (type == SKINTYPE_5KEYS || type == SKINTYPE_10KEYS || type == SKINTYPE_5KEYSBATTLE) )) {
 			skinName->assign(&sm->Data[i].skinFile);
 			sm->skinID[type] = i;
 			return 1;
@@ -78,7 +78,7 @@ int SetFirstSkin_5kb(SkinManage *sm, SKINTYPE type, CSTR *skinName) {
 
 	sm->skinID[type] = -1;
 	for (int i = 0; i < sm->Count; i++) {
-		if (sm->Data[i].skinFile.isSame(skinName) && (sm->Data[i].type == 13 || sm->Data[i].type == 12)) {
+		if (sm->Data[i].skinFile.isSame(skinName) && (sm->Data[i].type == SKINTYPE_5KEYSBATTLE || sm->Data[i].type == SKINTYPE_7KEYSBATTLE)) {
 			sm->skinID[type] = i;
 			ErrorLogFmtAdd("SetFirstSkin 正しくスキン番号を設定しました。種別%d パス%s 番号%d\n", type, skinName->body, i);
 			return 1;
@@ -86,7 +86,7 @@ int SetFirstSkin_5kb(SkinManage *sm, SKINTYPE type, CSTR *skinName) {
 	}
 	ErrorLogFmtAdd("SetFirstSkin()で該当のタイプのスキンが見つかりませんでした。種別%d パス%s\n", type, skinName->body);
 	for (int i = 0; i < sm->Count; i++) {
-		if (sm->Data[i].type == 13 || sm->Data[i].type == 12) {
+		if (sm->Data[i].type == SKINTYPE_5KEYSBATTLE || sm->Data[i].type == SKINTYPE_7KEYSBATTLE) {
 			skinName->assign(&sm->Data[i].skinFile);
 			sm->skinID[type] = i;
 			return 1;

--- a/LR2/LR2_skinmanage.cpp
+++ b/LR2/LR2_skinmanage.cpp
@@ -116,7 +116,7 @@ int SetFirstSkins(game *g){
 		ErrorLogAdd("14keysスキンが有りません。\n");
 	}
 	if (SetFirstSkin_10k(sm, SKINTYPE_10KEYS, &g->config.skin.skinFilePath[3]) == -1) {
-		ErrorLogAdd("14keysスキンが有りません。\n");
+		ErrorLogAdd("10keysスキンが有りません。\n");
 	}
 	if (SetFirstSkin(sm, SKINTYPE_9KEYS, &g->config.skin.skinFilePath[4]) == -1) {
 		ErrorLogAdd("9keysスキンが有りません。\n");

--- a/LR2/LR2_skinmanage.cpp
+++ b/LR2/LR2_skinmanage.cpp
@@ -175,6 +175,7 @@ int SetFirstSkins(game *g){
 
 //4a7390
 int InitSkinData(SkinManage *skm){
+	// FIXME: 1) move to SkinManage constructor 2) move to std::vector. This leaks memory.
 	skm->Max = 100;
 	skm->Data = (SkinHeader *)malloc(sizeof(SkinHeader) * 100);
 	assert(skm->Data != nullptr);

--- a/LR2/LR2_skinmanage.cpp
+++ b/LR2/LR2_skinmanage.cpp
@@ -1,6 +1,7 @@
 ﻿#include "LR2_skinmanage.h"
 #include "Engine.h"
 #include "LR2_configsave.h"
+#include "filesystem.h"
 
 #include <filesystem>
 
@@ -101,8 +102,8 @@ int SetFirstSkins(game *g){
 	ErrorLogAdd("スキンを列挙します。\n");
 	sm = &g->skinData;
 	InitSkinData(sm);
-	MakeSkinList(sm, CSTR("LR2files/Theme/"));
-	MakeSkinList(sm, CSTR("LR2files/Sound/"));
+	MakeSkinList(sm, CSTR(fs::make_preferred("LR2files/Theme/").data()));
+	MakeSkinList(sm, CSTR(fs::make_preferred("LR2files/Sound/").data()));
 	ErrorLogAdd("スキンの列挙を終了しました。\n");
 
 	if (SetFirstSkin(sm, SKINTYPE_7KEYS, &g->config.skin.skinFilePath[0]) == -1) {
@@ -223,7 +224,7 @@ int ParseLR2SkinCustom(SkinManage *skm, CSTR filepath) {
 	FILE *pFile;
 	char* pBuffer;
 
-	cstrSprintf(&md5Filepath, "LR2files/SkinCustomize/%s.xml", MD5str(filepath) );
+	cstrSprintf(&md5Filepath, fs::make_preferred("LR2files/SkinCustomize/%s.xml").data(), MD5str(filepath) );
 	ReadSkinCustomize(&skCustom, md5Filepath);
 	pFile = fopen(filepath, "r");
 	if (!pFile) return 0;

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -6,6 +6,7 @@
 #include "LR2_configsave.h"
 #include "LR2_statplay.h"
 #include "Scenes.h"
+#include "filesystem.h"
 
 #include <DxLib/DxLib.h>
 
@@ -3577,13 +3578,13 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 					g->KeyInput.config_key = -1;
 					switch (g->KeyInput.config_keymode) {
 						case 0:
-							ReadKeyConfig(g, "LR2files/Config/keyconfig.xml");
+							ReadKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 							break;
 						case 1:
-							ReadKeyConfig(g, "LR2files/Config/keyconfig_p.xml");
+							ReadKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig_p.xml").data());
 							break;
 						case 2:
-							ReadKeyConfig(g, "LR2files/Config/keyconfig_5.xml");
+							ReadKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig_5.xml").data());
 							break;
 					}
 					ProcS_Keyconfig(g);
@@ -3644,7 +3645,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 					g->skinData.previewCustomID = 0;
 					CSTR tcstr;
 					SkinUser sku;
-					cstrSprintf(&tcstr, "LR2files/SkinCustomize/%s.xml", MD5str(g->skinData.Data[g->skinData.previewID].skinFile));
+					cstrSprintf(&tcstr, fs::make_preferred("LR2files/SkinCustomize/%s.xml").data(), MD5str(g->skinData.Data[g->skinData.previewID].skinFile));
 					ReadSkinCustomize(&sku, tcstr);
 
 					for (int j = 0; j < 100; j++) { // VULNERABILITY : out of index sku (array size 40, but access to 100)
@@ -3702,7 +3703,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 					g->skinData.previewCustomID = 0;
 					CSTR tcstr;
 					SkinUser sku;
-					cstrSprintf(&tcstr, "LR2files/SkinCustomize/%s.xml", MD5str(g->skinData.Data[g->skinData.previewID].skinFile));
+					cstrSprintf(&tcstr, fs::make_preferred("LR2files/SkinCustomize/%s.xml").data(), MD5str(g->skinData.Data[g->skinData.previewID].skinFile));
 					ReadSkinCustomize(&sku, tcstr);
 
 					for (int j = 0; j < 100; j++) { // VULNERABILITY : out of index sku (array size 40, but access to 100)
@@ -3797,7 +3798,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 
 					CSTR tcstr;
 					SkinUser sku;
-					cstrSprintf(&tcstr, "LR2files/SkinCustomize/%s.xml", MD5str(g->skinData.Data[g->skinData.previewID].skinFile));
+					cstrSprintf(&tcstr, fs::make_preferred("LR2files/SkinCustomize/%s.xml").data(), MD5str(g->skinData.Data[g->skinData.previewID].skinFile));
 					ReadSkinCustomize(&sku, tcstr);
 
 					for (int j = 0; j < 100; j++) { // VULNERABILITY : out of index sku (array size 40, but access to 100)

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -4361,6 +4361,8 @@ int ReadOptionstrFile(OptionString *arrOpStr, CSTR filepath) {
 		pFbuf = fBuf.outstr();
 	}
 
+	fclose(pFile);
+
 	ErrorLogAdd("オプション文字列リストを読み込みました。\n");
 	return 1;
 }

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -2,6 +2,8 @@
 #include "Engine.h"
 #include "LR2_statlong.h"
 
+#include <iterator>
+
 #ifdef _WIN32
 #include <shellapi.h>
 #endif // _WIN32
@@ -2484,6 +2486,7 @@ int LoadLR2CustomFolder(sqlite3 *sql, CONFIG_JUKEBOX *jb, CSTR scoreDBpath, char
 	}
 	else {
 		if (flag_direct == 0) {
+			// FIXME: out of bounds write if jb->numOfPath == jb->path.size(). Make jb->path a vector.
 			//TODO : make define customfolderoption constant
 			if (jb->customfolder & 1) {
 				jb->path[jb->numOfPath] = "LR2files/CustomFolder/RANDOM/";
@@ -2644,7 +2647,7 @@ int LoadLR2CustomFolder(sqlite3 *sql, CONFIG_JUKEBOX *jb, CSTR scoreDBpath, char
 		}
 		sqlite3_exec(sql, "COMMIT", 0, 0, 0);
 		jb->numOfPath -= folderAddCount;
-		for (int i = jb->numOfPath; i < 1000; i++) {
+		for (int i = jb->numOfPath; i < std::size(jb->path); i++) {
 			jb->path[i].fillzero();
 		}
 	}

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -1521,7 +1521,6 @@ int SearchCourseFromDB(sqlite3 *sql, SONGSELECT *ss, int keys, int multistagemod
 			if (song.mybest.rank == 0 && song.mybest.stat_pgreat + song.mybest.stat_great > 0)
 				song.mybest.rank = 1;
 		}
-		song.mybest.rank = 1;
 		song.mybest.clear_db = sqlite3_column_int(pStmt, 20);
 		song.mybest.op_history = sqlite3_column_int(pStmt, 21);
 		song.mybest.clear_sd = sqlite3_column_int(pStmt, 24);

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -1,6 +1,7 @@
 ﻿#include "LR2_songmanage.h"
 #include "Engine.h"
 #include "LR2_statlong.h"
+#include "filesystem.h"
 
 #include <iterator>
 
@@ -902,7 +903,7 @@ int GetSongData(CSTR songMD5, SONGDATA *song, sqlite3 *sql, SONGSELECT *ss) {
 
 		song->tag = SQL_GetColumn(6, stmt);
 		song->difficulty = sqlite3_column_int(stmt, 15);
-		cstrSprintf(&replayPath, "LR2files/Replay/%s/%s.lr2rep", ss->playerID.body, song->hash.body);
+		cstrSprintf(&replayPath, fs::make_preferred("LR2files/Replay/%s/%s.lr2rep").data(), ss->playerID.body, song->hash.body);
 		song->replayExist = IsFileExist(replayPath);
 		if (song->keymode > 0) {
 			song->mybest.clear = sqlite3_column_int(stmt, 30);
@@ -1154,7 +1155,7 @@ int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 
 	ErrorLogFmtAdd("曲の検索を行います。パス%s\n", root.body);
 	ErrorLogTabAdd();
-	if (root.right(1).isDiff("/")) root.add("/");
+	if (root.right(1).isDiff("\\")) root.add("\\");
 
 	CSTR searchPath;
 	BMSMETA meta; 
@@ -1193,7 +1194,7 @@ int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 		}
 		else {
 			searchPath = root;
-			searchPath.add(findFileData.cFileName).add("/");
+			searchPath.add(findFileData.cFileName).add("\\");
 			ErrorLogFmtAdd("フォルダを発見しました。　パス:%s\n", searchPath.body);
 			
 			CSTR folderinfo(searchPath);
@@ -1209,7 +1210,7 @@ int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 				if (SQL_Run(str, sql) == 0) {
 					ErrorLogAdd("再帰検索を行います。\n");
 					CSTR subPath(root);
-					subPath.add(findFileData.cFileName).add("/");
+					subPath.add(findFileData.cFileName).add("\\");
 					count += SearchSongsFromPath(searchPath, sql, subPath);
 				}
 			}
@@ -1218,7 +1219,7 @@ int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 				if (SQL_Run(str, sql) == 0) {
 					ErrorLogAdd("再帰検索を行います。\n");
 					CSTR subPath(root);
-					subPath.add(findFileData.cFileName).add("/");
+					subPath.add(findFileData.cFileName).add("\\");
 					count += SearchSongsFromPath(searchPath, sql, subPath);
 				}
 			}
@@ -1496,10 +1497,10 @@ int SearchCourseFromDB(sqlite3 *sql, SONGSELECT *ss, int keys, int multistagemod
 		}
 
 		if (multistagemode == 1) { //nonstop
-			cstrSprintf(&str, "LR2files/Replay/%s/%s.lr2rep", ss->playerID.body, MD5str(song.hash));
+			cstrSprintf(&str, fs::make_preferred("LR2files/Replay/%s/%s.lr2rep").data(), ss->playerID.body, MD5str(song.hash));
 		}
 		else {
-			cstrSprintf(&str, "LR2files/Replay/%s/c/%s", ss->playerID.body, MD5str(song.hash));
+			cstrSprintf(&str, fs::make_preferred("LR2files/Replay/%s/c/%s").data(), ss->playerID.body, MD5str(song.hash));
 		}
 		song.replayExist = IsFileExist(str);
 		song.mybest.clear = sqlite3_column_int(pStmt, 6);
@@ -1749,7 +1750,7 @@ int GetFolderDataFromPath(CSTR path, sqlite3 *sql) {
 	ErrorLogTabAdd();
 	BMSMETA meta;
 	CSTR searchPath(path);
-	if (searchPath.right(1).isSame("/")) {
+	if (searchPath.right(1).isSame("\\") || searchPath.right(1).isSame("/")) {
 		*searchPath.atPos(searchPath.length() - 1) = 0;
 	}
 
@@ -1854,7 +1855,7 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 		isRival = 1;
 		SQL_Run("DETACH rivaldb", sql);
 		CSTR str;
-		cstrSprintf(&str, "ATTACH \'LR2files/Rival/%d.db\' AS rivaldb", rivalID);
+		cstrSprintf(&str, fs::make_preferred("ATTACH \'LR2files/Rival/%d.db\' AS rivaldb").data(), rivalID);
 		SQL_Run(str, sql);
 		ss->rivalID = rivalID;
 		rivalID = 0;
@@ -2057,7 +2058,7 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 
 					song.tag = SQL_GetColumn(6, pStmt);
 					song.difficulty = sqlite3_column_int(pStmt, 15);
-					cstrSprintf(&replayPath, "LR2files/Replay/%s/%s.lr2rep", ss->playerID.body, song.hash.body);
+					cstrSprintf(&replayPath, fs::make_preferred("LR2files/Replay/%s/%s.lr2rep").data(), ss->playerID.body, song.hash.body);
 					song.replayExist = IsFileExist(replayPath);
 					thisFolder = SQL_GetColumn(9, pStmt);
 					song.folder = thisFolder;
@@ -2489,59 +2490,59 @@ int LoadLR2CustomFolder(sqlite3 *sql, CONFIG_JUKEBOX *jb, CSTR scoreDBpath, char
 			// FIXME: out of bounds write if jb->numOfPath == jb->path.size(). Make jb->path a vector.
 			//TODO : make define customfolderoption constant
 			if (jb->customfolder & 1) {
-				jb->path[jb->numOfPath] = "LR2files/CustomFolder/RANDOM/";
+				jb->path[jb->numOfPath] = fs::make_preferred("LR2files/CustomFolder/RANDOM/").data();
 				jb->numOfPath++;
 				folderAddCount++;
 			}
 			if (jb->customfolder & 2) {
-				jb->path[jb->numOfPath] = "LR2files/CustomFolder/favorite.lr2folder";
+				jb->path[jb->numOfPath] = fs::make_preferred("LR2files/CustomFolder/favorite.lr2folder").data();
 				jb->numOfPath++;
 				folderAddCount++;
 			}
 			if (jb->customfolder & 4) {
-				jb->path[jb->numOfPath] = "LR2files/CustomFolder/TOP10.lr2folder";
+				jb->path[jb->numOfPath] = fs::make_preferred("LR2files/CustomFolder/TOP10.lr2folder").data();
 				jb->numOfPath++;
 				folderAddCount++;
 			}
 			if (jb->customfolder & 8) {
-				jb->path[jb->numOfPath] = "LR2files/CustomFolder/PLAYLEVEL/";
+				jb->path[jb->numOfPath] = fs::make_preferred("LR2files/CustomFolder/PLAYLEVEL/").data();
 				jb->numOfPath++;
 				folderAddCount++;
 			}
 			if (jb->customfolder & 0x10) {
-				jb->path[jb->numOfPath] = "LR2files/CustomFolder/CLEAR/";
+				jb->path[jb->numOfPath] = fs::make_preferred("LR2files/CustomFolder/CLEAR/").data();
 				jb->numOfPath++;
 				folderAddCount++;
 			}
 			if (jb->customfolder & 0x20) {
-				jb->path[jb->numOfPath] = "LR2files/CustomFolder/RANK/";
+				jb->path[jb->numOfPath] = fs::make_preferred("LR2files/CustomFolder/RANK/").data();
 				jb->numOfPath++;
 				folderAddCount++;
 			}
 			if (jb->customfolder & 0x40) {
-				jb->path[jb->numOfPath] = "LR2files/CustomFolder/ignore.lr2folder";
+				jb->path[jb->numOfPath] = fs::make_preferred("LR2files/CustomFolder/ignore.lr2folder").data();
 				jb->numOfPath++;
 				folderAddCount++;
 			}
 			if (jb->customfolder & 0x80) {
-				jb->path[jb->numOfPath] = "LR2files/CustomFolder/INSANE01/";
+				jb->path[jb->numOfPath] = fs::make_preferred("LR2files/CustomFolder/INSANE01/").data();
 				jb->numOfPath++;
-				jb->path[jb->numOfPath] = "LR2files/CustomFolder/INSANE02/";
+				jb->path[jb->numOfPath] = fs::make_preferred("LR2files/CustomFolder/INSANE02/").data();
 				jb->numOfPath++;
 				folderAddCount+=2;
 				EnabledInsane = 1;
 			}
-			jb->path[jb->numOfPath] = "LR2files/CustomFolder/course1.lr2folder";
+			jb->path[jb->numOfPath] = fs::make_preferred("LR2files/CustomFolder/course1.lr2folder").data();
 			jb->numOfPath++;
-			jb->path[jb->numOfPath] = "LR2files/CustomFolder/course2.lr2folder";
+			jb->path[jb->numOfPath] = fs::make_preferred("LR2files/CustomFolder/course2.lr2folder").data();
 			jb->numOfPath++;
-			jb->path[jb->numOfPath] = "LR2files/CustomFolder/course3.lr2folder";
+			jb->path[jb->numOfPath] = fs::make_preferred("LR2files/CustomFolder/course3.lr2folder").data();
 			jb->numOfPath++;
 			folderAddCount += 3;
 		}
 
 		sqlite3_open(scoreDBpath,&scoreDB);
-		sqlite3_open("LR2files/Database/tag.db", &tagDB);
+		sqlite3_open(fs::make_preferred("LR2files/Database/tag.db").data(), &tagDB);
 		SQL_Run("CREATE TABLE folder(title TEXT ,subtitle TEXT ,category TEXT,info_a TEXT,info_b TEXT,command TEXT,path TEXT primary key,type INTEGER,banner TEXT,parent TEXT,date INTEGER,max INTEGER,adddate INTEGER)", sql);
 		SQL_Run("CREATE TABLE song(hash TEXT ,title TEXT ,subtitle TEXT ,genre TEXT,artist TEXT,subartist TEXT,tag TEXT ,path TEXT primary key ,type INTEGER,folder TEXT,stagefile TEXT,banner TEXT,backbmp TEXT,parent TEXT,level INTEGER,difficulty INTEGER,maxbpm INTEGER,minbpm INTEGER,mode INTEGER,judge INTEGER,longnote INTEGER,bga INTEGER,random INTEGER,date INTEGER,favorite INTEGER,txt INTEGER,karinotes INTEGER,adddate INTEGER,exlevel INTEGER)", sql);
 		SQL_Run("CREATE INDEX hashidx ON song (hash)", sql);
@@ -2561,7 +2562,7 @@ int LoadLR2CustomFolder(sqlite3 *sql, CONFIG_JUKEBOX *jb, CSTR scoreDBpath, char
 			ErrorLogAdd("スコアデータベースの接続に失敗しました。\n");
 			return -1;
 		}
-		if (SQL_Run("ATTACH \'LR2files/Database/tag.db\' AS tagdb", sql) != 0) {
+		if (SQL_Run(fs::make_preferred("ATTACH \'LR2files/Database/tag.db\' AS tagdb").data(), sql) != 0) {
 			ErrorLogAdd("タグとかデータベースの接続に失敗しました。\n");
 			return -1;
 		}
@@ -2623,22 +2624,22 @@ int LoadLR2CustomFolder(sqlite3 *sql, CONFIG_JUKEBOX *jb, CSTR scoreDBpath, char
 		ErrorLogAdd("データベースチェックは終了しました。\n");
 
 		if (flag_starter == 0) {
-			SQL_Run("DELETE FROM folder WHERE path LIKE \'LR2files/Rival/%\'", sql);
+			SQL_Run(fs::make_preferred("DELETE FROM folder WHERE path LIKE \'LR2files/Rival/%\'").data(), sql);
 
 			for (int i = 0; i < 20; i++) {
 				if (jb->rival[i] < 1) break;
-				cstrSprintf(&jb->path[jb->numOfPath], "LR2files/Rival/%d.lr2folder", jb->rival[i]);
+				cstrSprintf(&jb->path[jb->numOfPath], fs::make_preferred("LR2files/Rival/%d.lr2folder").data(), jb->rival[i]);
 				GetFolderDataFromPath(jb->path[jb->numOfPath], sql);
 				jb->numOfPath++;
 				folderAddCount++;
 			}
 
-			SQL_Run("DELETE FROM folder WHERE path=\'LR2files/CustomFolder/newsong.lr2folder\'", sql);
+			SQL_Run(fs::make_preferred("DELETE FROM folder WHERE path=\'LR2files/CustomFolder/newsong.lr2folder\'").data(), sql);
 			sqlite3_snprintf(1024, query, "SELECT * FROM song WHERE adddate > %d", GetNowUnixtime() - jb->titleflash * 3600);
 			sqlite3_stmt *pStmt;
 			SQL_prepare(query, sql, &pStmt);
 			if (sqlite3_step(pStmt) == 100) {
-				jb->path[jb->numOfPath] = "LR2files/CustomFolder/newsong.lr2folder";
+				jb->path[jb->numOfPath] = fs::make_preferred("LR2files/CustomFolder/newsong.lr2folder").data();
 				GetFolderDataFromPath(jb->path[jb->numOfPath], sql);
 				jb->numOfPath++;
 				folderAddCount++;

--- a/LR2/LR2_statlong.cpp
+++ b/LR2/LR2_statlong.cpp
@@ -1,4 +1,5 @@
 ﻿#include "LR2_statlong.h"
+#include "filesystem.h"
 
 #ifndef _WIN32
 #include <iostream>
@@ -35,7 +36,7 @@ int ReadPlayerScore(CSTR id, CSTR pass, PLAYERSTATISTIC *pstat) {
 	sqlite3 *scoreDB;
 	sqlite3_stmt *stmt;
 
-	cstrSprintf(&dbPath, "LR2files/Database/Score/%s.db", id.body);
+	cstrSprintf(&dbPath, fs::make_preferred("LR2files/Database/Score/%s.db").data(), id.body);
 	passMD5 = MD5str(pass);
 	
 	sqlite3_open(dbPath, &scoreDB);

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -322,6 +322,8 @@ int main(int argc, char** argv) {
 		}
 #endif // _WIN32
 
+		// DxLib-for-Linux can only set title of an already existing window
+		if constexpr (!is_linux()) { SetMainWindowText(LR2TITLE); }
 		// DxLib-for-Linux only writes to stderr when writing to the log file.
 		SetOutApplicationLogValidFlag(gs.config.system.outputlog || is_linux());
 #ifdef _WIN32
@@ -343,7 +345,7 @@ int main(int argc, char** argv) {
 		}
 #endif // _WIN32
 		if (DxLib_Init() != -1) {
-			SetMainWindowText(LR2TITLE);
+			if constexpr (is_linux()) { SetMainWindowText(LR2TITLE); }
 			ChangeFont("", 0);
 			SetLogFontSize(14); //DXLIBVER: change this for further dxlib version
 #ifdef _WIN32

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -4,6 +4,7 @@
 #include "Engine.h"
 #include "LR2.h"
 #include "Scenes.h"
+#include "filesystem.h"
 
 #include <chrono>
 #include <filesystem>
@@ -101,7 +102,7 @@ int main(int argc, char** argv) {
 		GetModuleFileName(NULL, (LPCH)curDir, 260);
 		*(char*)(strrchr(curDir, '\\') + 1) = '\x00';
 		SetCurrentDirectory((LPCSTR)curDir);
-		gs.baseDirectory.assign(curDir, 0).add("/");
+		gs.baseDirectory.assign(curDir, 0).add("\\");
 	}
 #else // TODO(utf-8): use this
 	{
@@ -124,7 +125,7 @@ int main(int argc, char** argv) {
 	copy_if_not_exists("LR2files/Config/midi_def.xml", "LR2files/Config/midi.xml");
 	ErrorLogAdd("コンフィグを読み込みます…");
 
-	if (!ReadConfig(&gs, "LR2files/Config/config.xml") && gs.is_starter == false) {
+	if (!ReadConfig(&gs, fs::make_preferred("LR2files/Config/config.xml").data()) && gs.is_starter == false) {
 		MessageBoxA(NULL, "コンフィグファイルが見つかりません。", "エラー", NULL);
 		return -1;
 	}
@@ -153,7 +154,7 @@ int main(int argc, char** argv) {
 		}
 		lr1ir = gs.config.network.lr1ir;
 		lr2ir = gs.config.network.lr2ir;
-		ReadMIDI(&gs, "LR2files/Config/midi.xml");
+		ReadMIDI(&gs, fs::make_preferred("LR2files/Config/midi.xml").data());
 		if (gs.config.system.softwarerendering == 1) {
 			SetUse3DFlag(0);
 		}
@@ -262,10 +263,10 @@ int main(int argc, char** argv) {
 			std::filesystem::create_directories("LR2files/SkinCustomize", ec);
 			std::filesystem::create_directories("screenshot", ec);
 		}
-		ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
+		ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 		gs.is_clicked_screenModeChange = 0;
 		gs.flag_Screenshot = false;
-		ReadOptionstrFile(gs.txtStruct.option_str, "LR2files/Config/optionstr.csv");
+		ReadOptionstrFile(gs.txtStruct.option_str, fs::make_preferred("LR2files/Config/optionstr.csv").data());
 		gs.audio.is_fmod_disabled = gs.config.sound.disablefmod;
 		if (gs.config.sound.disablefmod != 0) {
 			gs.config.select.preview = 0;
@@ -373,7 +374,7 @@ int main(int argc, char** argv) {
 				ErrorLogAdd(gs.net.request_result);
 			}
 
-			loadingGrHandle = LoadGraph("LR2files/Config/loading.bmp", 0);
+			loadingGrHandle = LoadGraph(fs::make_preferred("LR2files/Config/loading.bmp").data(), 0);
 
 			int backgroundGrHandle = MakeScreen(640, 480, 0); //TODO_RESOULUTION
 			SetDrawScreen(backgroundGrHandle);
@@ -381,7 +382,9 @@ int main(int argc, char** argv) {
 			SetDrawScreen(DX_SCREEN_BACK);
 
 			memcpy(gs.config.jukebox.rival, gs.net.rivals, 4 * 20);
-			sqlite3_open(gs.is_starter ? "LR2files/Database.db" : "LR2files/Database/song.db", &sql3);
+			sqlite3_open(gs.is_starter
+					? fs::make_preferred("LR2files/Database.db" ).data()
+					: fs::make_preferred("LR2files/Database/song.db").data(), &sql3);
 			LoadLR2CustomFolder(sql3, &gs.config.jukebox, pathScoreDB, gs.is_starter, gs.cmd_directplay);
 			if ( gs.cmd_directplay == false && gs.config.network.lr2ir == 1 && (((unsigned char)gs.config.jukebox.customfolder & 0x80) != 0)) {
 				gs.net.GetInsaneList();
@@ -579,7 +582,7 @@ int main(int argc, char** argv) {
 			InitSound(&gs.audio,gs.config.sound.bufferlength,gs.config.sound.numbuffers,gs.config.sound.disabledsp,gs.config.sound.output,gs.config.sound.driver);
 			ReadLR2SoundSet(&gs, gs.config.skin.skinFilePath[10], 0);
 			if (gs.is_starter == false) {
-				if (LoadSound(&gs.audio, &gs.gameplay.muon, CSTR("LR2files/Config/muon.wav"), 1, gs.config.sound.disabledsp, 0) == -1) {
+				if (LoadSound(&gs.audio, &gs.gameplay.muon, fs::make_preferred("LR2files/Config/muon.wav").data(), 1, gs.config.sound.disabledsp, 0) == -1) {
 					ErrorLogAdd("muon.wavがありません\n");
 					gs.procSelecter = 0;
 				}
@@ -708,7 +711,9 @@ int main(int argc, char** argv) {
 								memcpy(&gs.config.play, &gs.gameplay.targetCfg, sizeof(CONFIG_PLAY));
 							}
 							gs.gameplay.ghostBattle = '\0';
-							ReadKeyConfig(&gs, (gs.config.select.control == 0) ? "LR2files/Config/keyconfig.xml" : "LR2files/Config/keyconfig_p.xml");
+							ReadKeyConfig(&gs, (gs.config.select.control == 0)
+									? fs::make_preferred("LR2files/Config/keyconfig.xml" ).data()
+									: fs::make_preferred("LR2files/Config/keyconfig_p.xml").data());
 							DeleteGraph(gs.skstruct.GrHandle[GrH_Stage]);
 							gs.skstruct.GrHandle[GrH_Stage] = -1;
 							DeleteGraph(gs.skstruct.GrHandle[GrH_BackBMP]);
@@ -899,13 +904,13 @@ int main(int argc, char** argv) {
 								if (gs.sSelect.bmsList[gs.sSelect.cur_song].keymode == 5) {
 									LoadSceneG(&gs, &gs.skstruct, 13);
 									if (gs.skinData.Data[gs.skinData.skinID[13]].type != SKINTYPE_7KEYSBATTLE)
-										ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
+										ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 									else 
-										ReadKeyConfig(&gs, "LR2files/Config/keyconfig_5.xml");
+										ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig_5.xml").data());
 								}
 								else {
 									LoadSceneG(&gs, &gs.skstruct, 12);
-									ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
+									ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 								}
 							}
 							else if (gs.config.select.control == 1 && (gs.sSelect.metaSelected.keymode == 5 || gs.sSelect.metaSelected.keymode == 7)) {
@@ -915,7 +920,7 @@ int main(int argc, char** argv) {
 								else if (gs.config.play.battle == 1) {
 									LoadSceneG(&gs, &gs.skstruct, 14);
 								}
-								ReadKeyConfig(&gs,"LR2files/Config/keyconfig_p.xml");
+								ReadKeyConfig(&gs,fs::make_preferred("LR2files/Config/keyconfig_p.xml").data());
 							}
 							else {
 								switch (gs.sSelect.metaSelected.keymode) {
@@ -923,23 +928,23 @@ int main(int argc, char** argv) {
 										if (gs.config.play.battle == 0) {
 											LoadSceneG(&gs, &gs.skstruct, 1);
 											if (gs.skinData.Data[gs.skinData.skinID[1]].type != SKINTYPE_5KEYS)
-												ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
+												ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 											else
-												ReadKeyConfig(&gs, "LR2files/Config/keyconfig_5.xml");
+												ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig_5.xml").data());
 										}
 										else if (gs.config.play.battle == 1) {
 											LoadSceneG(&gs, &gs.skstruct, 13);
 											if (gs.skinData.Data[gs.skinData.skinID[13]].type != SKINTYPE_7KEYSBATTLE)
-												ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
+												ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 											else
-												ReadKeyConfig(&gs, "LR2files/Config/keyconfig_5.xml");
+												ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig_5.xml").data());
 										}
 										else if (gs.config.play.battle == 2 || gs.config.play.battle == 3) {
 											LoadSceneG(&gs, &gs.skstruct, 3);
 											if (gs.skinData.Data[gs.skinData.skinID[3]].type != SKINTYPE_10KEYS)
-												ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
+												ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 											else
-												ReadKeyConfig(&gs, "LR2files/Config/keyconfig_5.xml");
+												ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig_5.xml").data());
 										}
 										break;
 
@@ -953,13 +958,13 @@ int main(int argc, char** argv) {
 										else if (gs.config.play.battle == 2 || gs.config.play.battle == 3) {
 											LoadSceneG(&gs, &gs.skstruct, 2);
 										}
-										ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
+										ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 										break;
 
 									case 9:
 										if (gs.config.play.battle == 3) {
 											LoadSceneG(&gs, &gs.skstruct, 0);
-											ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
+											ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 											break;
 										}
 										else if (gs.config.play.battle == 0 || gs.config.play.battle == 2) {
@@ -968,30 +973,30 @@ int main(int argc, char** argv) {
 										else if (gs.config.play.battle == 1) {
 											LoadSceneG(&gs, &gs.skstruct, 4);
 										}
-										ReadKeyConfig(&gs, "LR2files/Config/keyconfig_p.xml");
+										ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig_p.xml").data());
 										break;
 
 									case 10:
 										if (gs.config.play.battle == 0) {
 											LoadSceneG(&gs, &gs.skstruct, 3);
 											if (gs.skinData.Data[gs.skinData.skinID[3]].type == SKINTYPE_10KEYS)
-												ReadKeyConfig(&gs, "LR2files/Config/keyconfig_5.xml"); 
+												ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig_5.xml").data()); 
 											else
-												ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
+												ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 										}
 										else if (gs.config.play.battle == 1 || gs.config.play.battle == 2) {
 											LoadSceneG(&gs, &gs.skstruct, 13);
 											if (gs.skinData.Data[gs.skinData.skinID[13]].type == SKINTYPE_7KEYSBATTLE)
-												ReadKeyConfig(&gs, "LR2files/Config/keyconfig_5.xml");
+												ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig_5.xml").data());
 											else
-												ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
+												ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 										}
 										else if (gs.config.play.battle == 3) {
 											LoadSceneG(&gs, &gs.skstruct, 1);
 											if (gs.skinData.Data[gs.skinData.skinID[1]].type == SKINTYPE_5KEYS)
-												ReadKeyConfig(&gs, "LR2files/Config/keyconfig_5.xml");
+												ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig_5.xml").data());
 											else
-												ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
+												ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 										}
 										break;
 
@@ -1005,14 +1010,14 @@ int main(int argc, char** argv) {
 										else if(gs.config.play.battle == 3) {
 											LoadSceneG(&gs, &gs.skstruct, 0);
 										}
-										ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
+										ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 										break;
 								}
 							}
 
 							if (gs.config.play.m_lunaris) {
 								LoadSceneG(&gs, &gs.skstruct, 0);
-								ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
+								ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 								gs.gameplay.isAutoplay = 0;
 							}
 							for (int i = 0; i < gs.skstruct.num_of_ImageFont; i++) {
@@ -1041,7 +1046,7 @@ int main(int argc, char** argv) {
 							break;
 						case 8:
 							LoadSceneG(&gs, &gs.skstruct, 0);
-							ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
+							ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 							LUNARIS_START(&gs);
 							break;
 						case 9:
@@ -1107,7 +1112,7 @@ int main(int argc, char** argv) {
 							LoadSceneG(&gs, &gs.skstruct, 18);
 							break;
 						case 11:
-							LoadScene(&gs.skstruct, CSTR("LR2files/event.csv"), 0, 0);
+							LoadScene(&gs.skstruct, fs::make_preferred("LR2files/event.csv").data(), 0, 0);
 							break;
 						case 13:
 							ProcS_CourseResult(&gs,sql3);
@@ -1333,7 +1338,7 @@ int main(int argc, char** argv) {
 							break;
 						case 4: {
 							CSTR skinMD5;
-							cstrSprintf(&skinMD5, "LR2files/SkinCustomize/%s.xml", gs.skstruct.skinMD5.body);
+							cstrSprintf(&skinMD5, fs::make_preferred("LR2files/SkinCustomize/%s.xml").data(), gs.skstruct.skinMD5.body);
 							SkinUser tmpSk;
 							ReadSkinCustomize(&tmpSk, skinMD5);
 							tmpSk.adjust.shift_x = gs.skstruct.adjust.shift_x;
@@ -1393,7 +1398,7 @@ int main(int argc, char** argv) {
 								ErrorLogAdd("BMSの音を初期化しました\n");
 							}
 
-							ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
+							ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 							if (gs.gameplay.replay.status == 2) {
 								ReleaseReplayBuffer(&gs.gameplay.replay);
 								gs.audio.param.eq_gain[0] = gs.gameplay.replay.aud.eq_gain[0];
@@ -1500,7 +1505,7 @@ int main(int argc, char** argv) {
 							}
 							break;
 						case 6:
-							ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
+							ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 							break;
 						case 7:
 							ClearSkinGraph(&gs.skstruct2);
@@ -2207,8 +2212,8 @@ int main(int argc, char** argv) {
 			gs.config.network.lr1ir = lr1ir;
 			gs.config.network.lr2ir = lr2ir;
 			if ( gs.auto2avi == 0 && gs.is_recordmode == 0 && gs.rec.recMode == 0) {
-				WriteConfigXml(&gs, "LR2files/Config/config.xml");
-				WriteMidiXml(&gs, "LR2files/Config/midi.xml");
+				WriteConfigXml(&gs, fs::make_preferred("LR2files/Config/config.xml").data());
+				WriteMidiXml(&gs, fs::make_preferred("LR2files/Config/midi.xml").data());
 			}
 			CloseMIDI();
 			for (int i = 0; i < 6480; i++) {

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -500,12 +500,6 @@ int main(int argc, char** argv) {
 			gs.gameplay.bmsobj_line.noteVal = 0;
 			gs.gameplay.bmsobj_line.autoplay = 0;
 			gs.gameplay.bpmt_buffersize = 0;
-			gs.gameplay.highScore.judge_queue_count = 0;
-			gs.gameplay.highScore.judge_queue = NULL;
-			gs.gameplay.p1Score.judge_queue_count = 0;
-			gs.gameplay.p1Score.judge_queue = NULL;
-			gs.gameplay.targetScore.judge_queue_count = 0;
-			gs.gameplay.targetScore.judge_queue = NULL;
 			gs.gameplay.isCourse = 0;
 			gs.gameplay.isPreviewLoad = 0;
 			gs.gameplay.previewStatus = 0;

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -903,7 +903,7 @@ int main(int argc, char** argv) {
 							if (gs.gameplay.ghostBattle == 1) {
 								if (gs.sSelect.bmsList[gs.sSelect.cur_song].keymode == 5) {
 									LoadSceneG(&gs, &gs.skstruct, 13);
-									if (gs.skinData.Data[gs.skinData.skinID[13]].type != SKINTYPE_7KEYSBATTLE)
+									if (gs.skinData.Data[gs.skinData.skinID[13]].type != SKINTYPE_5KEYSBATTLE)
 										ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 									else 
 										ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig_5.xml").data());
@@ -934,7 +934,7 @@ int main(int argc, char** argv) {
 										}
 										else if (gs.config.play.battle == 1) {
 											LoadSceneG(&gs, &gs.skstruct, 13);
-											if (gs.skinData.Data[gs.skinData.skinID[13]].type != SKINTYPE_7KEYSBATTLE)
+											if (gs.skinData.Data[gs.skinData.skinID[13]].type != SKINTYPE_5KEYSBATTLE)
 												ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 											else
 												ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig_5.xml").data());
@@ -986,7 +986,7 @@ int main(int argc, char** argv) {
 										}
 										else if (gs.config.play.battle == 1 || gs.config.play.battle == 2) {
 											LoadSceneG(&gs, &gs.skstruct, 13);
-											if (gs.skinData.Data[gs.skinData.skinID[13]].type == SKINTYPE_7KEYSBATTLE)
+											if (gs.skinData.Data[gs.skinData.skinID[13]].type == SKINTYPE_5KEYSBATTLE)
 												ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig_5.xml").data());
 											else
 												ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -505,16 +505,12 @@ int main(int argc, char** argv) {
 			gs.gameplay.isCourse = 0;
 			gs.gameplay.isPreviewLoad = 0;
 			gs.gameplay.previewStatus = 0;
-			if (gs.gameplay.hThreadPreview.joinable()) {
-				gs.gameplay.hThreadPreview.join();
-			}
 			gs.gameplay.courseType = -1;
 			gs.gameplay.courseStageNow = 0;
 			gs.gameplay.timetick = GetTimeWrap();
 			gs.gameplay.flag_threadDoingProcGame = 0;
 			InitSkin(&gs.skstruct, 0, 0);
 			gs.skstruct.fontname.assign(&gs.config.skin.fontname);
-			if(gs.hThreadBanner.joinable()) gs.hThreadBanner.join();
 			for (int i = 0; i < 6480; i++) gs.gameplay.keysound->load = 0;
 			for (int i = 0; i < 200; i++) gs.skstruct2.caption[i].fillzero();
 			for (int i = 0; i < 10; i++) gs.skstruct2.helpfilePath[i].fillzero();

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -153,7 +153,6 @@ int main(int argc, char** argv) {
 		}
 		lr1ir = gs.config.network.lr1ir;
 		lr2ir = gs.config.network.lr2ir;
-		gs.flag_showFPS = 0;
 		ReadMIDI(&gs, "LR2files/Config/midi.xml");
 		if (gs.config.system.softwarerendering == 1) {
 			SetUse3DFlag(0);
@@ -265,13 +264,12 @@ int main(int argc, char** argv) {
 		}
 		ReadKeyConfig(&gs, "LR2files/Config/keyconfig.xml");
 		gs.is_clicked_screenModeChange = 0;
-		gs.flag_Screenshot = 0;
+		gs.flag_Screenshot = false;
 		ReadOptionstrFile(gs.txtStruct.option_str, "LR2files/Config/optionstr.csv");
 		gs.audio.is_fmod_disabled = gs.config.sound.disablefmod;
 		if (gs.config.sound.disablefmod != 0) {
 			gs.config.select.preview = 0;
 		}
-		gs.flag_unk420 = 0;
 		SetHPtimerFlag(gs.config.system.hptimer == 1);
 		SetManualTimerFlag(&gs.timer1, 0);
 		gs.timer1.movieFramerate = (double)gs.config.tools.movie_framerate;
@@ -1984,27 +1982,13 @@ int main(int argc, char** argv) {
 						}
 					}
 					gs.timer1.vSyncTick = GetTimeWrap();
-					if (gs.flag_Screenshot == 1) {
-						CSTR captureFilename;
+					if (gs.flag_Screenshot) {
+						gs.flag_Screenshot = false;
 						GetDateTime(&date);
+						CSTR captureFilename;
 						cstrSprintf(&captureFilename, "screenshot/LR2 %04d-%02d-%02d %02d-%02d-%02d.png", date.Year, date.Mon, date.Day, date.Hour, date.Min, date.Sec);
 						SaveDrawScreenToPNG(0, 0, skinSizeX, skinSizeY, captureFilename, -1);
-						gs.flag_Screenshot = 0;
 						PlaySound(&gs.audio, &gs.audio.sysSound.screenshot, gs.audio.chnKey, -1);
-					}
-					else if (gs.flag_Screenshot == 2) {
-						CSTR captureFilename;
-						int scrdraw = MakeGraph(skinSizeX, skinSizeY, 0);
-						GetDrawScreenGraph(0, 0, skinSizeX, skinSizeY, scrdraw, 1);
-						SetDrawMode(1);
-						SetDrawBlendMode(0, 255);
-						DrawExtendGraph(0, 0, skinSizeX/2, skinSizeY/2, scrdraw, 0);
-						GetDateTime(&date);
-						cstrSprintf(&captureFilename, "screenshot/LR2 %04d-%02d-%02d %02d-%02d-%02d.png", date.Year, date.Mon, date.Day, date.Hour, date.Min, date.Sec);
-						SaveDrawScreenToPNG(0, 0, skinSizeX/2, skinSizeY/2, captureFilename, -1);
-						DrawGraph(0, 0, scrdraw, 0);
-						DeleteGraph(scrdraw);
-						gs.flag_Screenshot = 0;
 					}
 
 					if (gs.is_recordmode) {
@@ -2089,7 +2073,7 @@ int main(int argc, char** argv) {
 					EditTag(&gs.sSelect.bmsList[gs.sSelect.cur_song],sql3);
 					gs.sSelect.is_clicked_tagedit = 0;
 					ProcS_Select(&gs);
-					gs.sSelect.is_filter_changed = 1;
+					gs.sSelect.is_filter_changed = true;
 					gs.sSelect.filter_clicked = 4;
 					SetObjectStrings_SongSelect(&gs);
 				}
@@ -2100,7 +2084,7 @@ int main(int argc, char** argv) {
 					gs.sSelect.is_tag_edited = 0;
 					ProcS_Select(&gs);
 					if (gs.sSelect.bmsList[gs.sSelect.cur_song].favorite != 2) {
-						gs.sSelect.is_filter_changed = 1;
+						gs.sSelect.is_filter_changed = true;
 						gs.sSelect.filter_clicked = 4;
 					}
 					SetObjectStrings_SongSelect(&gs);
@@ -2111,7 +2095,7 @@ int main(int argc, char** argv) {
 				}
 				if (gs.sSelect.is_filter_changed) {
 					SetBmsFilter(&gs, sql3);
-					gs.sSelect.is_filter_changed = 0;
+					gs.sSelect.is_filter_changed = false;
 				}
 				if (gs.is_clicked_screenModeChange == 1) {
 					for (int i = 0; i < 200; i++) {

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -2,6 +2,7 @@
 #include "Engine.h"
 #include "LR2.h"
 #include <stdio.h>
+#include "filesystem.h"
 
 #ifndef _WIN32
 #include "En_dxlibstub.h"
@@ -1485,11 +1486,11 @@ void CheckNewSong(glb_dbgame *glb) {
 		if (err) {
 			ErrorLogAdd("未設定の#DIFFICULTYを設定します。\n");
 			SetUndefinedDifficulty(glb->pSql);
-			sqlite3_exec(glb->pSql, "DELETE FROM folder WHERE path=\'LR2files/CustomFolder/newsong.lr2folder\'", 0, 0, 0);
+			sqlite3_exec(glb->pSql, fs::make_preferred("DELETE FROM folder WHERE path=\'LR2files/CustomFolder/newsong.lr2folder\'").data(), 0, 0, 0);
 			sqlite3_snprintf(1024, buf, "SELECT * FROM song WHERE adddate > %d", GetNowUnixtime() - jb.titleflash * 3600);
 			sqlite3_prepare(glb->pSql, buf, -1, &pStmt, NULL);
 			if (sqlite3_step(pStmt) == 100) {
-				jb.path[jb.numOfPath] = "LR2files/CustomFolder/newsong.lr2folder";
+				jb.path[jb.numOfPath] = fs::make_preferred("LR2files/CustomFolder/newsong.lr2folder").data();
 				GetFolderDataFromPath(jb.path[jb.numOfPath], glb->pSql);
 			}
 			sqlite3_finalize(pStmt);
@@ -1544,8 +1545,8 @@ static void ThreadProc_RankingAutoUpdate(game* g) {
 		g->net.rankingData.rivalID = g->sSelect.stack_rivalID[g->sSelect.cur];
 	}
 	CSTR path;
-	if (hash.length() < 50) cstrSprintf(&path, "LR2files/Ir/%s.xml", hash.body);
-	else cstrSprintf(&path, "LR2files/Ir/%s.xml", AssignCRC32(hash).body);
+	if (hash.length() < 50) cstrSprintf(&path, fs::make_preferred("LR2files/Ir/%s.xml").data(), hash.body);
+	else cstrSprintf(&path, fs::make_preferred("LR2files/Ir/%s.xml").data(), AssignCRC32(hash).body);
 	
 	if (path.canOpenFile()) {
 		if (hash.isSame(g->sSelect.bmsList[g->sSelect.cur_song].hash)) {

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1681,6 +1681,8 @@ static void ThreadProc_LoadPreview(game *g) {
 		g->gameplay.previewStatus = 0;
 		g->gameplay.isPreviewLoad = 0;
 	}
+
+	g->gameplay.hThreadPreview.detach(); // Detach ourselves TODO: refactor surrounding code to avoid this
 }
 
 

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1545,7 +1545,7 @@ static void ThreadProc_RankingAutoUpdate(game* g) {
 	}
 	CSTR path;
 	if (hash.length() < 50) cstrSprintf(&path, "LR2files/Ir/%s.xml", hash.body);
-	else cstrSprintf(&path, "LR2files/Ir/%s.xml", hash.makeCRCstr().body);
+	else cstrSprintf(&path, "LR2files/Ir/%s.xml", AssignCRC32(hash).body);
 	
 	if (path.canOpenFile()) {
 		if (hash.isSame(g->sSelect.bmsList[g->sSelect.cur_song].hash)) {

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -3028,6 +3028,7 @@ int SwapBmsList(SONGSELECT *ss){
 
 //444650
 int InitBmsList(SONGSELECT *ss) {
+	// FIXME: 1) move to SONGSELECT constructor 2) move to std::vector. This leaks memory.
 	ss->bmsListSize = 1000;
 	ss->cur = 0;
 	ss->bmsList = (SONGDATA*)malloc(sizeof(SONGDATA) * 1000);

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1848,10 +1848,10 @@ int ProcS_Play(game *g, sqlite3* sql) {
 		if (g->sSelect.metaSelected.keymode == 5 && (g->config.play.battle == 2 || g->config.play.battle == 3) && g->skinData.Data[g->skinData.skinID[3]].type == SKINTYPE_14KEYS) {
 			scratchside = g->skstruct.scratchside_1 + g->skstruct.scratchside_2 * 2;
 		}
-		if (g->sSelect.metaSelected.keymode == 10 && g->config.play.battle == 0 && g->skinData.Data[g->skinData.skinID[13]].type == SKINTYPE_5KEYSBATTLE) {
+		if (g->sSelect.metaSelected.keymode == 10 && g->config.play.battle == 0 && g->skinData.Data[g->skinData.skinID[13]].type == SKINTYPE_7KEYSBATTLE) {
 			scratchside = g->skstruct.scratchside_1 + g->skstruct.scratchside_2 * 2;
 		}
-		if (g->sSelect.metaSelected.keymode == 5 && g->config.play.battle == 1 && g->skinData.Data[g->skinData.skinID[13]].type == SKINTYPE_5KEYSBATTLE) {
+		if (g->sSelect.metaSelected.keymode == 5 && g->config.play.battle == 1 && g->skinData.Data[g->skinData.skinID[13]].type == SKINTYPE_7KEYSBATTLE) {
 			scratchside = g->skstruct.scratchside_1 + g->skstruct.scratchside_2 * 2;
 		}
 		if (g->sSelect.metaSelected.keymode == 5 && g->config.play.battle == 0 && g->skinData.Data[g->skinData.skinID[1]].type == SKINTYPE_7KEYS) {

--- a/LR2/Scene06_Keyconfig.cpp
+++ b/LR2/Scene06_Keyconfig.cpp
@@ -1,6 +1,7 @@
 #include "Scene06_Keyconfig.h"
 #include "LR2_configsave.h"
 #include "LR2_skinobject.h"
+#include "filesystem.h"
 
 //401da0
 int ProcS_Keyconfig(game *g) {
@@ -50,13 +51,13 @@ int ProcI_Keyconfig(game *g) {
 			g->config.input.buttonMap[g->KeyInput.config_button_inMap][g->KeyInput.config_key] = (g->KeyInput.inputID[KEY_INPUT_DELETE] == 1)? 0 : fndkey;
 			PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 			if (g->KeyInput.config_keymode == 0) {
-				WriteKeyConfig(g, "LR2files/Config/keyconfig.xml", 7);
+				WriteKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig.xml").data(), 7);
 			}
 			else if(g->KeyInput.config_keymode == 1){
-				WriteKeyConfig(g, "LR2files/Config/keyconfig_p.xml", 9);
+				WriteKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig_p.xml").data(), 9);
 			}
 			else if (g->KeyInput.config_keymode == 2) {
-				WriteKeyConfig(g, "LR2files/Config/keyconfig_5.xml", 5);
+				WriteKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig_5.xml").data(), 5);
 			}
 			ProcS_Keyconfig(g);
 		}
@@ -66,16 +67,16 @@ int ProcI_Keyconfig(game *g) {
 		memset(g->config.input.buttonMap, 0, 16 * 40 * sizeof(int));
 
 		if (g->KeyInput.config_keymode == 0) {
-			ReadKeyConfig(g, "LR2files/Config/keyconfig_def.xml");
-			WriteKeyConfig(g, "LR2files/Config/keyconfig.xml", 7);
+			ReadKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig_def.xml").data());
+			WriteKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig.xml").data(), 7);
 		}
 		else if (g->KeyInput.config_keymode == 1) {
-			ReadKeyConfig(g, "LR2files/Config/keyconfig_p_def.xml");
-			WriteKeyConfig(g, "LR2files/Config/keyconfig_p.xml", 9);
+			ReadKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig_p_def.xml").data());
+			WriteKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig_p.xml").data(), 9);
 		}
 		else if (g->KeyInput.config_keymode == 2) {
-			ReadKeyConfig(g, "LR2files/Config/keyconfig_5_def.xml");
-			WriteKeyConfig(g, "LR2files/Config/keyconfig_5.xml", 5);
+			ReadKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig_5_def.xml").data());
+			WriteKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig_5.xml").data(), 5);
 		}
 		ProcS_Keyconfig(g);
 	}

--- a/LR2/Scene07_Skinselect.cpp
+++ b/LR2/Scene07_Skinselect.cpp
@@ -331,7 +331,7 @@ int PlayPreviewSample(game *g) {
 		scratchSide = g->skstruct2.scratchside_1 + g->skstruct2.scratchside_2 * 2;
 	if (g->skinData.select == 1 && g->skinData.Data[g->skinData.skinID[1]].type == SKINTYPE_7KEYS)
 		scratchSide = g->skstruct2.scratchside_1 + g->skstruct2.scratchside_2 * 2;
-	if (g->skinData.select == 13 && g->skinData.Data[g->skinData.skinID[13]].type == SKINTYPE_5KEYSBATTLE)
+	if (g->skinData.select == 13 && g->skinData.Data[g->skinData.skinID[13]].type == SKINTYPE_7KEYSBATTLE)
 		scratchSide = g->skstruct2.scratchside_1 + g->skstruct2.scratchside_2 * 2;
 	ProcS_Select(g);
 	ReleaseBGA(g);
@@ -383,7 +383,7 @@ int PlayPreviewSample(game *g) {
 			break;
 
 		case 13:
-			if (g->skinData.Data[g->skinData.skinID[13]].type == SKINTYPE_5KEYSBATTLE)
+			if (g->skinData.Data[g->skinData.skinID[13]].type == SKINTYPE_7KEYSBATTLE)
 				ReadKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 			else
 				ReadKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig_5.xml").data());
@@ -504,8 +504,8 @@ int SkinPreviewNext(SkinManage *sm, SKINTYPE type){
 				return 1;
 			}
 		}
-		else if (type == SKINTYPE_7KEYSBATTLE) {
-			if (newType == SKINTYPE_5KEYSBATTLE) {
+		else if (type == SKINTYPE_5KEYSBATTLE) {
+			if (newType == SKINTYPE_7KEYSBATTLE) {
 				sm->previewID = i;
 				return 1;
 			}
@@ -530,8 +530,8 @@ int SkinPreviewNext(SkinManage *sm, SKINTYPE type){
 				return 1;
 			}
 		}
-		else if (type == SKINTYPE_7KEYSBATTLE) {
-			if (newType == SKINTYPE_5KEYSBATTLE) {
+		else if (type == SKINTYPE_5KEYSBATTLE) {
+			if (newType == SKINTYPE_7KEYSBATTLE) {
 				sm->previewID = i;
 				return 1;
 			}
@@ -567,8 +567,8 @@ int SkinPreviewPrev(SkinManage *sm, SKINTYPE type) {
 				return 1;
 			}
 		}
-		else if (type == SKINTYPE_7KEYSBATTLE) {
-			if (newType == SKINTYPE_5KEYSBATTLE) {
+		else if (type == SKINTYPE_5KEYSBATTLE) {
+			if (newType == SKINTYPE_7KEYSBATTLE) {
 				sm->previewID = i;
 				return 1;
 			}
@@ -593,8 +593,8 @@ int SkinPreviewPrev(SkinManage *sm, SKINTYPE type) {
 				return 1;
 			}
 		}
-		else if (type == SKINTYPE_7KEYSBATTLE) {
-			if (newType == SKINTYPE_5KEYSBATTLE) {
+		else if (type == SKINTYPE_5KEYSBATTLE) {
+			if (newType == SKINTYPE_7KEYSBATTLE) {
 				sm->previewID = i;
 				return 1;
 			}

--- a/LR2/Scene07_Skinselect.cpp
+++ b/LR2/Scene07_Skinselect.cpp
@@ -2,6 +2,8 @@
 #include "LR2.h"
 #include "Scenes.h"
 
+#include "filesystem.h"
+
 //4198d0
 int SkinSelect_SoundSet(game *g, CSTR filepath) {
 	
@@ -313,7 +315,7 @@ int MakeSkinPreview(game* g, skstruct* sk, SkinManage* sm) {
 		g->skstruct2.op[900 + i] = 0;
 	}
 	DeleteGraph(sk->GrHandle[GrH_Stage]);
-	sk->GrHandle[GrH_Stage] = LoadGraph("LR2files/Config/title.bmp", 0);
+	sk->GrHandle[GrH_Stage] = LoadGraph(fs::make_preferred("LR2files/Config/title.bmp").data(), 0);
 	LoadScene(sk, sm->Data[sm->previewID].skinFile, 0, 1);
 	return 0;
 }
@@ -335,60 +337,60 @@ int PlayPreviewSample(game *g) {
 	ReleaseBGA(g);
 	switch (g->skinData.select) {
 		default: //case 0:?
-			ReadKeyConfig(g, "LR2files/Config/keyconfig.xml");
+			ReadKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 			g->sSelect.metaSelected.keymode = 7;
 			InitGameplay(&g->gameplay, &tCfg.play);
-			ParseBmsFile(&g->gameplay, "LR2files/Config/sample_7.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
-			LoadBmsResource(&g->gameplay, "LR2files/Config/sample_7.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
+			ParseBmsFile(&g->gameplay, fs::make_preferred("LR2files/Config/sample_7.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
+			LoadBmsResource(&g->gameplay, fs::make_preferred("LR2files/Config/sample_7.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
 			break;
 
 		case 1:
 			if (g->skinData.Data[g->skinData.skinID[1]].type == SKINTYPE_7KEYS) 
-				ReadKeyConfig(g, "LR2files/Config/keyconfig.xml");
+				ReadKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 			else 
-				ReadKeyConfig(g, "LR2files/Config/keyconfig_5.xml");
+				ReadKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig_5.xml").data());
 			g->sSelect.metaSelected.keymode = 5;
 			InitGameplay(&g->gameplay, &tCfg.play);
-			ParseBmsFile(&g->gameplay, "LR2files/Config/sample_5.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
-			LoadBmsResource(&g->gameplay, "LR2files/Config/sample_5.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
+			ParseBmsFile(&g->gameplay, fs::make_preferred("LR2files/Config/sample_5.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
+			LoadBmsResource(&g->gameplay, fs::make_preferred("LR2files/Config/sample_5.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
 			break;
 
 		case 2:
-			ReadKeyConfig(g, "LR2files/Config/keyconfig.xml");
+			ReadKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 			g->sSelect.metaSelected.keymode = 14;
 			InitGameplay(&g->gameplay, &tCfg.play);
-			ParseBmsFile(&g->gameplay, "LR2files/Config/sample_14.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
-			LoadBmsResource(&g->gameplay, "LR2files/Config/sample_14.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
+			ParseBmsFile(&g->gameplay, fs::make_preferred("LR2files/Config/sample_14.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
+			LoadBmsResource(&g->gameplay, fs::make_preferred("LR2files/Config/sample_14.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
 			break;
 
 		case 3:
 			if (g->skinData.Data[g->skinData.skinID[3]].type == SKINTYPE_14KEYS)
-				ReadKeyConfig(g, "LR2files/Config/keyconfig.xml");
+				ReadKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 			else
-				ReadKeyConfig(g, "LR2files/Config/keyconfig_5.xml");
+				ReadKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig_5.xml").data());
 			g->sSelect.metaSelected.keymode = 10;
 			InitGameplay(&g->gameplay, &tCfg.play);
-			ParseBmsFile(&g->gameplay, "LR2files/Config/sample_10.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
-			LoadBmsResource(&g->gameplay, "LR2files/Config/sample_10.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
+			ParseBmsFile(&g->gameplay, fs::make_preferred("LR2files/Config/sample_10.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
+			LoadBmsResource(&g->gameplay, fs::make_preferred("LR2files/Config/sample_10.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
 			break;
 
 		case 4:
-			ReadKeyConfig(g, "LR2files/Config/keyconfig_p.xml");
+			ReadKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig_p.xml").data());
 			g->sSelect.metaSelected.keymode = 9;
 			InitGameplay(&g->gameplay, &tCfg.play);
-			ParseBmsFile(&g->gameplay, "LR2files/Config/sample_9.pms", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
-			LoadBmsResource(&g->gameplay, "LR2files/Config/sample_9.pms", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
+			ParseBmsFile(&g->gameplay, fs::make_preferred("LR2files/Config/sample_9.pms").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
+			LoadBmsResource(&g->gameplay, fs::make_preferred("LR2files/Config/sample_9.pms").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
 			break;
 
 		case 13:
 			if (g->skinData.Data[g->skinData.skinID[13]].type == SKINTYPE_5KEYSBATTLE)
-				ReadKeyConfig(g, "LR2files/Config/keyconfig.xml");
+				ReadKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 			else
-				ReadKeyConfig(g, "LR2files/Config/keyconfig_5.xml");
+				ReadKeyConfig(g, fs::make_preferred("LR2files/Config/keyconfig_5.xml").data());
 			g->sSelect.metaSelected.keymode = 5;
 			InitGameplay(&g->gameplay, &tCfg.play);
-			ParseBmsFile(&g->gameplay, "LR2files/Config/sample_5.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
-			LoadBmsResource(&g->gameplay, "LR2files/Config/sample_5.bme", &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
+			ParseBmsFile(&g->gameplay, fs::make_preferred("LR2files/Config/sample_5.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
+			LoadBmsResource(&g->gameplay, fs::make_preferred("LR2files/Config/sample_5.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
 			break;
 	}
 
@@ -438,7 +440,7 @@ int ProcS_SkinSelect(game *g) {
 	int &n = d.previewID;
 	SkinHeader &skd = d.Data[n];
 
-	cstrSprintf(&path, "LR2files/SkinCustomize/%s.xml", MD5str(skd.skinFile));
+	cstrSprintf(&path, fs::make_preferred("LR2files/SkinCustomize/%s.xml").data(), MD5str(skd.skinFile));
 	ReadSkinCustomize(&sku, path);
 
 	for (int i = 0; i < 20; i++) {

--- a/LR2/Scene11_Po4select.cpp
+++ b/LR2/Scene11_Po4select.cpp
@@ -12,7 +12,6 @@ void ThreadProc_PO4parseBMS(game *g) {
 	InitGameplay(&g->gameplay, &g->config.play);
 	
 	ParseBmsFile(&g->gameplay, g->sSelect.metaSelected.filepath, &g->audio, &g->config, &g->sSelect.metaSelected, g->skstruct.flag_BGA, 0);
-	g->po4_hThread_ParseBMS = 0;
 	g->gameplay.bmsResourceLoaded = 1;
 	return;
 }
@@ -28,7 +27,6 @@ int ProcI_PO4Select(game *g, sqlite3 *sql) { //not tested
 		g->po4_unk23d88 = 0;
 		g->po4flagSceneStart = '\x01';
 		g->po4flagSceneEnd = '\0';
-		g->po4_hThread_ParseBMS = 0;
 		g->sSelect.listCalculatedBar = 0;
 		g->sSelect.barMoveStartTime = GetTimeWrap();
 		g->sSelect.barMoveEndTime = GetTimeWrap();
@@ -394,7 +392,6 @@ int ProcI_PO4Select(game *g, sqlite3 *sql) { //not tested
 					SetTimeLapse(15, &g->timer1);
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 				}
-				g->po4_23da9 = 1;
 				break;
 			}
 

--- a/LR2/filesystem.h
+++ b/LR2/filesystem.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <filesystem>
+
+namespace fs {
+
+// \param in Null-terminated string
+template <std::size_t N>
+[[nodiscard]] consteval auto make_preferred(const char (&in)[N]) {
+	std::array<char, N> out{};
+	std::copy(in, in + N, out.data());
+	for (auto &c : out) {
+		if (c == '/' || c == '\\') {
+			c = std::filesystem::path::preferred_separator;
+		}
+	}
+	return out;
+}
+
+} // namespace fs

--- a/LR2/strclass.cpp
+++ b/LR2/strclass.cpp
@@ -488,9 +488,7 @@ bool CSTR::canOpenFile() {
 
 //43b630
 CSTR::CSTR() {
-	body = NULL;
 	body = (char *)calloc(1, 0x40);
-	return;
 }
 
 //43b650 copy construct

--- a/LR2/strclass.cpp
+++ b/LR2/strclass.cpp
@@ -534,39 +534,6 @@ CSTR::CSTR(const char *str, int len) {
 	}
 }
 
-//43b730
-CSTR CSTR::makeCRCstr() {
-	char cVar1;
-	char* str;
-	DWORD dVar2;
-	int pcVar3;
-	char* CVar4;
-	char *pstr;
-	char* local_4;
-	char* ret;
-
-	local_4 = (char *)calloc(1, 0x40);
-	dVar2 = CRC32();
-	sprintf(local_4, "%x", dVar2);
-	str = local_4;
-	if (local_4 == NULL) {
-		return (char*)calloc(1, 0x40);
-	}
-	CVar4 = local_4;
-	do {
-		cVar1 = *CVar4;
-		CVar4 = CVar4 + 1;
-	} while (cVar1 != '\0');
-	pcVar3 = CVar4 - (local_4 + 1);
-	pstr = (char *)calloc(1, (size_t)(pcVar3 + 1));
-	ret = pstr;
-	if (pstr != (char *)0x0) {
-		strncpy(pstr, (char *)str, pcVar3);
-	}
-	free((void *)str);
-	return ret;
-}
-
 //43b7e0
 CSTR& CSTR::assign(const char *str, int len) {
 	if (str == NULL) {

--- a/LR2/strclass.h
+++ b/LR2/strclass.h
@@ -59,4 +59,9 @@ class CSTR {
 		CSTR& trimWhiteSpace();
 		CSTR getFilename();
 };
-char * cstrSprintf(CSTR *str, const char *format, ...);
+
+char *cstrSprintf(CSTR *str, const char *format, ...)
+#ifndef _MSC_VER
+	__attribute__((format(printf, 2, 3)))
+#endif // _MSC_VER
+	;

--- a/LR2/strclass.h
+++ b/LR2/strclass.h
@@ -44,7 +44,6 @@ class CSTR {
 		CSTR();
 		CSTR(const CSTR &copy, int len = 0);
 		CSTR(const char *str, int len = 0);
-		CSTR makeCRCstr();
 		CSTR& assign(const char *str, int len);
 		int icmp(CSTR *param_1);
 		CSTR left (int len);

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1368,7 +1368,7 @@ struct NETWORK {
 	CSTR IR_passMD5;
 	CSTR IR_name;
 	int IR_ID{0};
-	int rivals[20];
+	int rivals[20]{};
 	int rivalcount{};
 	int getrival{};
 	CSTR domain = "www.dream-pro.info";

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1138,18 +1138,17 @@ struct PLAYERSTATUS {
 
 struct PLAYSCORE {
 	CSTR name;
-	char * judge_queue;
-	int judge_queue_count;
-	int ghostReadCount;
-	int judgecount;
-	int nownote;
-	int totalnotes;
-	int judgeExpect[6];
-	int judge[6];
-	int rate;
-	int exscore;
+	char* judge_queue{};
+	int judge_queue_capacity{};
+	int ghostReadCount{};
+	int judge_queue_len{};
+	int nownote{};
+	int totalnotes{};
+	int judgeExpect[6]{};
+	int judge[6]{};
+	int rate{};
+	int exscore{};
 
-	PLAYSCORE();
 	int InitJudgeQueue(void);
 	int ResetJudgeQueue(int size);
 	int ResizeJudgeQueue(size_t size);

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -980,15 +980,15 @@ struct SONGSELECT {
 	CSTR newsongfolder;
 	int panel_unk;
 	int panel;
-	char is_mouseOnSongBars;
-	char is_mouseOnSelected;
-	char is_mouseOnTextInput;
-	char is_filter_changed;
-	char is_clicked_filter;
-	char is_coursemaking_done; /* and tag edit */
-	char is_clicked_autoplay_replay;
-	char is_clicked_keyconfig;
-	char is_clicked_skinselect;
+	bool is_mouseOnSongBars;
+	bool is_mouseOnSelected;
+	bool is_mouseOnTextInput;
+	bool is_filter_changed;
+	bool is_clicked_filter;
+	bool is_coursemaking_done; /* and tag edit */
+	bool is_clicked_autoplay_replay;
+	bool is_clicked_keyconfig;
+	bool is_clicked_skinselect;
 	CSTR playerPassMD5;
 	CSTR playerID;
 	char is_clicked_tagedit;
@@ -1421,8 +1421,6 @@ struct game {
 	int po4sceneFadeout;
 	int po4cur_song;
 	char po4_23da8;
-	char po4_23da9;
-	int po4_hThread_ParseBMS;
 	int po4MainMenuCursor;
 	int procSelecter; /* 2:select 3:deciide 4:play 5:result 6:keyconfig 7:skinselect */
 	int procPhase;
@@ -1430,9 +1428,8 @@ struct game {
 	struct gameplay gameplay;
 	char is_clicked_screenModeChange;
 	int isSkipDrawTick; /* skip frame? */
-	int flag_Screenshot; /* char */
-	char flag_unk420;
-	char flag_showFPS;
+	bool flag_Screenshot{};
+	bool flag_showFPS{};
 	char cmd_nosave;
 	int cmd_directplay;
 	char cmd_auto;

--- a/SkinEditor/winWorkspace.cpp
+++ b/SkinEditor/winWorkspace.cpp
@@ -283,7 +283,7 @@ int WORKSPACE::drawCustomize() {
     for (int i = 0; i < meta.custom_count; i++) {
         SkinCustom& cu = meta.customs[i];
 
-        ImGui::Text("%s", cu.title);
+        ImGui::TextUnformatted(cu.title);
         ImGui::SameLine();
         
         char item[64];
@@ -401,9 +401,9 @@ int WORKSPACE::drawTextEdit() {
                 {
                     ImGui::TableSetColumnIndex(column);
                     if(read.csv.str[column].atPos(0) == nullptr)
-                        ImGui::TextDisabled("%s", read.csv.str[column]);
+                        ImGui::TextDisabled("%s", read.csv.str[column].body);
                     else
-                        ImGui::Text("%s", read.csv.str[column]);
+                        ImGui::TextUnformatted(read.csv.str[column]);
                 }
                 ImGui::EndTable();
             }


### PR DESCRIPTION
Some bugfixes, notably crash fix when pressing keys in play, and small refactors other than ghost DB refactor.
43b628d2eb57fa2b261a2ebb3e1203a6aed37722 shows how to bind data correctly instead of formatting query strings by hand (ignoring UTF-8 conversion, not needed for ghost specifically), which is a bad practice and was one of the reasons for the score saving bug in last release.