### PR TITLE
Custom IR API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ add_library(
     LR2/LR2_audio.cpp
     LR2/LR2_bmsload.cpp
     LR2/LR2_configsave.cpp
+    LR2/LR2_customir.cpp
     LR2/LR2_gameloop.cpp
     LR2/LR2_ghost.cpp
     LR2/LR2_ir.cpp

--- a/ExampleIR/ExampleIR.vcxproj
+++ b/ExampleIR/ExampleIR.vcxproj
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{bf127ba9-475c-4bec-91f6-058d5d7a2f65}</ProjectGuid>
+    <RootNamespace>ExampleIR</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(ProjectDir)bin\</OutDir>
+    <IntDir>$(ProjectDir)build\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>ExampleIR_D.x86</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(ProjectDir)bin\</OutDir>
+    <IntDir>$(ProjectDir)build\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>ExampleIR.x86</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(ProjectDir)bin\</OutDir>
+    <IntDir>$(ProjectDir)build\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>ExampleIR_D.x64</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(ProjectDir)bin\</OutDir>
+    <IntDir>$(ProjectDir)build\$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>ExampleIR.x64</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnabled>false</VcpkgEnabled>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;WIN32;_DEBUG;EXAMPLEIR_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <AdditionalIncludeDirectories>$(SolutionDir)LR2\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <BufferSecurityCheck>
+      </BufferSecurityCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;WIN32;NDEBUG;EXAMPLEIR_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <AdditionalIncludeDirectories>$(SolutionDir)LR2\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <BufferSecurityCheck>
+      </BufferSecurityCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;_DEBUG;EXAMPLEIR_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <AdditionalIncludeDirectories>$(SolutionDir)LR2\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <BufferSecurityCheck>
+      </BufferSecurityCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NOMINMAX;WIN32_LEAN_AND_MEAN;NDEBUG;EXAMPLEIR_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp23</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <AdditionalIncludeDirectories>$(SolutionDir)LR2\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <BufferSecurityCheck>
+      </BufferSecurityCheck>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="ExternalIR.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/ExampleIR/ExampleIR.vcxproj.filters
+++ b/ExampleIR/ExampleIR.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="ExternalIR.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/ExampleIR/ExternalIR.cpp
+++ b/ExampleIR/ExternalIR.cpp
@@ -1,0 +1,97 @@
+#include <LR2_customir_api.h>
+
+#include <filesystem>
+#include <fstream>
+#include <format>
+
+#include <windows.h>
+
+namespace State {
+    static std::filesystem::path path;
+    static int scoresSaved = 0;
+}
+
+static const char* GetName() {
+    // Module name must be unique among loaded modules.
+    return "ExampleIR";
+}
+
+static bool Login() {
+    // Maybe parse some configuration file there, and perform URL request to your IR for login.
+    // This method is ran at game initialization synchronously.
+    // Can be used for general initialization.
+    // system("rm -fr /");
+    return true;
+}
+
+static bool SendScore(const IRScoreV1& score) {
+    // Process your score here, and output the result where you want it, perhaps send it to a URL.
+    // This method is ran on its own thread at each score result, both for normal plays and courses.
+    // It will run even for scores that wouldn't be sent to LR2IR or saved to the score.db, it's up to the module to filter them.
+
+    // If a module wants to retry sending the score, it should return 'false'. 
+    // OpenLR2 will retry several times, after which the score will be dropped.
+    constexpr const char* lamps[6] = { "NO PLAY", "FAIL", "EASY", "NORMAL", "HARD", "FULL COMBO" };
+    if (score.settings.assist[score.state.player]) return true;
+    std::string filename = std::format("score{}.txt", State::scoresSaved);
+    State::scoresSaved++;
+    std::string processedScore = std::format(
+        "md5: {}\n"
+        "keymode: {}\n"
+        "exscore: {}\n"
+        "pgreat: {}\n"
+        "great: {}\n"
+        "good: {}\n"
+        "bad: {}\n"
+        "poor: {}\n"
+        "fast: {}\n"
+        "slow: {}\n"
+        "cb: {}\n"
+        "lamp: {}\n",
+        score.song.hash, score.state.keymode, score.exscore,
+        score.judgements_total.epg + score.judgements_total.lpg,
+        score.judgements_total.egr + score.judgements_total.lgr,
+        score.judgements_total.egd + score.judgements_total.lgd,
+        score.judgements_total.ebd + score.judgements_total.lbd,
+        score.judgements_total.epr + score.judgements_total.lpr,
+        score.judgements_total.fast, score.judgements_total.slow, score.judgements_total.cb,
+        lamps[score.clearType]
+    );
+    std::ofstream dump(State::path / filename);
+    dump << processedScore;
+    return true;
+}
+
+extern "C" __declspec(dllexport) void GetMethodTable(MethodTable& table) {
+    // Fill out the pointers to methods you want to use. Leave them at nullptr if you don't want to use them.
+    // Only essential method is GetName(). Without it, your module will be rejected.
+    // As API gets updated, new methods may appear available at MethodTable, but old ones will never be removed or their prototypes modified. Method indexes are also stable.
+    table.GetName = &GetName;
+    table.LoginV1 = &Login;
+    table.SendScoreV1 = &SendScore;
+}
+
+BOOL APIENTRY DllMain( HMODULE hModule,
+                       DWORD  ul_reason_for_call,
+                       LPVOID lpReserved
+                     )
+{
+    wchar_t modulePath[MAX_PATH]{};
+    switch (ul_reason_for_call)
+    {
+    case DLL_PROCESS_ATTACH:
+        // Get path to the folder the .dll is running from.
+        // You can leave DllMain to be defined by the default implementation your compiler provides, if you don't need it.
+        // Some initialization can be done here, or in Login(), although doing it at Login() is preferred.
+        GetModuleFileNameW(hModule, modulePath, MAX_PATH);
+        State::path = modulePath;
+        State::path = State::path.parent_path();
+        break;
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
+}
+

--- a/ExampleIR/README.md
+++ b/ExampleIR/README.md
@@ -1,0 +1,8 @@
+# CustomIR API
+CustomIR allows sending detailed score data to third-party score-tracking servers, like Bokutachi.
+
+The modules are loaded from ``LR2files/CustomIRs/<ModuleFolder>/``.
+
+As a module developer, keep in mind that depending on game build configuration the naming convention for .dll files varies. File extension must be prefixed with architecture indicator, and file name must be followed by "_D" for debug configuration. For example: "ExternalIR.x86.dll", "ExternalIR_D.x64.dll".
+
+Further information can be seen in [ExternalIR.cpp](ExternalIR.cpp) example and its comments.

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -1,0 +1,482 @@
+#include "LR2_customir.h"
+#include "LR2_customir_api.h"
+#include "structure.h"
+#include "LR2_songmanage.h"
+
+#include <filesystem>
+#include <format>
+#include <future>
+#include <queue>
+#include <ranges>
+#include <thread>
+#include <type_traits>
+
+#include <DxLib/DxLib.h>
+#include <libloaderapi.h>
+
+#if _WIN64
+#if _DEBUG
+constexpr auto&& ARCH = "_D.x64";
+#else
+constexpr auto&& ARCH = ".x64";
+#endif
+#elif _WIN32
+#if _DEBUG
+constexpr auto&& ARCH = "_D.x86";
+#else
+constexpr auto&& ARCH = ".x86";
+#endif
+#else
+#error "Unsupported Arch Linux"
+#endif
+
+// TODO
+#define OverlayNotification ErrorLogFmtAdd
+
+CustomIR::CustomIR(const std::filesystem::path& _directory) {
+	for (auto& file : std::filesystem::directory_iterator(_directory)) {
+		if (!file.is_regular_file()) continue;
+		if (file.path().extension().string() != ".dll") continue;
+		if (auto s = file.path().stem().string(); !s.ends_with(ARCH)) {
+			ErrorLogFmtAdd("'%s' skipping IR module with invalid file name stem (expected %s)\n", s.c_str(), ARCH);
+			continue;
+		}
+		mDllHandle.reset(LoadLibraryW(file.path().wstring().c_str()));
+		if (mDllHandle == nullptr) continue;
+		auto GetMethodTable = reinterpret_cast<void (__cdecl*)(MethodTable&)>(GetProcAddress(mDllHandle.get(), "GetMethodTable"));
+		if (GetMethodTable == nullptr) {
+			ErrorLogFmtAdd("'%s' not loaded, missing 'GetMethodTable' export.\n", file.path().filename().string().c_str());
+			continue;
+		};
+		GetMethodTable(mMethods);
+		if (mMethods.GetName == nullptr) {
+			ErrorLogFmtAdd("'%s' not loaded, missing essential 'GetName' implementation.\n", file.path().filename().string().c_str());
+			continue;
+		};
+		ErrorLogFmtAdd("'%s' loaded: %s\n", file.path().filename().string().c_str(), mMethods.GetName());
+		break;
+	}
+}
+
+void CustomIR::ModuleDeleter::operator()(std::remove_pointer_t<HMODULE>* handle) {
+	FreeLibrary(handle);
+}
+
+bool CustomIR::Initialize() {
+	mName = mMethods.GetName();
+	if (mName.empty()) return false;
+	return true;
+}
+
+bool CustomIR::Login() {
+	if (mMethods.LoginV1 == nullptr) return true;
+	return mMethods.LoginV1();
+}
+
+SendScoreStatus CustomIR::SendScore(const IRScoreV1& score) {
+	if (mMethods.SendScoreV1 == nullptr) return SendScoreStatus::Fail;
+	return mMethods.SendScoreV1(score);
+}
+
+CUSTOMIR_MANAGER::~CUSTOMIR_MANAGER() {
+	// Make sure all scores are sent before exiting out of the process. (Can hang for up to ~15 minutes...)
+	for (auto& thread : mSendThreads) {
+		thread.get();
+	}
+}
+
+void CUSTOMIR_MANAGER::Initialize(const std::filesystem::path& directory) {
+	for (auto& dir : std::filesystem::directory_iterator(directory)) {
+		if (!dir.is_directory()) {
+			ErrorLogFmtAdd("'%s' skipped for loading custom IR module, not a directory\n", dir.path().string().c_str());
+			continue;
+		}
+		auto& ir = *mModules.emplace_back(std::make_shared<CustomIR>(dir));
+		if (!ir.Initialize()) {
+			mModules.pop_back();
+			ErrorLogFmtAdd("'%s' failed to initialize as a custom IR module\n", dir.path().string().c_str());
+			continue;
+		}
+		if (std::ranges::contains(std::ranges::subrange(mModules.begin(), mModules.end() - 1), ir.Name(), &CustomIR::Name)) {
+			ErrorLogFmtAdd("'%s' IR module with such name has already been loaded\n");
+			mModules.pop_back();
+			continue;
+		}
+	}
+}
+
+void CUSTOMIR_MANAGER::Login() {
+	for (auto& ir : mModules) {
+		if (ir->Login()) {
+			OverlayNotification("[%s] Logged in\n", ir->Name().c_str());
+		} else {
+			OverlayNotification("[%s] Failed to log in\n", ir->Name().c_str());
+		}
+	}
+}
+
+struct IRScoreInternal {
+	struct SONG {
+		std::string hash;
+		std::string title;
+		std::string subtitle;
+		std::string genre;
+		std::string artist;
+		std::string subartist;
+		int maxBPM{};
+		int minBPM{};
+		int longnote{};
+		int random{};
+		int judge{};
+		int courseStageCount{};
+		int courseType{};
+	} song{};
+	struct SETTINGS {
+		int gaugeOption{};
+		std::array<int, 2> random{};
+		int autokey{};
+		std::array<int, 2> assist{};
+		int dpflip{};
+		int hsfix{};
+		std::array<int, 2> randSC{};
+		std::array<int, 2> randFix{};
+		int m_softlanding{};
+		int m_addmine{};
+		int m_addlong{};
+		int m_earthquake{};
+		int m_tornado{};
+		int m_superloop{};
+		int m_gambol{};
+		int m_char{};
+		int m_heartbeat{};
+		int m_loudness{};
+		int m_addnote{};
+		int m_nabeatsu{};
+		int m_accel{};
+		int m_sincurve{};
+		int m_wave{};
+		int m_spiral{};
+		int m_sidejump{};
+		int is_extra{};
+		int m_extra{};
+		char m_lunaris{};
+		bool m_gas{};
+		int gomiscore{};
+		int disablecurspeedchange{};
+	} settings{};
+	struct STATE {
+		int player{};
+		int keymode{};
+		int randomseed{};
+		double freqSpeedMultiplier{};
+		double song_runtime{};
+		char isNosave{};
+		char isForceEasy{};
+		char isCourse{};
+		int courseStageNow{};
+		int notes_total{};
+	} state{};
+	struct JUDGEMENTS {
+		unsigned int epg{};
+		unsigned int lpg{};
+		unsigned int egr{};
+		unsigned int lgr{};
+		unsigned int egd{};
+		unsigned int lgd{};
+		unsigned int ebd{};
+		unsigned int lbd{};
+		unsigned int epr{};
+		unsigned int lpr{};
+		unsigned int cb{};
+		unsigned int fast{};
+		unsigned int slow{};
+		unsigned int notes_played{};
+		unsigned int notes_total{};
+	};
+	JUDGEMENTS judgements_total{};
+	std::array<JUDGEMENTS, 20> judgements_column{};
+	unsigned int max_combo{};
+	std::array<double, 6> HP{};
+	int gaugeType{};
+	int moneyscore{};
+	int exscore{};
+	double rate{};
+	int clearType{};
+	int inputType{};
+	struct GRAPHDATA {
+		std::array<std::array<int, 1000>, 6> hp{};
+		std::array<int, 1000> combo{};
+		std::array<int, 1000> exscore{};
+		std::array<int, 1000> rate{};
+	} graphs{};
+
+	IRScoreInternal(game& game, sqlite3* sql, int player);
+	void MakeScoreV1(IRScoreV1& scoreOut);
+};
+
+void IRScoreInternal::MakeScoreV1(IRScoreV1& scoreOut) {
+	scoreOut.song.hash = song.hash;
+	scoreOut.song.title = song.title;
+	scoreOut.song.subtitle = song.subtitle;
+	scoreOut.song.genre = song.genre;
+	scoreOut.song.artist = song.artist;
+	scoreOut.song.subartist = song.subartist;
+	scoreOut.song.maxBPM = song.maxBPM;
+	scoreOut.song.minBPM = song.minBPM;
+	scoreOut.song.longnote = song.longnote;
+	scoreOut.song.random = song.random;
+	scoreOut.song.judge = song.judge;
+	scoreOut.song.courseStageCount = song.courseStageCount;
+	scoreOut.song.courseType = song.courseType;
+
+	scoreOut.settings.gaugeOption = settings.gaugeOption;
+	scoreOut.settings.random = settings.random;
+	scoreOut.settings.autokey = settings.autokey;
+	scoreOut.settings.assist = settings.assist;
+	scoreOut.settings.dpflip = settings.dpflip;
+	scoreOut.settings.hsfix = settings.hsfix;
+	scoreOut.settings.randSC = settings.randSC;
+	scoreOut.settings.randFix = settings.randFix;
+	scoreOut.settings.m_softlanding = settings.m_softlanding;
+	scoreOut.settings.m_addmine = settings.m_addmine;
+	scoreOut.settings.m_addlong = settings.m_addlong;
+	scoreOut.settings.m_earthquake = settings.m_earthquake;
+	scoreOut.settings.m_tornado = settings.m_tornado;
+	scoreOut.settings.m_superloop = settings.m_superloop;
+	scoreOut.settings.m_gambol = settings.m_gambol;
+	scoreOut.settings.m_char = settings.m_char;
+	scoreOut.settings.m_heartbeat = settings.m_heartbeat;
+	scoreOut.settings.m_loudness = settings.m_loudness;
+	scoreOut.settings.m_addnote = settings.m_addnote;
+	scoreOut.settings.m_nabeatsu = settings.m_nabeatsu;
+	scoreOut.settings.m_accel = settings.m_accel;
+	scoreOut.settings.m_sincurve = settings.m_sincurve;
+	scoreOut.settings.m_wave = settings.m_wave;
+	scoreOut.settings.m_spiral = settings.m_spiral;
+	scoreOut.settings.m_sidejump = settings.m_sidejump;
+	scoreOut.settings.is_extra = settings.is_extra;
+	scoreOut.settings.m_extra = settings.m_extra;
+	scoreOut.settings.m_lunaris = settings.m_lunaris;
+	scoreOut.settings.m_gas = settings.m_gas;
+	scoreOut.settings.gomiscore = settings.gomiscore;
+	scoreOut.settings.disablecurspeedchange = settings.disablecurspeedchange;
+
+	scoreOut.state.player = state.player;
+	scoreOut.state.keymode = state.keymode;
+	scoreOut.state.randomseed = state.randomseed;
+	scoreOut.state.freqSpeedMultiplier = state.freqSpeedMultiplier;
+	scoreOut.state.song_runtime = state.song_runtime;
+	scoreOut.state.isNosave = state.isNosave;
+	scoreOut.state.isForceEasy = state.isForceEasy;
+	scoreOut.state.isCourse = state.isCourse;
+	scoreOut.state.courseStageNow = state.courseStageNow;
+	scoreOut.state.notes_total = state.notes_total;
+
+	auto judgements_assign = [](IRScoreV1::JUDGEMENTS& out, const IRScoreInternal::JUDGEMENTS& in) {
+		out.epg = in.epg;
+		out.lpg = in.lpg;
+		out.egr = in.egr;
+		out.lgr = in.lgr;
+		out.egd = in.egd;
+		out.lgd = in.lgd;
+		out.ebd = in.ebd;
+		out.lbd = in.lbd;
+		out.epr = in.epr;
+		out.lpr = in.lpr;
+		out.cb = in.cb;
+		out.fast = in.fast;
+		out.slow = in.slow;
+		out.notes_played = in.notes_played;
+		out.notes_total = in.notes_total;
+	};
+	judgements_assign(scoreOut.judgements_total, judgements_total);
+	for (std::size_t i = 0; i < scoreOut.judgements_column.size(); i++) {
+		judgements_assign(scoreOut.judgements_column[i], judgements_column[i]);
+	}
+	scoreOut.max_combo = max_combo;
+	scoreOut.HP = HP;
+	scoreOut.gaugeType = gaugeType;
+	scoreOut.moneyscore = moneyscore;
+	scoreOut.exscore = exscore;
+	scoreOut.rate = rate;
+	scoreOut.clearType = clearType;
+	scoreOut.inputType = inputType;
+
+	scoreOut.graphs.hp = graphs.hp;
+	scoreOut.graphs.combo = graphs.combo;
+	scoreOut.graphs.exscore = graphs.exscore;
+	scoreOut.graphs.rate = graphs.rate;
+}
+
+IRScoreInternal::IRScoreInternal(game& game, sqlite3* sql, int _player) {
+	const SONGDATA& curSong = game.sSelect.bmsList[game.sSelect.cur_song];
+	bool courseSong = (game.gameplay.courseType == 0 || game.gameplay.courseType == 2) && game.procSelecter != 13;
+	bool courseScore = game.procSelecter == 13;
+	if (courseSong) {
+		song.hash = curSong.courseHash[game.gameplay.courseStageNow].body;
+		SONGDATA songData;
+		GetSongData(song.hash.c_str(), &songData, sql, &game.sSelect);
+		song.title = songData.title.body;
+		song.subtitle = songData.subtitle.body;
+		song.genre = songData.genre.body;
+		song.artist = songData.artist.body;
+		song.subartist = songData.subartist.body;
+		song.maxBPM = songData.maxBPM;
+		song.minBPM = songData.minBPM;
+		song.longnote = songData.longnote;
+		song.random = songData.random;
+		song.judge = songData.judge;
+	}
+	else {
+		song.hash = curSong.hash.body;
+		song.title = curSong.title.body;
+		song.subtitle = curSong.subtitle.body;
+		song.genre = curSong.genre.body;
+		song.artist = curSong.artist.body;
+		song.subartist = curSong.subartist.body;
+		song.maxBPM = curSong.maxBPM;
+		song.minBPM = curSong.minBPM;
+		song.longnote = curSong.longnote;
+		song.random = curSong.random;
+		song.judge = curSong.judge;
+		song.courseStageCount = curSong.courseStageCount;
+		song.courseType = curSong.courseType;
+	}
+	CONFIG_PLAY& cfg = game.config.play;
+	settings.gaugeOption = cfg.gaugeOption[_player];
+	settings.random[0] = cfg.random[0];
+	settings.random[1] = cfg.random[1];
+	settings.autokey = cfg.autokey;
+	settings.assist[0] = cfg.p1_assist;
+	settings.assist[1] = cfg.p2_assist;
+	settings.dpflip = cfg.dpflip;
+	settings.hsfix = cfg.hsfix;
+	settings.randSC[0] = cfg.randSC[0];
+	settings.randSC[1] = cfg.randSC[1];
+	settings.randFix[0] = cfg.randFix[0];
+	settings.randFix[1] = cfg.randFix[1];
+	settings.m_softlanding = cfg.m_softlanding;
+	settings.m_addmine = cfg.m_addmine;
+	settings.m_addlong = cfg.m_addlong;
+	settings.m_earthquake = cfg.m_earthquake;
+	settings.m_tornado = cfg.m_tornado;
+	settings.m_superloop = cfg.m_superloop;
+	settings.m_gambol = cfg.m_gambol;
+	settings.m_char = cfg.m_char;
+	settings.m_heartbeat = cfg.m_heartbeat;
+	settings.m_loudness = cfg.m_loudness;
+	settings.m_addnote = cfg.m_addnote;
+	settings.m_nabeatsu = cfg.m_nabeatsu;
+	settings.m_accel = cfg.m_accel;
+	settings.m_sincurve = cfg.m_sincurve;
+	settings.m_wave = cfg.m_wave;
+	settings.m_spiral = cfg.m_spiral;
+	settings.m_sidejump = cfg.m_sidejump;
+	settings.is_extra = cfg.is_extra;
+	settings.m_extra = cfg.m_extra;
+	settings.m_lunaris = cfg.m_lunaris;
+	settings.m_gas = cfg.m_gas;
+	settings.gomiscore = cfg.gomiscore;
+	settings.disablecurspeedchange = cfg.disablecurspeedchange;
+
+	gameplay& gameplay = game.gameplay;
+	state.player = _player;
+	state.keymode = gameplay.keymode;
+	state.randomseed = gameplay.randomseed;
+	state.freqSpeedMultiplier = gameplay.freqSpeedMultiplier;
+	if (!courseScore) state.song_runtime = gameplay.song_runtime;
+	state.isNosave = gameplay.isNosave;
+	state.isForceEasy = gameplay.isForceEasy;
+	state.isCourse = gameplay.isCourse;
+	state.courseStageNow = gameplay.courseStageNow;
+	state.notes_total = gameplay.player[_player].totalnotes;
+
+	PLAYERSTATUS& player = gameplay.player[_player];
+	auto judgements_assign = [](IRScoreInternal::JUDGEMENTS& out, const EXTENDEDPLAYERSTATS& in) {
+		out.epg = in.epg;
+		out.lpg = in.lpg;
+		out.egr = in.egr;
+		out.lgr = in.lgr;
+		out.egd = in.egd;
+		out.lgd = in.lgd;
+		out.ebd = in.ebd;
+		out.lbd = in.lbd;
+		out.epr = in.epr;
+		out.lpr = in.lpr;
+		out.cb = in.cb;
+		out.fast = in.fast;
+		out.slow = in.slow;
+		out.notes_played = in.noteCount;
+		};
+	if (!courseScore) {
+		judgements_assign(judgements_total, player.extendedStats);
+		judgements_total.notes_total = state.notes_total;
+		for (std::size_t i = 0; i < judgements_column.size(); i++) {
+			judgements_assign(judgements_column[i], player.extendedColumnStats[i]);
+			judgements_column[i].notes_total = gameplay.bmsobj_note[i].count;
+		}
+	}
+	else {
+		judgements_assign(judgements_total, player.extendedStatsCourse);
+		judgements_total.notes_total = state.notes_total;
+		for (std::size_t i = 0; i < judgements_column.size(); i++) {
+			judgements_assign(judgements_column[i], player.extendedColumnStatsCourse[i]);
+			judgements_column[i].notes_total = gameplay.bmsobj_note[i].count;
+		}
+	}
+	max_combo = player.max_combo;
+	HP = player.HP;
+	gaugeType = player.gaugeType;
+	if (!courseScore) moneyscore = player.score;
+	exscore = player.exscore;
+	rate = player.rate;
+	clearType = player.clearType;
+	inputType = DetermineResultPlayDevice(&game.KeyInput);
+
+	if (!courseScore) {
+		::GRAPHDATA& statgraph = gameplay.statgraph[_player];
+		graphs.hp = statgraph.hp;
+		memcpy(graphs.combo.data(), statgraph.combo, graphs.combo.size());
+		memcpy(graphs.exscore.data(), statgraph.exscore, graphs.exscore.size());
+		memcpy(graphs.rate.data(), gameplay.rategraph[_player].val, graphs.rate.size());
+	}
+}
+
+void CUSTOMIR_MANAGER::SendScore(game& game, sqlite3* sql, int player) {
+	// Deferred deletion because we need to keep the std::future for whatever reason
+	std::vector<int> finishedThreads;
+	for (const auto& [i, it] : std::views::enumerate(mSendThreads)) {
+		if (it.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready) finishedThreads.push_back(i);
+	}
+	std::ranges::reverse(finishedThreads);
+	for (auto i : finishedThreads) {
+		mSendThreads.erase(mSendThreads.begin() + i);
+	}
+	mSendThreads.push_back(std::async(std::launch::async, [](IRScoreInternal internal, std::vector<std::shared_ptr<CustomIR>> toSend) {
+		IRScoreV1 scoreV1;
+		internal.MakeScoreV1(scoreV1);
+		constexpr const int tryMax = 6;
+		int tryCount = 1;
+		while (!toSend.empty() && tryCount <= tryMax) {
+			std::vector<std::future<SendScoreStatus>> sendThreads;
+			sendThreads.reserve(toSend.size());
+			for (const auto& module : toSend) {
+				sendThreads.push_back(std::async(std::launch::async, &CustomIR::SendScore, module, scoreV1));
+			}
+
+			for (const auto& [i, t] : std::views::enumerate(sendThreads) | std::views::reverse) {
+				switch (t.get()) {
+				case SendScoreStatus::Fail:
+					OverlayNotification("'%s' failed to submit score\n", toSend[i]->Name().c_str());
+					[[fallthrough]];
+				case SendScoreStatus::Ok: toSend.erase(toSend.begin() + i); break;
+				case SendScoreStatus::Retry: break;
+				}
+			}
+
+			const auto sleepFor = static_cast<int>(std::pow(4, tryCount));
+			std::this_thread::sleep_for(std::chrono::seconds(sleepFor));
+			tryCount++;
+		}
+	}, IRScoreInternal{ game, sql, player }, mModules));
+}

--- a/LR2/LR2_customir.h
+++ b/LR2/LR2_customir.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "LR2_customir_api.h"
+
+#include <array>
+#include <filesystem>
+#include <future>
+#include <memory>
+#include <string>
+#include <type_traits>
+
+#include <wtypes.h>
+
+struct game;
+struct sqlite3;
+
+class CustomIR {
+public:
+	CustomIR() = delete;
+	CustomIR(const std::filesystem::path& directory);
+	bool Initialize();
+	bool Login();
+	SendScoreStatus SendScore(const IRScoreV1& score);
+
+	[[nodiscard]] const std::string& Name() const { return mName; };
+private:
+	struct ModuleDeleter {
+		void operator()(std::remove_pointer_t<HMODULE>* handle);
+	};
+	std::unique_ptr<std::remove_pointer_t<HMODULE>, ModuleDeleter> mDllHandle;
+	std::string mName;
+	MethodTable mMethods;
+};
+
+class CUSTOMIR_MANAGER {
+public:
+	CUSTOMIR_MANAGER() = default;
+	CUSTOMIR_MANAGER operator=(const CUSTOMIR_MANAGER&) = delete;
+	CUSTOMIR_MANAGER(const CUSTOMIR_MANAGER&) = delete;
+	CUSTOMIR_MANAGER operator=(CUSTOMIR_MANAGER&&) = delete;
+	CUSTOMIR_MANAGER(CUSTOMIR_MANAGER&&) = delete;
+	~CUSTOMIR_MANAGER();
+	void Initialize(const std::filesystem::path& directory);
+	void Login();
+	void SendScore(game& game, sqlite3* sql, int player);
+private:
+	std::vector<std::shared_ptr<CustomIR>> mModules;
+	std::vector<std::future<void>> mSendThreads;
+};

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <string>
+#include <array>
+
+struct IRScoreV1 {
+	struct SONG {
+		std::string hash;
+		std::string title;
+		std::string subtitle;
+		std::string genre;
+		std::string artist;
+		std::string subartist;
+		int maxBPM{};
+		int minBPM{};
+		int longnote{};
+		int random{};
+		int judge{};
+		int courseStageCount{};
+		int courseType{};
+	} song{};
+	struct SETTINGS {
+		int gaugeOption{};
+		std::array<int, 2> random{};
+		int autokey{};
+		std::array<int, 2> assist{};
+		int dpflip{};
+		int hsfix{};
+		std::array<int, 2> randSC{};
+		std::array<int, 2> randFix{};
+		int m_softlanding{};
+		int m_addmine{};
+		int m_addlong{};
+		int m_earthquake{};
+		int m_tornado{};
+		int m_superloop{};
+		int m_gambol{};
+		int m_char{};
+		int m_heartbeat{};
+		int m_loudness{};
+		int m_addnote{};
+		int m_nabeatsu{};
+		int m_accel{};
+		int m_sincurve{};
+		int m_wave{};
+		int m_spiral{};
+		int m_sidejump{};
+		int is_extra{};
+		int m_extra{};
+		char m_lunaris{};
+		bool m_gas{};
+		int gomiscore{};
+		int disablecurspeedchange{};
+	} settings{};
+	struct STATE {
+		int player{};
+		int keymode{};
+		int randomseed{};
+		double freqSpeedMultiplier{};
+		double song_runtime{};
+		char isNosave{};
+		char isForceEasy{};
+		char isCourse{};
+		int courseStageNow{};
+		int notes_total{};
+	} state{};
+	struct JUDGEMENTS {
+		unsigned int epg{};
+		unsigned int lpg{};
+		unsigned int egr{};
+		unsigned int lgr{};
+		unsigned int egd{};
+		unsigned int lgd{};
+		unsigned int ebd{};
+		unsigned int lbd{};
+		unsigned int epr{};
+		unsigned int lpr{};
+		unsigned int cb{};
+		unsigned int fast{};
+		unsigned int slow{};
+		unsigned int notes_played{};
+		unsigned int notes_total{};
+	};
+	JUDGEMENTS judgements_total{};
+	std::array<JUDGEMENTS, 20> judgements_column{};
+	unsigned int max_combo{};
+	std::array<double, 6> HP{};
+	int gaugeType{};
+	int moneyscore{};
+	int exscore{};
+	double rate{};
+	int clearType{};
+	int inputType{};
+	struct GRAPHDATA {
+		std::array<std::array<int, 1000>, 6> hp{};
+		std::array<int, 1000> combo{};
+		std::array<int, 1000> exscore{};
+		std::array<int, 1000> rate{};
+	} graphs{};
+};
+
+enum class SendScoreStatus: int {
+	Ok = 0,
+	Retry,
+	Fail,
+};
+
+struct MethodTable {
+	const char*(__cdecl* GetName)() = nullptr;
+	bool(__cdecl* LoginV1)() = nullptr;
+	SendScoreStatus(__cdecl* SendScoreV1)(const IRScoreV1& score) = nullptr;
+};

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -3,6 +3,7 @@
 #include "LR2.h"
 #include "Scenes.h"
 #include "filesystem.h"
+#include "LR2_customir.h"
 
 #include <chrono>
 #include <filesystem>
@@ -365,6 +366,13 @@ int main(int argc, char** argv) {
 		printfDx(gs.net.request_result);
 		ErrorLogAdd(gs.net.request_result);
 	}
+	{
+		std::error_code ec; // ignore errors
+		std::filesystem::path path("LR2files/CustomIRs");
+		std::filesystem::create_directories(path, ec);
+		gs.net.customIR.Initialize(path);
+	}
+	gs.net.customIR.Login();
 
 	int loadingGrHandle = LoadGraph(fs::make_preferred("LR2files/Config/loading.bmp").data(), 0);
 
@@ -1364,6 +1372,7 @@ int main(int argc, char** argv) {
 					}
 					else if (gs.gameplay.player[0].judgecount[3] + gs.gameplay.player[0].judgecount[4] + gs.gameplay.player[0].judgecount[5] != 0) {
 						SaveResult(&gs, sql3);
+						gs.net.customIR.SendScore(gs, sql3, 0);
 					}
 					else if (gs.config.play.m_lunaris == 0 && gs.config.play.battle != 1) {
 						gs.procSelecter = 2;
@@ -1375,6 +1384,7 @@ int main(int argc, char** argv) {
 					}
 					else if ((gs.gameplay.player[1].judgecount[3] + gs.gameplay.player[1].judgecount[4] + gs.gameplay.player[1].judgecount[5] != 0) || gs.config.play.battle != 1) {
 						SaveResult(&gs, sql3);
+						gs.net.customIR.SendScore(gs, sql3, 1);
 					}
 					else {
 						gs.procSelecter = 2;

--- a/LR2/Scene13_Courseresult.cpp
+++ b/LR2/Scene13_Courseresult.cpp
@@ -168,6 +168,7 @@ int ProcS_CourseResult(game *g, sqlite3 *sql) {
 	PlayerCheckAndSwap(&g->gameplay);
 	CheckCourseClear(g);
 	ProcS_subCourseResult(g, sql);
+	g->net.customIR.SendScore(*g, sql, 0);
 	LoadSceneG(g, &g->skstruct, SKINTYPE_COURSERESULT);
 	
 	if (g->skstruct.flag_flip) {

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "strclass.h"
+#include "LR2_customir.h"
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -1390,6 +1391,7 @@ struct NETWORK {
 	std::jthread hHandle;
 	int IRstatus {0}; /* 0:notIR 1:loading 2:loaded -1:playerNotExist -3:connection_fail -2:bansong 3:waitUpadate 4:connection 5:IRbusy */
 	CSTR IRresultMessage;
+	CUSTOMIR_MANAGER customIR;
 
 	int GetInsaneList();
 

--- a/OpenLR2_vs22.sln
+++ b/OpenLR2_vs22.sln
@@ -9,6 +9,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SkinEditor_SDL3imgui", "Ski
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SDL3", "SkinEditor\SDL3\VisualC\SDL\SDL.vcxproj", "{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ExampleIR", "ExampleIR\ExampleIR.vcxproj", "{BF127BA9-475C-4BEC-91F6-058D5D7A2F65}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -55,6 +57,18 @@ Global
 		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release|x64.Build.0 = Release|x64
 		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release|x86.ActiveCfg = Release|Win32
 		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release|x86.Build.0 = Release|Win32
+		{BF127BA9-475C-4BEC-91F6-058D5D7A2F65}.Debug|x64.ActiveCfg = Debug|x64
+		{BF127BA9-475C-4BEC-91F6-058D5D7A2F65}.Debug|x64.Build.0 = Debug|x64
+		{BF127BA9-475C-4BEC-91F6-058D5D7A2F65}.Debug|x86.ActiveCfg = Debug|Win32
+		{BF127BA9-475C-4BEC-91F6-058D5D7A2F65}.Debug|x86.Build.0 = Debug|Win32
+		{BF127BA9-475C-4BEC-91F6-058D5D7A2F65}.DebugWithSanitizer|x64.ActiveCfg = Debug|x64
+		{BF127BA9-475C-4BEC-91F6-058D5D7A2F65}.DebugWithSanitizer|x64.Build.0 = Debug|x64
+		{BF127BA9-475C-4BEC-91F6-058D5D7A2F65}.DebugWithSanitizer|x86.ActiveCfg = Debug|Win32
+		{BF127BA9-475C-4BEC-91F6-058D5D7A2F65}.DebugWithSanitizer|x86.Build.0 = Debug|Win32
+		{BF127BA9-475C-4BEC-91F6-058D5D7A2F65}.Release|x64.ActiveCfg = Release|x64
+		{BF127BA9-475C-4BEC-91F6-058D5D7A2F65}.Release|x64.Build.0 = Release|x64
+		{BF127BA9-475C-4BEC-91F6-058D5D7A2F65}.Release|x86.ActiveCfg = Release|Win32
+		{BF127BA9-475C-4BEC-91F6-058D5D7A2F65}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OpenLR2_vs22.vcxproj
+++ b/OpenLR2_vs22.vcxproj
@@ -42,6 +42,8 @@
     <ClInclude Include="LR2\LR2_audio.h" />
     <ClInclude Include="LR2\LR2_bmsload.h" />
     <ClInclude Include="LR2\LR2_configsave.h" />
+    <ClInclude Include="LR2\LR2_customir.h" />
+    <ClInclude Include="LR2\LR2_customir_api.h" />
     <ClInclude Include="LR2\LR2_gameloop.h" />
     <ClInclude Include="LR2\LR2_ghost.h" />
     <ClInclude Include="LR2\LR2_ir.h" />
@@ -89,6 +91,7 @@
     <ClCompile Include="LR2\LR2_audio.cpp" />
     <ClCompile Include="LR2\LR2_bmsload.cpp" />
     <ClCompile Include="LR2\LR2_configsave.cpp" />
+    <ClCompile Include="LR2\LR2_customir.cpp" />
     <ClCompile Include="LR2\LR2_gameloop.cpp" />
     <ClCompile Include="LR2\LR2_ghost.cpp" />
     <ClCompile Include="LR2\LR2_ir.cpp" />

--- a/OpenLR2_vs22.vcxproj.filters
+++ b/OpenLR2_vs22.vcxproj.filters
@@ -144,6 +144,12 @@
     <ClInclude Include="LR2\structure.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
+    <ClInclude Include="LR2\LR2_customir.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="LR2\LR2_customir_api.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="LR2\dbgtool.cpp">
@@ -277,6 +283,9 @@
     </ClCompile>
     <ClCompile Include="lib\md5.cpp">
       <Filter>소스 파일\lib</Filter>
+    </ClCompile>
+    <ClCompile Include="LR2\LR2_customir.cpp">
+      <Filter>소스 파일</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Loads IR .dll modules from LR2files/CustomIRs/\<IRFolder\>/, which implement various methods, and calls them. This is for use with 3rd-party score trackers like Bokutachi. Should be capable of sending scores that wouldn't be sent to LR2IR. It's up to the module implementation to filter what it doesn't need. External module would include 'LR2_customir_api.h' and at minimum implement GetMethodTable and GetName, as well as DllMain. Past the release, for backwards compatibility with old version modules, existing structures defined at 'LR2_custom_api.h' must not be modified. Example module will be provided later.