### PR TITLE
feat: utf-8 strings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,16 +97,17 @@ if(WIN32)
     target_link_libraries(OpenLR2Lib PUBLIC winmm.lib)
 endif()
 
-if(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
-    # FIXME(utf-8): not supported on any other compilers. Move to UTF-8.
-    target_compile_options(OpenLR2Lib PUBLIC /execution-charset:shift-JIS)
+if(WIN32)
+    # FIXME: only do this for msvc, `${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC"` doesn't work
+    target_compile_options(OpenLR2Lib PUBLIC /utf-8)
 endif()
 
-add_executable(OpenLR2 WIN32 LR2/Main.cpp)
+add_executable(OpenLR2 WIN32 LR2/Main.cpp OpenLR2.manifest)
 set_target_properties(OpenLR2 PROPERTIES CXX_STANDARD 23)
 target_link_libraries(OpenLR2 PUBLIC OpenLR2Lib)
 
 if(WIN32)
+    # FIXME: SkinEditor manifest
     add_executable(
         SkinEditor
         WIN32

--- a/LR2/En_audio.cpp
+++ b/LR2/En_audio.cpp
@@ -13,7 +13,7 @@
 #include <cmath>
 #include <array>
 #include <cstdint>
-
+#include "filesystem.h"
 using std::uintptr_t;
 
 #ifdef _WIN32
@@ -441,7 +441,7 @@ void WriteSoundFile(AUDIO *aud, CSTR filename, uint size) {
 	FILE* _File;
 	char header1[12], header2[24], header3[8];
 
-	_File = _wfopen(utf2ws(filename.body).c_str(), L"wb");
+	_File = fopen(filename.body, "wb");
 	if ((size != 0) && (size <= aud->size)) {
 		aud->size = size;
 	}

--- a/LR2/En_audio.cpp
+++ b/LR2/En_audio.cpp
@@ -441,7 +441,7 @@ void WriteSoundFile(AUDIO *aud, CSTR filename, uint size) {
 	FILE* _File;
 	char header1[12], header2[24], header3[8];
 
-	_File = fopen(filename, "wb");
+	_File = _wfopen(utf2ws(filename.body).c_str(), L"wb");
 	if ((size != 0) && (size <= aud->size)) {
 		aud->size = size;
 	}
@@ -597,21 +597,6 @@ int RecordFadeout(AUDIO *aud, double from, double length) {
 	return 1;
 }
 
-static std::string s2utf8(const std::string_view str, unsigned int codepage) {
-#ifdef _WIN32
-	int size_needed = MultiByteToWideChar(codepage, 0, str.data(), static_cast<int>(str.size()), nullptr, 0);
-	auto wstr = std::make_unique_for_overwrite<wchar_t[]>(size_needed);
-	MultiByteToWideChar(codepage, 0, str.data(), static_cast<int>(str.size()), wstr.get(), size_needed);
-	std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
-	return converter.to_bytes(wstr.get(), wstr.get() + size_needed);
-#else
-	if (codepage == CP_ACP) { // Already UTF-8
-		return std::string{str};
-	}
-	return std::string{str}; // unused currently :P
-#endif // _WIN32
-}
-
 int LoadSound(AUDIO *aud, SOUNDDATA *sound, CSTR filepath, int loop, int /*disableDSP*/, int previewFlag) {
 
 	CSTR path;
@@ -638,7 +623,7 @@ int LoadSound(AUDIO *aud, SOUNDDATA *sound, CSTR filepath, int loop, int /*disab
 		FMOD_RESULT result;
 		if (aud->cmd_mediaOut) {
 			FMOD_MODE mode = FMOD_ACCURATETIME | FMOD_LOOP_OFF;
-			result = FMOD_System_CreateSound(aud->fmodSys, filepath, mode, NULL, &sound->fmod_sound); 
+			result = FMOD_System_CreateSound(aud->fmodSys, filepath.body, mode, nullptr, &sound->fmod_sound); 
 			SOUND_normalize(aud, sound);
 		}
 		else {
@@ -646,7 +631,7 @@ int LoadSound(AUDIO *aud, SOUNDDATA *sound, CSTR filepath, int loop, int /*disab
 			if (previewFlag != 0) {
 				mode |= FMOD_CREATESTREAM;
 			}
-			result = FMOD_System_CreateSound(aud->fmodSys, s2utf8(filepath.body, CP_ACP).c_str(), mode, NULL, &sound->fmod_sound);
+			result = FMOD_System_CreateSound(aud->fmodSys, filepath.body, mode, nullptr, &sound->fmod_sound);
 		}
 
 		sound->flag2c = 0;
@@ -668,7 +653,7 @@ int LoadSound(AUDIO *aud, SOUNDDATA *sound, CSTR filepath, int loop, int /*disab
 	}
 
 	if (previewFlag) SetCreateSoundDataType(3);
-	sound->soundHandle = LoadSoundMem(filepath, 3, -1);
+	sound->soundHandle = LoadSoundMem(filepath.body, 3, -1);
 	if (previewFlag) SetCreateSoundDataType(0);
 	if (sound->soundHandle == -1) {
 		sound->filename.fillzero();

--- a/LR2/En_dbio.cpp
+++ b/LR2/En_dbio.cpp
@@ -60,23 +60,11 @@ static bool UTF8toANSI(LPCSTR str, char *oBuf, size_t *oSize){
 }
 
 int SQL_Run(CSTR queryStr, sqlite3 *sql) {
-	size_t size;
-	ANSItoUTF8(queryStr, nullptr, &size);
-	CSTR oBuf;
-	oBuf.resize2(size + 1);
-	memset(oBuf.body, 0, size + 1);
-	ANSItoUTF8(queryStr, oBuf.body, &size);
-	return sqlite3_exec(sql, oBuf.body, nullptr, nullptr, nullptr);
+	return sqlite3_exec(sql, queryStr.body, nullptr, nullptr, nullptr);
 }
 
 int SQL_prepare(CSTR queryStr, sqlite3 *sql, sqlite3_stmt **ppStmt) {
-	size_t size;
-	ANSItoUTF8(queryStr, nullptr, &size);
-	CSTR oBuf;
-	oBuf.resize2(size + 1);
-	memset(oBuf.body, 0, size + 1);
-	ANSItoUTF8(queryStr, oBuf.body, &size);
-	return sqlite3_prepare(sql, oBuf.body, -1, ppStmt, nullptr);
+	return sqlite3_prepare(sql, queryStr.body, -1, ppStmt, nullptr);
 }
 
 CSTR SQL_GetColumn(int i, sqlite3_stmt *pStmt){
@@ -89,15 +77,6 @@ CSTR SQL_GetColumn(int i, sqlite3_stmt *pStmt){
 	// Cast safety: it's safe to cast from unsigned char* to char*
 	const char* columnText = reinterpret_cast<const char*>(sqlite3_column_text(pStmt, i));
 
-	size_t size;
-	UTF8toANSI(columnText, nullptr, &size);
-
-	CSTR oBuf;
-	oBuf.resize2(size + 1);
-	memset(oBuf.body, 0, size + 1);
-
-	UTF8toANSI(columnText, oBuf.body, &size);
-	oBuf.body[size] = '\0';
-
+	CSTR oBuf(columnText);
 	return oBuf;
 }

--- a/LR2/En_fileutil.cpp
+++ b/LR2/En_fileutil.cpp
@@ -2,7 +2,7 @@
 #include <md5.h>
 #include "DxLib/DxLib.h" //log
 #include <codecvt>
-
+#include "filesystem.h"
 #ifndef _WIN32
 #include <chrono>
 #include <filesystem>
@@ -67,7 +67,7 @@ std::u32string utf8_to_utf32(const std::string& str) {
 
 int makeFileHash(LPCSTR filepath, LPCSTR oBuf) {
 	FILE* pFile;
-	pFile = _wfopen(utf2ws(filepath).c_str(), L"rb");
+	pFile = fopen(filepath, "rb");
 	if (!pFile)  return -1;
 	unsigned char* md5buf = (unsigned char*)md5File(pFile);
 	fclose(pFile);

--- a/LR2/En_fileutil.cpp
+++ b/LR2/En_fileutil.cpp
@@ -1,6 +1,7 @@
 ﻿#include "En_fileutil.h"
 #include <md5.h>
 #include "DxLib/DxLib.h" //log
+#include <codecvt>
 
 #ifndef _WIN32
 #include <chrono>
@@ -8,9 +9,65 @@
 #include <sys/stat.h>
 #endif // _WIN32
 
+std::wstring utf2ws(const std::string_view str) {
+	int size_needed = MultiByteToWideChar(CP_UTF8, 0, str.data(), str.size(), nullptr, 0);
+	std::wstring wstr(size_needed, 0);
+	MultiByteToWideChar(CP_UTF8, 0, str.data(), str.size(), wstr.data(), size_needed);
+	return wstr;
+}
+
+std::string ws2utf(const std::wstring_view wstr) {
+	std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
+	return converter.to_bytes(wstr.data());
+}
+
+std::string utf2ansi(const std::string_view in, unsigned int codepage) {
+	int size_needed = MultiByteToWideChar(CP_UTF8, 0, in.data(), in.size(), nullptr, 0);
+	std::wstring wstr(size_needed, 0);
+	MultiByteToWideChar(CP_UTF8, 0, in.data(), in.size(), wstr.data(), size_needed);
+	size_needed = WideCharToMultiByte(codepage, 0, wstr.data(), wstr.size(), nullptr, 0, 0, 0);
+	std::string out(size_needed, 0);
+	WideCharToMultiByte(codepage, 0, wstr.data(), wstr.size(), out.data(), out.size(), 0, 0);
+	return out;
+}
+
+std::string ansi2utf(const std::string_view str, unsigned int codepage) {
+	int size_needed = MultiByteToWideChar(codepage, 0, str.data(), static_cast<int>(str.size()), nullptr, 0);
+	auto wstr = std::make_unique_for_overwrite<wchar_t[]>(size_needed);
+	MultiByteToWideChar(codepage, 0, str.data(), static_cast<int>(str.size()), wstr.get(), size_needed);
+	std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
+	return converter.to_bytes(wstr.get(), wstr.get() + size_needed);
+}
+
+std::u32string utf8_to_utf32(const std::string& str) {
+	std::u32string out;
+	// FIXME: std::use_facet is already deprecated and removed in C++26, and is not supported well in Wine.
+	static const auto locale = std::locale("ja_JP.UTF8");
+	static const auto& facet_u32_u8 = std::use_facet<std::codecvt<char32_t, char, std::mbstate_t>>(locale);
+	out.resize(str.size() * facet_u32_u8.max_length(), '\0');
+
+	std::mbstate_t s;
+	const char* from_next = str.data();
+	char32_t* to_next = out.data();
+
+	std::codecvt_base::result res;
+	do
+	{
+		res = facet_u32_u8.in(s, from_next, &str[str.size()], from_next, to_next, &out[out.size()], to_next);
+
+		// skip unconvertiable chars (which is impossible though)
+		if (res == std::codecvt_base::error)
+			from_next++;
+
+	} while (res == std::codecvt_base::error);
+
+	out.resize(to_next - &out[0]);
+	return out;
+}
+
 int makeFileHash(LPCSTR filepath, LPCSTR oBuf) {
 	FILE* pFile;
-	pFile = fopen(filepath, "rb");
+	pFile = _wfopen(utf2ws(filepath).c_str(), L"rb");
 	if (!pFile)  return -1;
 	unsigned char* md5buf = (unsigned char*)md5File(pFile);
 	fclose(pFile);
@@ -53,9 +110,8 @@ time_t GetFileUnixtime(CSTR str) {
 	}
 
 #ifdef _WIN32
-	WIN32_FIND_DATA FindFileData;
-	LPWIN32_FIND_DATAA lpFindFileData = (LPWIN32_FIND_DATAA)&FindFileData;
-	HANDLE hFindFile = FindFirstFileA(str, lpFindFileData);
+	WIN32_FIND_DATAW FindFileData;
+	HANDLE hFindFile = FindFirstFileW(utf2ws(str.body).c_str(), &FindFileData);
 	if (hFindFile == (HANDLE)-1) {
 		ErrorLogFmtAdd("ファイルのLR2TIME取得エラー:%sが見つからない\n", str.body);
 		return -1;
@@ -80,14 +136,15 @@ CSTR GetRandomFileOnDir(CSTR path, char fOnlyName) {
 #ifdef _WIN32
 	CSTR oBuf;
 	//CSTR str1,str2,str3;
-	WIN32_FIND_DATA FindFileData;
+	WIN32_FIND_DATAW FindFileData;
 	HANDLE hFindFile;
 	int fileCount = 0;
 	CSTR str1( path.left(path.findStrPos("*")) );
 	CSTR str2( path.right(path.length() - str1.length() - 1) );
 	CSTR str3( str1 );
 	str3.add("*");
-	hFindFile = FindFirstFileA(str3, (LPWIN32_FIND_DATAA)&FindFileData);
+	std::wstring wstr = utf2ws(str3.body);
+	hFindFile = FindFirstFileW(wstr.c_str(), &FindFileData);
 	if (hFindFile == (HANDLE)-1) {
 		//oBuf = CSTR("ERROR");
 		return CSTR("ERROR");
@@ -96,37 +153,39 @@ CSTR GetRandomFileOnDir(CSTR path, char fOnlyName) {
 		if (FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
 			if (strcmp("..", (char*)FindFileData.cFileName) && strcmp(".", (char*)FindFileData.cFileName)) fileCount++;
 		}
-	} while (FindNextFileA(hFindFile, (LPWIN32_FIND_DATAA)&FindFileData));
+	} while (FindNextFileW(hFindFile, &FindFileData));
 	FindClose(hFindFile);
 	if (fileCount > 0) {
 		fileCount = GetRand(fileCount - 1);
 
-		hFindFile = FindFirstFileA(str3, (LPWIN32_FIND_DATAA)&FindFileData);
+		hFindFile = FindFirstFileW(wstr.c_str(), &FindFileData);
 		if (hFindFile != (HANDLE)-1) {
 			do {
 				if (FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-					if (strcmp("..", (char*)FindFileData.cFileName) && strcmp(".", (char*)FindFileData.cFileName)) {
+					std::string filename = ws2utf(FindFileData.cFileName);
+					if (strcmp("..", filename.c_str()) && strcmp(".", filename.c_str())) {
 						//LAB_00438327
 						int i = 0;
 						while (i < fileCount) {
-							FindNextFileA(hFindFile, (LPWIN32_FIND_DATAA)&FindFileData);
+							FindNextFileW(hFindFile, &FindFileData);
 							if (FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-								if (strcmp("..", (char*)FindFileData.cFileName) && strcmp(".", (char*)FindFileData.cFileName)) i++;
+								filename = ws2utf(FindFileData.cFileName);
+								if (strcmp("..", filename.c_str()) && strcmp(".", filename.c_str())) i++;
 							}
 						}
 						FindClose(hFindFile);
 						path.assign(&str1);
-						path.add((char*)FindFileData.cFileName);
+						path.add(filename.c_str());
 						path.add(&str2);
 						if (fOnlyName) {
 							//oBuf = CSTR(FindFileData.cFileName);
-							return CSTR((char*)FindFileData.cFileName);
+							return CSTR(filename.c_str());
 						}
 						//oBuf = CSTR(path);
 						return CSTR(path);
 					}
 				}
-				FindNextFileA(hFindFile, (LPWIN32_FIND_DATAA)&FindFileData);
+				FindNextFileW(hFindFile, &FindFileData);
 			} while (true);
 		}
 	}
@@ -298,10 +357,10 @@ bool IsFileExist(CSTR path) {
 
 #ifdef _WIN32
 	HANDLE hFindFile;
-	_WIN32_FIND_DATAA findFileData;
+	_WIN32_FIND_DATAW findFileData;
 	char dirFlag = 0;
 
-	hFindFile = FindFirstFileA(path, &findFileData);
+	hFindFile = FindFirstFileW(utf2ws(path.body).c_str(), &findFileData);
 	FindClose(hFindFile);
 	return hFindFile != (HANDLE)-1;
 #else
@@ -699,31 +758,33 @@ CSTR GetRandomFile(CSTR path, char fOnlyName) {
 	}
 
 #ifdef _WIN32
-	WIN32_FIND_DATA FindFileData;
+	std::wstring wpath = utf2ws(path.body);
+	WIN32_FIND_DATAW FindFileData;
 	//count files for random
-	HANDLE hFindFile = FindFirstFileA(path, (LPWIN32_FIND_DATAA)&FindFileData);
+	HANDLE hFindFile = FindFirstFileW(wpath.c_str(), &FindFileData);
 	if (hFindFile == (HANDLE)-1) return CSTR("ERROR");
 	
 	count = 0;
 	do {
 		count++;
-	} while (FindNextFileA(hFindFile, (LPWIN32_FIND_DATAA)&FindFileData));
+	} while (FindNextFileW(hFindFile, &FindFileData));
 	if (count < 1) return CSTR("ERROR");
 
 	count = GetRand(count - 1);
 
 	//get file by random
-	hFindFile = FindFirstFileA(path, (LPWIN32_FIND_DATAA)&FindFileData);
+	hFindFile = FindFirstFileW(wpath.c_str(), &FindFileData);
 	if (hFindFile == (HANDLE)-1) return CSTR("ERROR");
 
 	for (int i = 0; i < count; i++) {
-		FindNextFile(hFindFile, &FindFileData);
+		FindNextFileW(hFindFile, &FindFileData);
 	}
 	FindClose(hFindFile);
 	path.assign(path.getDirectory());
-	path.add((char*)FindFileData.cFileName);
+	std::string filename = ws2utf(FindFileData.cFileName);
+	path.add(filename.c_str());
 	if (fOnlyName) {
-		path.assign((char*)FindFileData.cFileName);
+		path.assign(filename.c_str());
 		path.nullAtPos(path.findStrPos("."));
 	}
 	return path;

--- a/LR2/En_fileutil.h
+++ b/LR2/En_fileutil.h
@@ -74,8 +74,8 @@ void MD5byte(char **iStr, uint len, char *oByte);
 char* MD5str(char *iStr);
 
 //string convert
-std::wstring utf2ws(const std::string_view str);
-std::string ws2utf(const std::wstring_view wstr);
-std::string utf2ansi(const std::string_view in, unsigned int codepage);
-std::string ansi2utf(const std::string_view str, unsigned int codepage);
+std::wstring utf2ws(std::string_view str);
+std::string ws2utf(std::wstring_view wstr);
+std::string utf2ansi(std::string_view in, unsigned int codepage);
+std::string ansi2utf(std::string_view str, unsigned int codepage);
 std::u32string utf8_to_utf32(const std::string& str);

--- a/LR2/En_fileutil.h
+++ b/LR2/En_fileutil.h
@@ -72,3 +72,10 @@ CSTR GetRandomFileNoError(CSTR path, CSTR dir);
 //md5
 void MD5byte(char **iStr, uint len, char *oByte);
 char* MD5str(char *iStr);
+
+//string convert
+std::wstring utf2ws(const std::string_view str);
+std::string ws2utf(const std::wstring_view wstr);
+std::string utf2ansi(const std::string_view in, unsigned int codepage);
+std::string ansi2utf(const std::string_view str, unsigned int codepage);
+std::u32string utf8_to_utf32(const std::string& str);

--- a/LR2/En_recordmovie.cpp
+++ b/LR2/En_recordmovie.cpp
@@ -1,5 +1,5 @@
 ﻿#include "En_recordmovie.h"
-
+#include "filesystem.h"
 #include <cstring>
 
 #include "structure.h"
@@ -382,13 +382,13 @@ int Mp3toWavF(FILE *iFile, FILE *oFile) { //TODO : need test
 bool Mp3toWavP(char *iPath, char *oPath) {
 	FILE *iFile, *oFile;
 
-	iFile = _wfopen(utf2ws(iPath).c_str(), L"rb");
+	iFile = fopen(iPath, "rb");
 	if (iFile == NULL) {
 		ErrorLogFmtAdd("入力ファイルが開けません(%s)。\n", iPath);
 		_exit(1);
 	}
 
-	oFile = _wfopen(utf2ws(iPath).c_str(), L"wb");
+	oFile = fopen(iPath, "wb");
 	if (oFile == NULL) {
 		ErrorLogFmtAdd("出力ファイルが開けません(%s)。\n", oPath);
 		_exit(1);

--- a/LR2/En_recordmovie.cpp
+++ b/LR2/En_recordmovie.cpp
@@ -4,6 +4,7 @@
 
 #include "structure.h"
 #include "filesystem.h"
+#include "En_fileutil.h"
 
 #include <DxLib/DxLib.h>
 
@@ -381,13 +382,13 @@ int Mp3toWavF(FILE *iFile, FILE *oFile) { //TODO : need test
 bool Mp3toWavP(char *iPath, char *oPath) {
 	FILE *iFile, *oFile;
 
-	iFile = fopen(iPath, "rb");
+	iFile = _wfopen(utf2ws(iPath).c_str(), L"rb");
 	if (iFile == NULL) {
 		ErrorLogFmtAdd("入力ファイルが開けません(%s)。\n", iPath);
 		_exit(1);
 	}
 
-	oFile = fopen(oPath, "wb");
+	oFile = _wfopen(utf2ws(iPath).c_str(), L"wb");
 	if (oFile == NULL) {
 		ErrorLogFmtAdd("出力ファイルが開けません(%s)。\n", oPath);
 		_exit(1);

--- a/LR2/LR2_audio.cpp
+++ b/LR2/LR2_audio.cpp
@@ -3,7 +3,7 @@
 #include "LR2_replay.h"
 #include "LR2_skinobject.h"
 #include "LR2_configsave.h"
-
+#include "filesystem.h"
 #include "filesystem.h"
 
 int FxByMIDI(game *g) {
@@ -345,12 +345,13 @@ int ReadLR2SoundSet(game *g, CSTR filepath, char reFlag) {
 		int t = sku.customize_value[i];
 		if (899 < t &&  t < 1000) dst_op[t] = 1;
 	}
-	hFile = _wfopen(utf2ws(filepath.body).c_str(), L"r");
+	hFile = fopen(filepath.body, "r");
 	if (!hFile) return 0;
 	CSTR fBuf(260);
 	char* pFbuf;
 	pFbuf = fBuf.outstr();
 	for (pFbuf = fgets(pFbuf, 256, hFile); pFbuf; pFbuf = fgets(pFbuf, 256, hFile)) {
+		fBuf = ansi2utf(pFbuf, 932).c_str();
 		if (*fBuf.atPos(0) == '#') {
 			fBuf.trimWhiteSpace();
 			DealWhiteSpace(&fBuf);

--- a/LR2/LR2_audio.cpp
+++ b/LR2/LR2_audio.cpp
@@ -345,7 +345,7 @@ int ReadLR2SoundSet(game *g, CSTR filepath, char reFlag) {
 		int t = sku.customize_value[i];
 		if (899 < t &&  t < 1000) dst_op[t] = 1;
 	}
-	hFile = fopen(filepath, "r");
+	hFile = _wfopen(utf2ws(filepath.body).c_str(), L"r");
 	if (!hFile) return 0;
 	CSTR fBuf(260);
 	char* pFbuf;

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -2,7 +2,7 @@
 #include "Engine.h"
 #include "LR2_replay.h"
 #include "filesystem.h"
-
+#include "filesystem.h"
 #include <algorithm>
 #include <unordered_map>
 
@@ -2000,7 +2000,7 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 				ErrorLogFmtAdd("エキスパ:ステージ=%d、フルパス=%s\n", gp->courseStageNow, filename.body);
 			}
 		}
-		hFile = _wfopen(utf2ws(filename.body).c_str(), L"r");
+		hFile = fopen(filename.body, "r");
 		if (hFile == NULL) {
 			ErrorLogAdd("BMSを開けません。\n");
 			return -1;
@@ -2030,6 +2030,7 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 				*fBuf.atPos(0) = '\0';
 				continue;
 			}
+			fBuf = ansi2utf(pFbuf, 932).c_str();
 			fBufOrg = fBuf;
 			fBuf.upper();
 

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -1786,32 +1786,32 @@ unsigned char channelConvert[] = { 0x00, 0x3c, 0x3c, 0x3c, 0x3c, 0x3c, 0x3c, 0x3
 									0x00, 0x3c, 0x35, 0x36, 0x37, 0x38, 0x39, 0x00, 0x3a, 0x3b };
 int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMSMETA *meta, int bgaFlag, int scratchSide) {
 
-	std::unordered_map<double, int> notesPerBpm;
-	double avgBPM_bpmsum;
-	float prevStageLastNoteTime;
-	int avgBPM_notes;
-	int noteRandomTable[2][10];
-	FILE *hFile;
+	std::unordered_map<double, int> notesPerBpm{};
+	double avgBPM_bpmsum{};
+	float prevStageLastNoteTime{};
+	int avgBPM_notes{};
+	int noteRandomTable[2][10]{};
+	FILE* hFile{};
 
-	int randomVal;
-	bool ifOn;
-	int channel;
+	int randomVal{};
+	bool ifOn{};
+	int channel{};
 
-	double endtime;
-	double nowBPM;
+	double endtime{};
+	double nowBPM{};
 
-	int rank;
+	int rank{};
 
-	int stages;
+	int stages{};
 
-	LaneStruct tmpLane[10];
-	double BPMslot[1296], STOPslot[1296];
-	int bmsobj_stageFirst;
-	double oldSpeedMultiplier;
+	LaneStruct tmpLane[10]{};
+	double BPMslot[1296]{}, STOPslot[1296]{};
+	int bmsobj_stageFirst{};
+	double oldSpeedMultiplier{};
 		
 	char mapAdded[2][10] = { 0, };
 	double prevStageTime = -1.0;
-	double meaLength;
+	double meaLength{};
 
 
 	if (cfg->play.random[0] == 5 && cfg->play.p1_assist == 1) {
@@ -1852,8 +1852,6 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 	}
 	ErrorLogFmtAdd("RANDOMSEEDは%dです。\n", gp->randomseed);
 	SRand(gp->randomseed);
-
-	CSTR dir = filename.getDirectory();
 
 	for (int i = 0; i < 1296; i++) BPMslot[i] = -1.0;
 	for (int i = 0; i < 1296; i++) STOPslot[i] = -1.0;
@@ -2002,7 +2000,7 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 				ErrorLogFmtAdd("エキスパ:ステージ=%d、フルパス=%s\n", gp->courseStageNow, filename.body);
 			}
 		}
-		hFile = fopen(filename, "r");
+		hFile = _wfopen(utf2ws(filename.body).c_str(), L"r");
 		if (hFile == NULL) {
 			ErrorLogAdd("BMSを開けません。\n");
 			return -1;

--- a/LR2/LR2_configsave.cpp
+++ b/LR2/LR2_configsave.cpp
@@ -1,5 +1,5 @@
 ﻿#include "LR2_configsave.h"
-
+#include "filesystem.h"
 #include <filesystem>
 #include <iterator>
 
@@ -193,7 +193,7 @@ int WriteConfigXml(game *g, const char *filename){
 	FILE *pFile;
 	char buf[256];
 	
-	pFile = _wfopen(utf2ws(filename).c_str(), L"w");
+	pFile = fopen(filename, "w");
 	if (pFile == NULL) return 0; 
 	
 	fputs("<?xml version=\"1.0\" encoding=\"shift_jis\"?>\n", pFile);
@@ -631,7 +631,7 @@ int WriteKeyConfig(game *g, const char *filepath, int key) {
 	FILE *pFile;
 	CONFIG_INPUT cfg_in;
 
-	pFile = _wfopen(utf2ws(filepath).c_str(), L"w");
+	pFile = fopen(filepath, "w");
 	if (pFile == (FILE *)0x0) {
 		return 0;
 	}
@@ -748,7 +748,7 @@ int WriteKeyConfig(game *g, const char *filepath, int key) {
 int WriteMidiXml(game *g, const char *filename) {
 	FILE *pFile;
 
-	pFile = _wfopen(utf2ws(filename).c_str(), L"w");
+	pFile = fopen(filename, "w");
 	if (pFile == NULL) {
 		return 0;
 	}
@@ -894,7 +894,7 @@ int WriteSkinCustomizeXml(SkinUser *sku, char *filepath) {
 	
 	FILE *pFile;
 
-	pFile = _wfopen(utf2ws(filepath).c_str(), L"w");
+	pFile = fopen(filepath, "w");
 	if (pFile == (FILE *)0x0) {
 		return 0;
 	}

--- a/LR2/LR2_configsave.cpp
+++ b/LR2/LR2_configsave.cpp
@@ -193,7 +193,7 @@ int WriteConfigXml(game *g, const char *filename){
 	FILE *pFile;
 	char buf[256];
 	
-	pFile = fopen(filename, "w");
+	pFile = _wfopen(utf2ws(filename).c_str(), L"w");
 	if (pFile == NULL) return 0; 
 	
 	fputs("<?xml version=\"1.0\" encoding=\"shift_jis\"?>\n", pFile);
@@ -631,7 +631,7 @@ int WriteKeyConfig(game *g, const char *filepath, int key) {
 	FILE *pFile;
 	CONFIG_INPUT cfg_in;
 
-	pFile = fopen(filepath, "w");
+	pFile = _wfopen(utf2ws(filepath).c_str(), L"w");
 	if (pFile == (FILE *)0x0) {
 		return 0;
 	}
@@ -748,7 +748,7 @@ int WriteKeyConfig(game *g, const char *filepath, int key) {
 int WriteMidiXml(game *g, const char *filename) {
 	FILE *pFile;
 
-	pFile = fopen(filename, "w");
+	pFile = _wfopen(utf2ws(filename).c_str(), L"w");
 	if (pFile == NULL) {
 		return 0;
 	}
@@ -894,7 +894,7 @@ int WriteSkinCustomizeXml(SkinUser *sku, char *filepath) {
 	
 	FILE *pFile;
 
-	pFile = fopen(filepath, "w");
+	pFile = _wfopen(utf2ws(filepath).c_str(), L"w");
 	if (pFile == (FILE *)0x0) {
 		return 0;
 	}

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -1,4 +1,7 @@
-﻿#pragma comment(lib,"ws2_32.lib")
+﻿#include <fstream>
+#include <sstream>
+#include <string>
+#pragma comment(lib,"ws2_32.lib")
 #include "LR2_ir.h"
 #include "DxLib/DxLib.h"
 #include "tinyxml/tinyxml.h"
@@ -105,22 +108,23 @@ void RANKING::Init() {
 }
 
 int RANKING::ParseXML(const char* path) {
-	
-	TiXmlDocument *hXml;
-	TiXmlElement *cur;
-	
 	Init();
 	ErrorLogFmtAdd("ランキングデータのパースを開始します。パス%s\n", path);
 
-	hXml = new TiXmlDocument(path);
-	if (hXml->LoadFile(TIXML_ENCODING_UNKNOWN) == false) {
-		if (hXml) {
-			delete(hXml);
-		}
-		ErrorLogFmtAdd("ランキングファイルが見つかりません\n");
-		return 0;
-	}
+	TiXmlDocument *hXml = new TiXmlDocument(path);
 
+	std::string s;
+	{
+		std::ifstream ifs{path};
+		std::stringstream ss;
+		ss << ifs.rdbuf();
+		s = ss.str();
+	}
+	s = ansi2utf(s.c_str(), 932);
+	// NOTE: TIXML_ENCODING_UTF8 or for whatever other reason it ignores `encoding='shift_jis'` in the header.
+	hXml->Parse(s.c_str(), nullptr, TIXML_ENCODING_UTF8);
+
+	TiXmlElement *cur;
 	cur = hXml->FirstChildElement("lastupdate");
 	if (cur && cur->ToElement()) {
 		cstrSprintf(&this->lastupdate, "%s", cur->ToElement()->GetText());

--- a/LR2/LR2_replay.cpp
+++ b/LR2/LR2_replay.cpp
@@ -1,7 +1,7 @@
 ﻿#include "LR2_replay.h"
 #include "Engine.h"
 #include "filesystem.h"
-
+#include "filesystem.h"
 #include <filesystem>
 #include <system_error>
 
@@ -127,7 +127,7 @@ int SaveReplay(REPLAY *rp, CSTR songMD5, CSTR localID) {
 
 	CSTR path;
 	cstrSprintf(&path, fs::make_preferred("LR2files/Replay/%s/%s.lr2rep").data(), localID.body, songMD5.body);
-	pFile = _wfopen(utf2ws(path.body).c_str(), L"wb");
+	pFile = fopen(path.body, "wb");
 	if (pFile == NULL) {
 		ErrorLogAdd("リプレイデータの保存に失敗しました。\n");
 		return -1;

--- a/LR2/LR2_replay.cpp
+++ b/LR2/LR2_replay.cpp
@@ -127,7 +127,7 @@ int SaveReplay(REPLAY *rp, CSTR songMD5, CSTR localID) {
 
 	CSTR path;
 	cstrSprintf(&path, fs::make_preferred("LR2files/Replay/%s/%s.lr2rep").data(), localID.body, songMD5.body);
-	pFile = fopen(path, "wb");
+	pFile = _wfopen(utf2ws(path.body).c_str(), L"wb");
 	if (pFile == NULL) {
 		ErrorLogAdd("リプレイデータの保存に失敗しました。\n");
 		return -1;

--- a/LR2/LR2_skindraw.cpp
+++ b/LR2/LR2_skindraw.cpp
@@ -856,45 +856,17 @@ int LRDrawImg(int *grHandle, DSTdraw *dstD) {
 }
 
 int GetTextGraphLength(CSTR *str, ImageFont *imF) {
-	int pos;
-	int ret;
-	char ch;
-	ushort vCh;
-	int x, y;
-
-	pos = 0;
-	ret = 0;
-
-	if (*(str->atPos(0)) == '\0') return 0;
-	do {
-		if (str->length() <= pos) return ret;
-		ch = *str->atPos(pos);
-		// 'ch < 0x81 || (0x9f < ch && (ch < 0xe0 || 0xfd < ch))' is replaced with !IsMultiByte()
-		if (!IsMultibyte(ch)) {
-			if (ch < 0)
-				vCh = *str->atPos(pos) + 0x100;
-			else
-				vCh = *str->atPos(pos);
-		}
-		else {
-			vCh = (*str->atPos(pos) << 8) + (uchar)*str->atPos(pos + 1);
-			if (vCh > 0xFF) {
-				if (vCh >= 0x9ffe) vCh += 0xbfbf;
-				vCh += 0x7fc0;
-			}
-		}
-		if (vCh >= 0x3bce) vCh = 0x3f;
-		
-		if (imF->chars[vCh].grHandle == -1) LoadFontCharGraph(imF, vCh);
-		GetGraphSize(imF->chars[vCh].grHandle, &x, &y);
-
-		ch = *str->atPos(pos);
-		if (!IsMultibyte(ch)) pos += 1;
-		else pos += 2;
-		ret += imF->kerning + x;
-		if (*str->atPos(pos) == 0 || pos >= str->length()) ret -= imF->kerning;
-	} while (*str->atPos(pos) != '\0');
-	return ret;
+	int totalX = 0;
+	if (str->length() == 0) return 0;
+	std::u32string u32Str = utf8_to_utf32(str->body);
+	for (auto& ch : u32Str) {
+		int x = 0, y = 0;
+		auto& chTex = imF->chars[ch];
+		if (chTex.grHandle == -1) LoadFontCharGraph(imF, ch);
+		GetGraphSize(chTex.grHandle, &x, &y);
+		totalX += imF->kerning + x;
+	}
+	return totalX - imF->kerning;
 }
 
 void LRDrawText(int* grHandle, DSTdraw *dstd, CSTR *str, ImageFont *imF) {
@@ -926,12 +898,7 @@ void LRDrawText(int* grHandle, DSTdraw *dstd, CSTR *str, ImageFont *imF) {
 					dstd->x = dstd->x - (int)(width*wl);
 				}
 				GetTimeWrap();
-				if (wl == 1.0 && hl == 1.0) {
-					DrawStringToHandle(dstd->x, dstd->y, str->outstr(), GetColor(dstd->r, dstd->g, dstd->b), *grHandle, 0, 0);
-				}
-				else {
-					DrawExtendStringToHandle(dstd->x, dstd->y, wl, hl, str->outstr(), GetColor(dstd->r, dstd->g, dstd->b), *grHandle, 0, 0);
-				}
+				DrawExtendStringToHandle(dstd->x, dstd->y, wl, hl, str->outstr(), GetColor(dstd->r, dstd->g, dstd->b), *grHandle, 0, 0);
 			}
 		}
 	}
@@ -955,39 +922,24 @@ void LRDrawText(int* grHandle, DSTdraw *dstd, CSTR *str, ImageFont *imF) {
 			}
 
 			wSum = 0.0;
-			for (int i = 0; *str->atPos(i) && i < str->length();) {
-				ch = *str->atPos(i);
-				// 'ch < 0x81 || (0x9f < ch && (ch < 0xe0 || 0xfd < ch))' is replaced with !IsMultiByte()
-				if (IsMultibyte(ch)) {
-					vCh = (*str->atPos(i) << 8) + (uchar)*str->atPos(i + 1);
-
-					if (vCh >= 0x9ffe) vCh += 0xbfbf;
-					vCh += 0x7fc0;
-				}
-				else {
-					vCh = (uchar)*str->atPos(i);
-				}
-				if (vCh >= 0x3bce) vCh = 0x3f;
-
-				if (imF->chars[vCh].grHandle == -1) LoadFontCharGraph(imF, vCh);
-				
-				GetGraphSize(imF->chars[vCh].grHandle, &x, &y);
+			std::u32string u32Str = utf8_to_utf32(str->body);
+			for (auto ch : u32Str) {
+				auto chTex = imF->chars[ch];
+				GetGraphSize(chTex.grHandle, &x, &y);
 				xf = x;
 				yf = y;
 				if (xf <= 0.0) {
-					vCh = 0x3f;
-					GetGraphSize(imF->chars[0x3f].grHandle, &x, &y);
+					ch = U'?';
+					chTex = imF->chars[ch];
+					GetGraphSize(chTex.grHandle, &x, &y);
 					xf = x;
 					yf = y;
 				}
 				xf *= wl;
-				if (vCh != 0x20 && vCh != 0x0A && imF->chars[vCh].grHandle != -1) {
-					DrawExtendGraphF(dstd->x + wSum, dstd->y, dstd->x + wSum + xf, dstd->y + hl*yf, imF->chars[vCh].grHandle, 1);
+				if (ch != U' ' && ch != U'\n' && chTex.grHandle != -1) {
+					DrawExtendGraphF(dstd->x + wSum, dstd->y, dstd->x + wSum + xf, dstd->y + hl * yf, chTex.grHandle, 1);
 				}
-				ch = *str->atPos(i);
-				if (IsMultibyte(ch)) i += 2; 
-				else i += 1;
-				wSum = imF->kerning*wl + xf + wSum;
+				wSum = imF->kerning * wl + xf + wSum;
 			}
 			return;
 		}

--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -3,7 +3,7 @@
 #include "LR2_configsave.h"
 #include "En_fileutil.h"
 #include "filesystem.h"
-
+#include "filesystem.h"
 bool IsMultibyte(byte ch){
 	/*if (0x80 < ch) {
 		if (ch < 0xa0) return true;
@@ -938,7 +938,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 	ErrorLogFmtAdd("スキンの読み込みを開始します。 %s\n", FilePath.body);
 	ErrorLogTabAdd();
 
-	pFile = _wfopen(utf2ws(FilePath.body).c_str(), L"r");
+	pFile = fopen(FilePath.body, "r");
 	CSTR dir(FilePath.getDirectory());
 	line = 0;
 
@@ -949,6 +949,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 	}
 	pFbuf = fBuf.outstr();
 	for (pFbuf = fgets(pFbuf, 1023, pFile); pFbuf; pFbuf = fgets(pFbuf, 1023, pFile)) {
+		fBuf = ansi2utf(pFbuf, 932).c_str();
 		//if (sk->image.dstSize - 1 == sk->image.srcSize) {
 		//	sk->image.src = (SRCstruct*)realloc(sk->image.src, (sk->image.dstSize + 50) * sizeof(SRCstruct));
 		//	sk->image.dst = (DSTstruct*)realloc(sk->image.dst, (sk->image.dstSize + 50) * sizeof(DSTstruct));

--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -1,6 +1,7 @@
 ﻿#include "LR2_skinload.h"
 #include "LR2_skindraw.h"
 #include "LR2_configsave.h"
+#include "En_fileutil.h"
 #include "filesystem.h"
 
 bool IsMultibyte(byte ch){
@@ -435,12 +436,7 @@ int InitSkin(skstruct *sk, int /*unused*/, char font) {
 	InitSRC(&sk->src_README[1]);
 	InitDST(&sk->dst_README[1]);
 	for (int i = 0; i < 10; i++) {
-		if (sk->ImageFonts[i].images == NULL) {
-			sk->ImageFonts[i].images = (FontImage*)malloc(1000 * sizeof(FontImage));
-		}
-		if (sk->ImageFonts[i].chars == NULL) {
-			sk->ImageFonts[i].chars = (FontChar*)malloc(0x3bce * sizeof(FontChar));
-		}
+		sk->ImageFonts[i].images.resize(1000);
 	}
 	sk->count = 0;
 	sk->num_of_struct = 0;
@@ -520,9 +516,9 @@ int InitImageFont(ImageFont *imgfont) {
 	imgfont->size = 0;
 	imgfont->kerning = 0;
 	imgfont->filepath[0] = '\0';
-	for (int i = 0; i < 0x3BCE; i++) {
-		DeleteGraph(imgfont->chars[i].grHandle);
-		imgfont->chars[i].grHandle = -1;
+	for (auto& [ch, chTex] : imgfont->chars) {
+		DeleteGraph(chTex.grHandle);
+		chTex.grHandle = -1;
 	}
 	for (int i = 0; i < 1000; i++) {
 		DeleteGraph(imgfont->images[i].grHandle);
@@ -540,9 +536,9 @@ int ReadImageFont(CSTR filename, ImageFont *imgfont) {
 	if (strcmp(str1, imgfont->filepath)) {
 		imgfont->size = 0;
 		imgfont->kerning = 0;
-		for (int i = 0; i < 0x3bce; i++) {
-			DeleteGraph(imgfont->chars[i].grHandle);
-			imgfont->chars[i].grHandle = -1;
+		for (auto& [idx, chTex] : imgfont->chars) {
+			DeleteGraph(chTex.grHandle);
+			chTex.grHandle = -1;
 		}
 		for (int i = 0; i < 1000; i++) {
 			DeleteGraph(imgfont->images[i].grHandle);
@@ -566,11 +562,35 @@ int ReadImageFont(CSTR filename, ImageFont *imgfont) {
 				DealWhiteSpace(&str2);
 				SplitCSV(str2, &csvBuf, ",");
 				if (*str2.atPos(1) == 'R') {
-					imgfont->chars[csvBuf.val[1]].srcX = csvBuf.val[3];
-					imgfont->chars[csvBuf.val[1]].srcY = csvBuf.val[4];
-					imgfont->chars[csvBuf.val[1]].width = csvBuf.val[5];
-					imgfont->chars[csvBuf.val[1]].height = csvBuf.val[6];
-					imgfont->chars[csvBuf.val[1]].ImageNum = csvBuf.val[2];
+					char s_sjis[3]{ 0 };
+					int chInt = csvBuf.val[1];
+					if (chInt >= 0 && chInt <= 255)
+					{
+						// ID = ASCII
+						s_sjis[0] = chInt & 0xFF;
+					}
+					else if (chInt >= 256 && chInt <= 8126)
+					{
+						// ID = Shift-JIS文字コードを10進数に変換して32832を引いた値
+						int i = chInt + 32832;
+						s_sjis[0] = (i >> 8) & 0xFF;
+						s_sjis[1] = i & 0xFF;
+					}
+					else if (chInt >= 8127 && chInt <= 15306)
+					{
+						// ID = Shift-JIS文字コードを10進数に変換して49281を引いてた値
+						int i = chInt + 49281;
+						s_sjis[0] = (i >> 8) & 0xFF;
+						s_sjis[1] = i & 0xFF;
+					}
+					std::u32string u32Ch = utf8_to_utf32(ansi2utf(s_sjis, 932));
+					char32_t chIdx = u32Ch.front();
+					auto& chTex = imgfont->chars[chIdx];
+					chTex.srcX = csvBuf.val[3];
+					chTex.srcY = csvBuf.val[4];
+					chTex.width = csvBuf.val[5];
+					chTex.height = csvBuf.val[6];
+					chTex.ImageNum = csvBuf.val[2];
 				}
 				else if (*str2.atPos(1) == 'M') {
 					imgfont->kerning = csvBuf.val[1];
@@ -591,68 +611,42 @@ int ReadImageFont(CSTR filename, ImageFont *imgfont) {
 	return 1;
 }
 
-int LoadFontGraph(ImageFont *imgfont, int *fontNum){
-	int fnum;
-	
-	fnum = *fontNum;
-	if ( 0 <= fnum && fnum < 1000 && imgfont->images[fnum].grHandle == -1 ) {
+int LoadFontGraph(ImageFont *imgfont, int fontNum) {
+	if ( 0 <= fontNum && fontNum < 1000 && imgfont->images[fontNum].grHandle == -1 ) {
 		CSTR str(imgfont->filepath, 0);
-		str.add(imgfont->images[fnum].filename);
-		DeleteGraph(imgfont->images[fnum].grHandle);
-		imgfont->images[fnum].grHandle = LoadGraph(str, 0);
+		str.add(imgfont->images[fontNum].filename);
+		DeleteGraph(imgfont->images[fontNum].grHandle);
+		imgfont->images[fontNum].grHandle = LoadGraph(str, 0);
 		return 1;
 	}
 	return 0;
 }
 
-int LoadFontCharGraph(ImageFont *imgfont, ushort vChar){
-	FontImage *fb;
-	int fNum;
-	FontChar *fc;
-
-	if (0x3bcd < vChar) {
-		return 0;
-	}
-	fc = imgfont->chars;
-	fNum = fc[vChar].ImageNum;
-	if (0 <= fNum && fNum < 1000 && fc[vChar].grHandle == -1 && 0 < fc[vChar].height && 0 < fc[vChar].width) {
-		fb = imgfont->images;
-		if (fb[fNum].grHandle == -1) {
-			LoadFontGraph(imgfont, &fc[vChar].ImageNum);
-			fb = imgfont->images;
+int LoadFontCharGraph(ImageFont *imgfont, char32_t vChar) {
+	auto& fc = imgfont->chars[vChar];
+	int fNum = fc.ImageNum;
+	auto& fb = imgfont->images[fNum];
+	if (0 <= fNum && fNum < 1000 && fc.grHandle == -1 && 0 < fc.height && 0 < fc.width) {
+		if (fb.grHandle == -1) {
+			LoadFontGraph(imgfont, fc.ImageNum);
 			/* load failure check */
-			if (fb[imgfont->chars[vChar].ImageNum].grHandle == -1) {
+			if (fb.grHandle == -1) {
 				return 0;
 			}
 		}
-		fc = imgfont->chars + vChar;
-		imgfont->chars[vChar].grHandle = DerivationGraph(fc->srcX, fc->srcY, fc->width, fc->height, fb[fc->ImageNum].grHandle);
+		fc.grHandle = DerivationGraph(fc.srcX, fc.srcY, fc.width, fc.height, fb.grHandle);
 		return 1;
 	}
 	return 0;
 }
 
 int LoadFontForText(ImageFont *imgfont, CSTR *str){
-	ushort twochar;
-
-	if (str->length() <= 0) return 0;
-
-	for (int i = 0; *str->atPos(i) && i < str->length(); ) {
-		if ( IsMultibyte(*str->atPos(i)) ) {
-			twochar = (*str->atPos(i) << 8) + (uchar)*str->atPos(i + 1);
-			if (twochar >= 0x9ffe) {
-				twochar += 0xbfbf;
-			}
-			twochar += 0x7fc0;
-			i += 2;
-		}
-		else {
-			twochar = (uchar)*str->atPos(i);
-			i++;
-		}
-
-		if (imgfont->chars[twochar].grHandle == -1){
-			LoadFontCharGraph(imgfont,twochar);
+	if (str->length() <= 0 /*|| imgfont->size == 0*/) return 0;
+	std::u32string u32str = utf8_to_utf32(str->body);
+	for (auto& ch : u32str) {
+		auto& chTex = imgfont->chars[ch];
+		if (chTex.grHandle == -1) {
+			LoadFontCharGraph(imgfont, ch);
 		}
 	}
 	return 1;
@@ -944,7 +938,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 	ErrorLogFmtAdd("スキンの読み込みを開始します。 %s\n", FilePath.body);
 	ErrorLogTabAdd();
 
-	pFile = fopen(FilePath, "r");
+	pFile = _wfopen(utf2ws(FilePath.body).c_str(), L"r");
 	CSTR dir(FilePath.getDirectory());
 	line = 0;
 
@@ -1090,7 +1084,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						else {
 							SplitCSV(fBuf, &csv, ",");
 							//sk->fontHandle[sk->num_of_struct] = CreateFontToHandle(sk->fontname, csv.val[1], csv.val[2], csv.val[3], 0, -1, 0, -1, -1); //DxLib3.02
-							sk->fontHandle[sk->num_of_struct] = CreateFontToHandle(sk->fontname, csv.val[1], csv.val[2], csv.val[3], 0, -1, 0, -1); //DxLib3.24f
+							sk->fontHandle[sk->num_of_struct] = CreateFontToHandle(sk->fontname.body, csv.val[1], csv.val[2], csv.val[3], DX_CHARSET_UTF8, -1, 0, -1); //DxLib3.24f
 							if (sk->fontHandle[sk->num_of_struct] == -1) {
 								sk->fontHandle[sk->num_of_struct] = 0;
 							}

--- a/LR2/LR2_skinload.h
+++ b/LR2/LR2_skinload.h
@@ -5,8 +5,8 @@ int InitImageFont(ImageFont * imgfont);
 int ReadImageFont(CSTR filename, ImageFont * imgfont);
 
 //imagefont img load on draw
-int LoadFontGraph(ImageFont * imgfont, int * fontNum);
-int LoadFontCharGraph(ImageFont * imgfont, ushort vChar);
+int LoadFontGraph(ImageFont * imgfont, int fontNum);
+int LoadFontCharGraph(ImageFont * imgfont, char32_t vChar);
 int LoadFontForText(ImageFont * imgfont, CSTR * str);
 
 //skinobj

--- a/LR2/LR2_skinmanage.cpp
+++ b/LR2/LR2_skinmanage.cpp
@@ -1,8 +1,9 @@
 ﻿#include "LR2_skinmanage.h"
+#include "En_fileutil.h"
 #include "Engine.h"
 #include "LR2_configsave.h"
 #include "filesystem.h"
-
+#include "filesystem.h"
 #include <filesystem>
 
 //maybe deleted by compiler, restored it for convenience
@@ -222,13 +223,14 @@ int ParseLR2SkinCustom(SkinManage *skm, CSTR filepath) {
 
 	cstrSprintf(&md5Filepath, fs::make_preferred("LR2files/SkinCustomize/%s.xml").data(), MD5str(filepath) );
 	ReadSkinCustomize(&skCustom, md5Filepath);
-	pFile = _wfopen(utf2ws(filepath.body).c_str(), L"r");
+	pFile = fopen(filepath.body, "r");
 	if (!pFile) return 0;
 
 	pBuffer = buffer.outstr();
 	for (pBuffer = fgets(pBuffer,256,pFile) ; pBuffer ; pBuffer = fgets(pBuffer, 256, pFile)) {
 		buffer.trimWhiteSpace();
 		DealWhiteSpace(&buffer);
+		buffer = ansi2utf(pBuffer, 932).c_str();
 		if (buffer.left(12).isSame("#INFORMATION")) {
 			SplitCSV(buffer, &csvBuf, ",");
 			if (csvBuf.val[1] < 0) {
@@ -381,30 +383,6 @@ int ParseLR2SkinCustom(SkinManage *skm, CSTR filepath) {
 int MakeSkinList(SkinManage *skm, CSTR dir) {
 	if (dir.right(1).isDiff("\\") && dir.right(1).isDiff("/"))
 		dir.add("\\");
-#ifdef _WIN32
-	CSTR filter;
-	filter.assign(&dir).add("*");
-	HANDLE hFindFile, hFindFileOld;
-	_WIN32_FIND_DATAA findFileData;
-	hFindFile = FindFirstFileA(filter, &findFileData);
-	do{
-		if ( (findFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) {
-			filter.assign(&dir).add(findFileData.cFileName);
-			if (filter.right(8).isSame(".lr2skin") || filter.right(6).isSame(".lr2ss")) ParseLR2SkinCustom(skm, filter);
-		}
-		else {  //logic arranged
-		if (strcmp("..", findFileData.cFileName) && strcmp(".", findFileData.cFileName)) {
-			filter.assign(&dir).add(findFileData.cFileName).add("\\");
-			MakeSkinList(skm, filter);
-		}
-		}
-		hFindFileOld = hFindFile;
-		if (FindNextFileA(hFindFile, &findFileData) == 0) {
-			FindClose(hFindFileOld);
-			return 0;
-		}
-	} while (true);
-#else // TODO(utf-8): use this
 #ifndef _WIN32
 	dir.replace("\\", "/");
 #endif // _WIN32
@@ -420,5 +398,4 @@ int MakeSkinList(SkinManage *skm, CSTR dir) {
 		}
 	}
 	return 0;
-#endif // _WIN32
 }

--- a/LR2/LR2_skinmanage.cpp
+++ b/LR2/LR2_skinmanage.cpp
@@ -222,7 +222,7 @@ int ParseLR2SkinCustom(SkinManage *skm, CSTR filepath) {
 
 	cstrSprintf(&md5Filepath, fs::make_preferred("LR2files/SkinCustomize/%s.xml").data(), MD5str(filepath) );
 	ReadSkinCustomize(&skCustom, md5Filepath);
-	pFile = fopen(filepath, "r");
+	pFile = _wfopen(utf2ws(filepath.body).c_str(), L"r");
 	if (!pFile) return 0;
 
 	pBuffer = buffer.outstr();

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -7,7 +7,7 @@
 #include "LR2_statplay.h"
 #include "Scenes.h"
 #include "filesystem.h"
-
+#include "filesystem.h"
 #include <DxLib/DxLib.h>
 
 #ifndef _WIN32
@@ -4255,7 +4255,7 @@ int ReadOptionstrFile(OptionString *arrOpStr, CSTR filepath) {
 	CSVbuf csv;
 
 	DefineOptionStrNum(arrOpStr);
-	pFile = _wfopen(utf2ws(filepath.body).c_str(), L"r");
+	pFile = fopen(filepath.body, "r");
 	if (pFile == 0) {
 		ErrorLogAdd("オプション文字列リストが見つかりません。\n");
 		return 0;
@@ -4263,6 +4263,7 @@ int ReadOptionstrFile(OptionString *arrOpStr, CSTR filepath) {
 
 	pFbuf = fBuf.outstr();
 	for (pFbuf = fgets(pFbuf, bufSize, pFile); pFbuf; pFbuf = fgets(pFbuf, bufSize, pFile)) {
+		fBuf = ansi2utf(pFbuf, 932).c_str();
 		if (*(fBuf.atPos(0)) == '#') {
 			SplitCSV(fBuf, &csv, ",");
 

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -4255,7 +4255,7 @@ int ReadOptionstrFile(OptionString *arrOpStr, CSTR filepath) {
 	CSVbuf csv;
 
 	DefineOptionStrNum(arrOpStr);
-	pFile = fopen(filepath, "r");
+	pFile = _wfopen(utf2ws(filepath.body).c_str(), L"r");
 	if (pFile == 0) {
 		ErrorLogAdd("オプション文字列リストが見つかりません。\n");
 		return 0;

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -2,7 +2,7 @@
 #include "Engine.h"
 #include "LR2_statlong.h"
 #include "filesystem.h"
-
+#include "filesystem.h"
 #include <iterator>
 
 #ifdef _WIN32
@@ -2680,7 +2680,7 @@ int ParseBMSMETA(BMSMETA *meta, CSTR filepath, char flag) {
 	InitBMSMETA(meta);
 	notes = 0.0;
 	flagIf = 0;
-	pFile = _wfopen(utf2ws(filepath.body).c_str(), L"r");
+	pFile = fopen(filepath.body, "r");
 	if (pFile == NULL) return 0;
 
 	CSTR dir(filepath.getDirectory()); // check this works as intended
@@ -2690,6 +2690,7 @@ int ParseBMSMETA(BMSMETA *meta, CSTR filepath, char flag) {
 	CSTR buffer(102401);
 	char* pBuffer = buffer.outstr();
 	for (pBuffer = fgets(pBuffer, 102400, pFile); pBuffer; pBuffer = fgets(pBuffer, 102400, pFile)) {
+		buffer = ansi2utf(pBuffer, 932).c_str();
 
 		if (buffer.left(3).isSame("#IF") && buffer.left(5).isDiff("#IF 1")) {
 			flagIf = 1;

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -2680,7 +2680,7 @@ int ParseBMSMETA(BMSMETA *meta, CSTR filepath, char flag) {
 	InitBMSMETA(meta);
 	notes = 0.0;
 	flagIf = 0;
-	pFile = fopen(filepath, "r");
+	pFile = _wfopen(utf2ws(filepath.body).c_str(), L"r");
 	if (pFile == NULL) return 0;
 
 	CSTR dir(filepath.getDirectory()); // check this works as intended
@@ -2899,7 +2899,7 @@ int ParseBMSMETA(BMSMETA *meta, CSTR filepath, char flag) {
 	} // TOFIX: meta->filepath is not loaded yet, so above this is useless hahahaha
 	//TOFIX: find difficulty at left???
 	makeFileHash(filepath, meta->hash); //test : CSTR to char* as oBuf : possible
-	meta->parentfolderpath = filepath.getParaentDirectory();
+	meta->parentfolderpath = filepath.getParentDirectory();
 	meta->filepath = filepath;
 	meta->filename = filepath.getFilename();
 	meta->folderpath = filepath.getDirectory();

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -28,21 +28,12 @@ int WINAPI WinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPSTR /
 	return main(__argc, __argv);
 }
 
-/* TODO(utf-8): use this
 static std::filesystem::path GetExecutablePath()
 {
-	wchar_t fullpath[256]{};
+	wchar_t fullpath[MAX_PATH]{};
 	if (!GetModuleFileNameW(nullptr, fullpath, std::size(fullpath)))
 		return {};
 	return std::filesystem::path(fullpath).parent_path();
-}
-*/
-
-static std::filesystem::path GetExecutablePath()
-{
-	std::wstring exePath(MAX_PATH, 0);
-	GetModuleFileNameW(nullptr, exePath.data(), MAX_PATH);
-	return std::filesystem::path(exePath).parent_path();
 }
 
 #else
@@ -85,23 +76,18 @@ int main(int argc, char** argv) {
 	while (!IsDebuggerPresent()) std::this_thread::sleep_for(std::chrono::milliseconds(200));
 #endif
 
-	int loadingGrHandle;
-
 	sqlite3* sql3;
-
-	CSTR pathScoreDB;
-	CSTR newPath;
-	DATEDATA date;
 
 	int wSizeY;
 	int wSizeX;
-	int lr1ir;
-	int lr2ir;
 	game gs;
 
 	const bool use_dx9 = getenv("OPENLR2_NO_DX9") == nullptr; // chown2: crashes on DxLib_Init with DX9 for me
 
 	int tmp;
+
+	SetUseCharCodeFormat(DX_CHARCODEFORMAT_UTF8);
+	SetFontCharCodeFormat(DX_CHARCODEFORMAT_UTF8);
 
 	{
 		auto curDir = GetExecutablePath();
@@ -148,8 +134,8 @@ int main(int argc, char** argv) {
 		gs.config.jukebox.numOfPath = 1;
 		gs.config.jukebox.path[0].assign("BeatVocaloids/");
 	}
-	lr1ir = gs.config.network.lr1ir;
-	lr2ir = gs.config.network.lr2ir;
+	int lr1ir = gs.config.network.lr1ir;
+	int lr2ir = gs.config.network.lr2ir;
 	ReadMIDI(&gs, fs::make_preferred("LR2files/Config/midi.xml").data());
 	if (gs.config.system.softwarerendering == 1) {
 		SetUse3DFlag(0);
@@ -230,6 +216,7 @@ int main(int argc, char** argv) {
 		}
 	}
 	gs.config.system.thread = 0;
+	CSTR pathScoreDB;
 	cstrSprintf(&pathScoreDB, "LR2files/Database/Score/%s.db", gs.config.player.id.body);
 	if (gs.is_starter == '\0') {
 		if (IsFileExist(pathScoreDB) == false) {
@@ -251,6 +238,7 @@ int main(int argc, char** argv) {
 	if (gs.config.select.disabledifficultyfilter == 1) gs.config.select.ignoredifficultyall = 0;
 	memcpy(&gs.sSelect.filter, &gs.config.select, sizeof(CONFIG_SELECT));
 	{
+		CSTR newPath;
 		std::error_code ec; // ignore errors
 		cstrSprintf(&newPath, "LR2files/Replay/%s", gs.config.player.id.body);
 		std::filesystem::create_directories(newPath.body, ec);
@@ -334,8 +322,6 @@ int main(int argc, char** argv) {
 		ErrorLogFmtAdd("動画作成モードなのでVSyncを待ちます。\n");
 	}
 #ifdef _WIN32
-	SetUseCharCodeFormat(DX_CHARCODEFORMAT_UTF8);
-	SetFontCharCodeFormat(DX_CHARCODEFORMAT_UTF8);
 	SetMultiThreadFlag(1);
 	SetUseFPUPreserveFlag(1);
 	SetUseDirectInputFlag(1); //DXLIBVER: not in original, but we need it to make same reaction.
@@ -372,7 +358,7 @@ int main(int argc, char** argv) {
 		ErrorLogAdd(gs.net.request_result);
 	}
 
-	loadingGrHandle = LoadGraph(fs::make_preferred("LR2files/Config/loading.bmp").data(), 0);
+	int loadingGrHandle = LoadGraph(fs::make_preferred("LR2files/Config/loading.bmp").data(), 0);
 
 	int backgroundGrHandle = MakeScreen(640, 480, 0); //TODO_RESOULUTION
 	SetDrawScreen(backgroundGrHandle);
@@ -1981,6 +1967,7 @@ int main(int argc, char** argv) {
 			gs.timer1.vSyncTick = GetTimeWrap();
 			if (gs.flag_Screenshot) {
 				gs.flag_Screenshot = false;
+				DATEDATA date;
 				GetDateTime(&date);
 				CSTR captureFilename;
 				cstrSprintf(&captureFilename, "screenshot/LR2 %04d-%02d-%02d %02d-%02d-%02d.png", date.Year, date.Mon, date.Day, date.Hour, date.Min, date.Sec);

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -38,6 +38,13 @@ static std::filesystem::path GetExecutablePath()
 }
 */
 
+static std::filesystem::path GetExecutablePath()
+{
+	std::wstring exePath(MAX_PATH, 0);
+	GetModuleFileNameW(nullptr, exePath.data(), MAX_PATH);
+	return std::filesystem::path(exePath).parent_path();
+}
+
 #else
 
 #include <iostream>
@@ -96,21 +103,11 @@ int main(int argc, char** argv) {
 
 	int tmp;
 
-#ifdef _WIN32
-	{
-		char curDir[260];
-		GetModuleFileName(NULL, (LPCH)curDir, 260);
-		*(char*)(strrchr(curDir, '\\') + 1) = '\x00';
-		SetCurrentDirectory((LPCSTR)curDir);
-		gs.baseDirectory.assign(curDir, 0).add("\\");
-	}
-#else // TODO(utf-8): use this
 	{
 		auto curDir = GetExecutablePath();
 		std::filesystem::current_path(curDir);
 		gs.baseDirectory.assign(curDir.string().c_str(), 0).add("/");
 	}
-#endif // _WIN32
 
 	gs.is_starter = false;
 	auto copy_if_not_exists = [](auto&& from, auto&& to_) {
@@ -337,6 +334,8 @@ int main(int argc, char** argv) {
 		ErrorLogFmtAdd("動画作成モードなのでVSyncを待ちます。\n");
 	}
 #ifdef _WIN32
+	SetUseCharCodeFormat(DX_CHARCODEFORMAT_UTF8);
+	SetFontCharCodeFormat(DX_CHARCODEFORMAT_UTF8);
 	SetMultiThreadFlag(1);
 	SetUseFPUPreserveFlag(1);
 	SetUseDirectInputFlag(1); //DXLIBVER: not in original, but we need it to make same reaction.
@@ -390,8 +389,8 @@ int main(int argc, char** argv) {
 	}
 	if (gs.is_starter == false) {
 		if (gs.cmd_directplay == false) {
-			printfDx(LR2VERSIONSTRING);
-			printfDx("\nPUSH ANY KEY\n");
+			printfDx(LR2VERSIONSTRING"\n");
+			printfDx("PUSH ANY KEY\n");
 			if (loadingGrHandle > 0) {
 				DrawGraph(0, 0, loadingGrHandle, 0);
 			}
@@ -470,7 +469,6 @@ int main(int argc, char** argv) {
 	for (int i = 0; i < 20; i++) gs.skstruct.customfile[i].fillzero();
 	gs.skstruct.skinMD5.fillzero();
 	gs.skstruct.skFontname.fillzero();
-	memset(&gs.skstruct, 0, sizeof(skstruct));
 	for (int i = 0; i < 200; i++) gs.skstruct.caption[i].fillzero();
 	for (int i = 0; i < 200; i++) gs.skstruct.caption[i].assign("(null)");
 	for (int i = 0; i < 200; i++) gs.skstruct.GrHandle[i] = -1;
@@ -520,7 +518,6 @@ int main(int argc, char** argv) {
 	for (int i = 0; i < 20; i++) gs.skstruct2.customfile[i].fillzero();
 	gs.skstruct2.skinMD5.fillzero();
 	gs.skstruct2.skFontname.fillzero();
-	memset(&gs.skstruct2, 0, sizeof(skstruct));
 	for (int i = 0; i < 200; i++) gs.skstruct2.caption[i].fillzero();
 	for (int i = 0; i < 200; i++) gs.skstruct2.caption[i].assign("(null)");
 	for (int i = 0; i < 200; i++) gs.skstruct2.GrHandle[i] = -1;

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -3,7 +3,6 @@
 #include "LR2.h"
 #include <stdio.h>
 #include "filesystem.h"
-
 #ifndef _WIN32
 #include "En_dxlibstub.h"
 #endif // _WIN32
@@ -650,7 +649,7 @@ int ShowReadmes(game *g) {
 		g->txtStruct.readme.path = g->txtStruct.readme.folderpath;
 		g->txtStruct.readme.path.add(filename.c_str());
 
-		_wfopen_s(&pFile, utf2ws(g->txtStruct.readme.path.body).c_str(), L"r");
+		pFile = fopen(g->txtStruct.readme.path.body, "r");
 
 		char *pFbuf = fBuf.outstr();
 		if (pFile != NULL) {
@@ -713,17 +712,14 @@ int ShowReadme(game *g, CSTR path) {
 
 	CSTR fBuf(0x400);
 
-#ifdef _WIN32
-	_wfopen_s(&pFile, utf2ws(g->txtStruct.readme.path.body).c_str(), L"r");
-#else
 	pFile = fopen(g->txtStruct.readme.path, "r");
-#endif // _WIN32
 
 	char *pFbuf = fBuf.outstr();
 	if (pFile != NULL) {
 		g->txtStruct.readme.show = 1;
 		pFbuf = fBuf.outstr();
 		for (pFbuf = fgets(pFbuf, 0x3FC, pFile); pFbuf; pFbuf = fgets(pFbuf, 0x3FC, pFile)) {
+			fBuf = ansi2utf(pFbuf, 932).c_str();
 			g->txtStruct.readme.body[g->txtStruct.readme.lines] = fBuf;
 			g->txtStruct.readme.lines++;
 			int len = GetTextGraphLength(&fBuf, &g->skstruct.ImageFonts[g->skstruct.src_README[0].cycle]);

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -604,7 +604,7 @@ int ShowReadmes(game *g) {
 #ifdef _WIN32
 	CSTR search;
 	HANDLE hFindFile;
-	WIN32_FIND_DATA FindFileData;
+	WIN32_FIND_DATAW FindFileData;
 	CSTR fBuf(2048);
 
 	FILE *pFile;
@@ -625,7 +625,7 @@ int ShowReadmes(game *g) {
 
 	g->txtStruct.readme.folderpath = g->sSelect.bmsList[g->sSelect.cur_song].filepath.getDirectory();
 	cstrSprintf(&search, "%s*.txt", g->txtStruct.readme.folderpath.body);
-	hFindFile = FindFirstFileA(search, (LPWIN32_FIND_DATAA)&FindFileData);
+	hFindFile = FindFirstFileW(utf2ws(search.body).c_str(), &FindFileData);
 	if (hFindFile == (HANDLE)-1) {
 		ErrorLogFmtAdd("テキストファイルが見つからない。%s\n", search.body);
 		return -1;
@@ -633,7 +633,7 @@ int ShowReadmes(game *g) {
 
 	do {
 		g->txtStruct.readme.file_count++;
-	} while (FindNextFileA(hFindFile, (LPWIN32_FIND_DATAA)&FindFileData));
+	} while (FindNextFileW(hFindFile, &FindFileData));
 	FindClose(hFindFile);
 
 	if (g->txtStruct.readme.file_count == 0) return 0;
@@ -644,28 +644,31 @@ int ShowReadmes(game *g) {
 		g->txtStruct.readme.current = g->txtStruct.readme.file_count-1;
 
 	int currentFileNum = 0;
-	hFindFile = FindFirstFileA(search, (LPWIN32_FIND_DATAA)&FindFileData);
+	hFindFile = FindFirstFileW(utf2ws(search.body).c_str(), &FindFileData);
 	do {
+		std::string filename = ws2utf(FindFileData.cFileName);
 		g->txtStruct.readme.path = g->txtStruct.readme.folderpath;
-		g->txtStruct.readme.path.add((const char*)FindFileData.cFileName);
+		g->txtStruct.readme.path.add(filename.c_str());
 
-		fopen_s(&pFile, g->txtStruct.readme.path, "r");
+		_wfopen_s(&pFile, utf2ws(g->txtStruct.readme.path.body).c_str(), L"r");
 
 		char *pFbuf = fBuf.outstr();
 		if (pFile != NULL) {
 			
 			currentFileNum++;
 			if (g->txtStruct.readme.file_count == 1) {
-				g->txtStruct.readme.body[g->txtStruct.readme.lines] = (const char*)FindFileData.cFileName;
+				g->txtStruct.readme.body[g->txtStruct.readme.lines] = filename.c_str();
 			}
 			else {
-				cstrSprintf(&g->txtStruct.readme.body[g->txtStruct.readme.lines], "%d/%d %s", currentFileNum, g->txtStruct.readme.file_count, FindFileData.cFileName);
+				std::string line = std::format("{}/{} {}", currentFileNum, g->txtStruct.readme.file_count, filename);
+				g->txtStruct.readme.body[g->txtStruct.readme.lines] = line.c_str();
 			}
 			g->txtStruct.readme.lines+=2;
 
 			g->txtStruct.readme.show = 1;
 			pFbuf = fBuf.outstr();
 			for (pFbuf = fgets(pFbuf, 2048, pFile); pFbuf; pFbuf = fgets(pFbuf, 2048, pFile)) {
+				fBuf = ansi2utf(fBuf.body, 932).c_str();
 				DealWhiteSpace(&fBuf);
 				g->txtStruct.readme.body[g->txtStruct.readme.lines] = fBuf;
 				g->txtStruct.readme.lines++;
@@ -677,7 +680,7 @@ int ShowReadmes(game *g) {
 			fclose(pFile);
 			g->txtStruct.readme.lines += 2;
 		}
-	} while (FindNextFileA(hFindFile, (LPWIN32_FIND_DATAA)&FindFileData));
+	} while (FindNextFileW(hFindFile, &FindFileData));
 	FindClose(hFindFile);
 
 	g->txtStruct.readme.y = g->skstruct.src_README[0].op1 * g->txtStruct.readme.lines;
@@ -711,7 +714,7 @@ int ShowReadme(game *g, CSTR path) {
 	CSTR fBuf(0x400);
 
 #ifdef _WIN32
-	fopen_s(&pFile, g->txtStruct.readme.path, "r");
+	_wfopen_s(&pFile, utf2ws(g->txtStruct.readme.path.body).c_str(), L"r");
 #else
 	pFile = fopen(g->txtStruct.readme.path, "r");
 #endif // _WIN32

--- a/LR2/Scene07_Skinselect.cpp
+++ b/LR2/Scene07_Skinselect.cpp
@@ -1,17 +1,10 @@
 #include "Scene07_Skinselect.h"
 #include "LR2.h"
 #include "Scenes.h"
-
+#include "filesystem.h"
 #include "filesystem.h"
 
 int SkinSelect_SoundSet(game *g, CSTR filepath) {
-	
-	FILE *pFile;
-
-	CSTR fBuf(1024);
-	char* pFbuf;
-	CSVbuf csv;
-
 	StopSysSound(g);
 	ReleaseSound(&g->audio, &g->audio.sysSound.select);
 	ReleaseSound(&g->audio, &g->audio.sysSound.folder_open);
@@ -27,25 +20,30 @@ int SkinSelect_SoundSet(game *g, CSTR filepath) {
 	ReleaseSound(&g->audio, &g->audio.sysSound.exselect);
 	if (g->audio.is_fmod_disabled == 0) FMOD_System_Update(g->audio.fmodSys);
 	
-	pFile = _wfopen(utf2ws(filepath.body).c_str(), L"r");
+	FILE* pFile = fopen(filepath.body, "r");
 	if (pFile == 0) return 0;
 
-	pFbuf = fBuf.outstr();
-	for (pFbuf = fgets(pFbuf, 1023, pFile); pFbuf; pFbuf = fgets(pFbuf, 1023, pFile)) {
-		if (*fBuf.atPos(0) = '#') {
-			fBuf.trimWhiteSpace();
-			DealWhiteSpace(&fBuf);
-			if (isdigit(*fBuf.atPos(1)) && isdigit(*fBuf.atPos(2))) {
-				
-				int type = atol(fBuf.getSliced(1, 2));
-				if (type < 0) continue;
+	CSVbuf csv;
 
-				SplitCSV(fBuf, &csv, ",");
-				g->config.skin.skinFilePath[type] = csv.str[1];
-				SetFirstSkin_5k(&g->skinData, (SKINTYPE)type, &g->config.skin.skinFilePath[type]);
-			}
-			*fBuf.atPos(0) = 0;
+	CSTR fBuf(1024);
+	char* pFbuf = fBuf.outstr();
+	for (pFbuf = fgets(pFbuf, 1023, pFile); pFbuf; pFbuf = fgets(pFbuf, 1023, pFile)) {
+		if (*fBuf.atPos(0) != '#') {
+			continue;
 		}
+		fBuf.trimWhiteSpace();
+		DealWhiteSpace(&fBuf);
+		fBuf = ansi2utf(pFbuf, 932).c_str();
+		if (isdigit(*fBuf.atPos(1)) && isdigit(*fBuf.atPos(2))) {
+
+			int type = atol(fBuf.getSliced(1, 2));
+			if (type < 0) continue;
+
+			SplitCSV(fBuf, &csv, ",");
+			g->config.skin.skinFilePath[type] = csv.str[1];
+			SetFirstSkin_5k(&g->skinData, (SKINTYPE)type, &g->config.skin.skinFilePath[type]);
+		}
+		*fBuf.atPos(0) = 0;
 	}
 
 	fclose(pFile);

--- a/LR2/Scene07_Skinselect.cpp
+++ b/LR2/Scene07_Skinselect.cpp
@@ -27,7 +27,7 @@ int SkinSelect_SoundSet(game *g, CSTR filepath) {
 	ReleaseSound(&g->audio, &g->audio.sysSound.exselect);
 	if (g->audio.is_fmod_disabled == 0) FMOD_System_Update(g->audio.fmodSys);
 	
-	pFile = fopen(filepath, "r");
+	pFile = _wfopen(utf2ws(filepath.body).c_str(), L"r");
 	if (pFile == 0) return 0;
 
 	pFbuf = fBuf.outstr();

--- a/LR2/filesystem.h
+++ b/LR2/filesystem.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <cstdio>
 #include <filesystem>
 
 namespace fs {

--- a/LR2/strclass.cpp
+++ b/LR2/strclass.cpp
@@ -1,5 +1,5 @@
 #include "strclass.h"
-
+#include "filesystem.h"
 #include <cstring>
 #include <span>
 #include <string>
@@ -334,7 +334,7 @@ int CSTR::toFile(const char *filepath) {
 	FILE *_File;
 	char *pcVar2;
 
-	_File = _wfopen(utf2ws(filepath).c_str(), L"w");
+	_File = fopen(filepath, "w");
 	if (_File == (FILE *)0x0) {
 		return -1;
 	}
@@ -414,7 +414,7 @@ char* CSTR::atPos(int pos) {
 bool CSTR::canOpenFile() {
 	FILE *_File;
 
-	_File = _wfopen(utf2ws(body).c_str(), L"r");
+	_File = fopen(body, "r");
 	if (_File == NULL) {
 		return false;
 	}

--- a/LR2/strclass.cpp
+++ b/LR2/strclass.cpp
@@ -6,6 +6,9 @@
 #include <string_view>
 #include <cstdarg>
 #include <cctype>
+#include <filesystem>
+
+#include "En_fileutil.h"
 
 typedef unsigned char byte;
 
@@ -50,53 +53,13 @@ DWORD CSTR::CRC32() {
 	if (0 < (int)(pcVar3 + 1)) {
 		do {
 			uVar4 = uVar4 ^ (int)pcVar2[iVar5];
-			if ((uVar4 & 1) == 0) {
-				uVar4 = uVar4 >> 1;
-			}
-			else {
-				uVar4 = uVar4 >> 1 ^ 0xedb88320;
-			}
-			if ((uVar4 & 1) == 0) {
-				uVar4 = uVar4 >> 1;
-			}
-			else {
-				uVar4 = uVar4 >> 1 ^ 0xedb88320;
-			}
-			if ((uVar4 & 1) == 0) {
-				uVar4 = uVar4 >> 1;
-			}
-			else {
-				uVar4 = uVar4 >> 1 ^ 0xedb88320;
-			}
-			if ((uVar4 & 1) == 0) {
-				uVar4 = uVar4 >> 1;
-			}
-			else {
-				uVar4 = uVar4 >> 1 ^ 0xedb88320;
-			}
-			if ((uVar4 & 1) == 0) {
-				uVar4 = uVar4 >> 1;
-			}
-			else {
-				uVar4 = uVar4 >> 1 ^ 0xedb88320;
-			}
-			if ((uVar4 & 1) == 0) {
-				uVar4 = uVar4 >> 1;
-			}
-			else {
-				uVar4 = uVar4 >> 1 ^ 0xedb88320;
-			}
-			if ((uVar4 & 1) == 0) {
-				uVar4 = uVar4 >> 1;
-			}
-			else {
-				uVar4 = uVar4 >> 1 ^ 0xedb88320;
-			}
-			if ((uVar4 & 1) == 0) {
-				uVar4 = uVar4 >> 1;
-			}
-			else {
-				uVar4 = uVar4 >> 1 ^ 0xedb88320;
+			for (int i = 0; i < 8; i++) {
+				if ((uVar4 & 1) == 0) {
+					uVar4 = uVar4 >> 1;
+				}
+				else {
+					uVar4 = uVar4 >> 1 ^ 0xedb88320;
+				}
 			}
 			iVar5 = iVar5 + 1;
 		} while (iVar5 < (int)(pcVar3 + 1));
@@ -371,7 +334,7 @@ int CSTR::toFile(const char *filepath) {
 	FILE *_File;
 	char *pcVar2;
 
-	_File = fopen(filepath, "w");
+	_File = _wfopen(utf2ws(filepath).c_str(), L"w");
 	if (_File == (FILE *)0x0) {
 		return -1;
 	}
@@ -451,7 +414,7 @@ char* CSTR::atPos(int pos) {
 bool CSTR::canOpenFile() {
 	FILE *_File;
 
-	_File = fopen(body, "r");
+	_File = _wfopen(utf2ws(body).c_str(), L"r");
 	if (_File == NULL) {
 		return false;
 	}
@@ -569,34 +532,21 @@ CSTR& CSTR::operator=(const char *str) {
 	return assign(str, 0);
 }
 
-CSTR CSTR::getDirectory() {
-	byte ch;
-	int len;
-	char *str;
-	int pos;
-	int i;
-
-	i = 0;
-	str = this->body;
-	pos = -1;
-	len = length();
-	while (str[i] != '\0') {
-		if ( i >= len - 1 ) break;
-		ch = str[i];
-		if ((byte)((ch ^ 0x20) + 0x5f) < 0x3c) {
-			i = i + 2;
-		}
-		else {
-			if ((ch == '\\') || (ch == '/')) {
-				pos = i;
-			}
-			i = i + 1;
-		}
-	}
-	return left(pos + 1);
+[[nodiscard]] inline const char* cs(const std::u8string& s)
+{
+	// Don't try making this take fs::path, pray on lifetime extension.
+	return reinterpret_cast<const char*>(s.c_str());
 }
 
-CSTR CSTR::getParaentDirectory() {
+CSTR CSTR::getDirectory() {
+	CSTR out;
+	std::filesystem::path path(reinterpret_cast<char8_t*>(this->body));
+	out.assign(cs(path.parent_path().u8string()));
+	*out.atPos(out.length()) = std::filesystem::path::preferred_separator;
+	return out;
+}
+
+CSTR CSTR::getParentDirectory() {
 	return getDirectory().getDirectory();
 }
 

--- a/LR2/strclass.h
+++ b/LR2/strclass.h
@@ -53,7 +53,7 @@ class CSTR {
 		CSTR& assign(const CSTR *iBuf); CSTR& operator=(const CSTR *iBuf); CSTR& operator=(CSTR &iBuf);//duplicated by converting man. delete one later
 		CSTR& assign(const char *str); CSTR& operator=(const char *str);//duplicated by converting man. delete one later
 		CSTR getDirectory();
-		CSTR getParaentDirectory();
+		CSTR getParentDirectory();
 		CSTR& cutDirectorySeparator();
 		CSTR& lastCut(int len);
 		CSTR& trimWhiteSpace();

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -4,6 +4,7 @@
 #include <mutex>
 #include <thread>
 #include <unordered_map>
+#include <vector>
 
 #include "strclass.h"
 

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <mutex>
 #include <thread>
+#include <unordered_map>
 
 #include "strclass.h"
 
@@ -468,8 +469,8 @@ struct COURSESELECT {
 };
 
 struct CSVbuf {
-	int val[30];
-	CSTR str[30];
+	int val[30]{};
+	CSTR str[30]{};
 };
 struct DSTdraw { /* 80bytes,4*0x14 */
 	float x;
@@ -522,17 +523,17 @@ struct DSTstruct { /* 44bytes.4*0x0b */
 };
 
 struct FontChar {
-	int srcX;
-	int srcY;
-	int width;
-	int height;
-	int ImageNum;
-	int grHandle;
+	int srcX{};
+	int srcY{};
+	int width{};
+	int height{};
+	int ImageNum{};
+	int grHandle = -1;
 };
 
 struct FontImage {
-	char filename[32];
-	int grHandle;
+	char filename[32]{};
+	int grHandle = -1;
 };
 
 struct RECORDING {
@@ -681,11 +682,11 @@ struct SkinAdjust {
 };
 
 struct ImageFont {
-	int size;
-	int kerning;
-	char filepath[260];
-	struct FontImage * images; /* est.array size 1000 */
-	struct FontChar * chars; /* est.array size 0x3bce */
+	int size{};
+	int kerning{};
+	char filepath[260]{};
+	std::vector<FontImage> images; /* est.array size 1000 */
+	std::unordered_map<char32_t, FontChar> chars;
 };
 
 struct SRCstruct { /* 68bytes,4*0x11 */
@@ -716,116 +717,116 @@ struct SkinObject {
 };
 
 struct skstruct {
-	char op[1000];
-	int startinput_start;
-	int startinput_rank;
-	int startinput_update;
-	int scenetime;
-	int loadstart;
-	int loadend;
-	int playstart;
-	int fadeout;
-	int close; /* =skip */
-	int GrHandle[200]; /* //101_gr_title */
-	int grIsMovie[200];
-	int count;
-	CSTR caption[200];
-	int fontHandle[10];
-	int num_of_struct;
-	struct ImageFont ImageFonts[10];
-	int num_of_ImageFont;
-	struct SkinObject image; /* 200//Image */
-	struct SkinObject otherObject[8]; /* 20//0:text 1:buttoon 2:slider 3:onmouse 4:BGA 5:bargraph 6:number 7:mask */
-	int BAR_CENTER;
-	struct SRCstruct src_BAR_BODY[10];
-	struct DSTstruct dst_BAR_BODY_OFF[30];
-	struct DSTstruct dst_BAR_BODY_ON[30];
-	struct SRCstruct src_BAR_TITLE[5];
-	struct DSTstruct dst_BAR_TITLE[5];
-	int bar_availabe_from;
-	int bar_availabe_to;
-	struct SRCstruct src_BAR_FLASH;
-	struct DSTstruct dst_BAR_FLASH;
-	struct SRCstruct src_BAR_LEVEL[10];
-	struct DSTstruct dst_BAR_LEVEL[10];
-	struct SRCstruct src_BAR_LAMP[10];
-	struct DSTstruct dst_BAR_LAMP[10];
+	char op[1000]{};
+	int startinput_start{};
+	int startinput_rank{};
+	int startinput_update{};
+	int scenetime{};
+	int loadstart{};
+	int loadend{};
+	int playstart{};
+	int fadeout{};
+	int close{}; /* =skip */
+	int GrHandle[200]{}; /* //101_gr_title */
+	int grIsMovie[200]{};
+	int count{};
+	CSTR caption[200]{};
+	int fontHandle[10]{};
+	int num_of_struct{};
+	struct ImageFont ImageFonts[10]{};
+	int num_of_ImageFont{};
+	struct SkinObject image {}; /* 200//Image */
+	struct SkinObject otherObject[8]{}; /* 20//0:text 1:buttoon 2:slider 3:onmouse 4:BGA 5:bargraph 6:number 7:mask */
+	int BAR_CENTER{};
+	struct SRCstruct src_BAR_BODY[10]{};
+	struct DSTstruct dst_BAR_BODY_OFF[30]{};
+	struct DSTstruct dst_BAR_BODY_ON[30]{};
+	struct SRCstruct src_BAR_TITLE[5]{};
+	struct DSTstruct dst_BAR_TITLE[5]{};
+	int bar_availabe_from{};
+	int bar_availabe_to{};
+	struct SRCstruct src_BAR_FLASH {};
+	struct DSTstruct dst_BAR_FLASH {};
+	struct SRCstruct src_BAR_LEVEL[10]{};
+	struct DSTstruct dst_BAR_LEVEL[10]{};
+	struct SRCstruct src_BAR_LAMP[10]{};
+	struct DSTstruct dst_BAR_LAMP[10]{};
 	//undefined unused[2240];
-	struct SRCstruct src_BAR_MY_LAMP[10];
-	struct DSTstruct dst_BAR_MY_LAMP[10];
-	struct SRCstruct src_BAR_RIVAL_LAMP[10];
-	struct DSTstruct dst_BAR_RIVAL_LAMP[10];
-	struct SRCstruct src_BAR_RANK[10];
-	struct DSTstruct dst_BAR_RANK[10];
-	struct SRCstruct src_BAR_RIVAL[10];
-	struct DSTstruct dst_BAR_RIVAL[10];
-	struct SRCstruct src_BAR_STAR[10];
-	struct DSTstruct dst_BAR_STAR[10];
-	struct DSTstruct dst_BAR_STAGEFILE;
-	struct SRCstruct src_MOUSECURSOR;
-	struct DSTstruct dst_MOUSECURSOR;
-	struct SRCstruct src_NOTE[20];
-	struct SRCstruct src_MINE[20];
-	struct SRCstruct src_LN_START[20];
-	struct SRCstruct src_LN_END[20];
-	struct SRCstruct src_LN_BODY[20];
-	struct SRCstruct src_AUTO_NOTE[20];
-	struct SRCstruct src_AUTO_MINE[20];
-	struct SRCstruct src_AUTO_LN_START[20];
-	struct SRCstruct src_AUTO_LN_END[20];
-	struct SRCstruct src_AUTO_LN_BODY[20];
-	struct DSTstruct dst_NOTE[20];
-	struct SRCstruct src_LINE[2];
-	struct DSTstruct dst_LINE[2];
-	struct SRCstruct src_JUDGELINE[2];
-	struct DSTstruct dst_JUDGELINE[2];
-	struct SRCstruct src_NOWJUDGE_1P[6];
-	struct DSTstruct dst_NOWJUDGE_1P[6];
-	struct SRCstruct src_NOWCOMBO_1P[6];
-	struct DSTstruct dst_NOWCOMBO_1P[6];
-	struct SRCstruct src_NOWJUDGE_2P[6];
-	struct DSTstruct dst_NOWJUDGE_2P[6];
-	struct SRCstruct src_NOWCOMBO_2P[6];
-	struct DSTstruct dst_NOWCOMBO_2P[6];
-	struct SRCstruct src_GROOVEGAUGE[2];
-	struct DSTstruct dst_GROOVEGAUGE[2];
-	double scratchAngle_1;
-	double scratchAngle_2;
-	struct SRCstruct src_GAUGECHART_1P[2];
-	struct DSTstruct dst_GAUGECHART_1P[2];
-	struct SRCstruct src_GAUGECHART_2P[2];
-	struct DSTstruct dst_GAUGECHART_2P[2];
-	struct SRCstruct src_SCORECHART[3];
-	struct DSTstruct dst_SCORECHART[3];
-	struct SRCstruct src_THUMBNAIL;
-	struct DSTstruct dst_THUMBNAIL;
-	struct SRCstruct src_README[2];
-	struct DSTstruct dst_README[2];
-	CSTR helpfilePath[10];
-	int helpfileCount;
-	int flag_BGA;
-	int scratchside_1;
-	int scratchside_2;
-	int flag_flip;
-	int textmergin_1;
-	int textmergin_2;
-	struct DrawingBuf drBuf;
-	CSTR fontname;
-	struct SkinAdjust adjust;
-	CSTR skinMD5;
-	CSTR skFontname;
-	int disableimagefont; /* bool */
-	CSTR customfileRANDOM[100];
-	CSTR customfile[100];
-	int customfile_count;
-	int reloadbanner;
-	struct SRCstruct src_EVENT_MODE_CURSOR;
-	struct DSTstruct dst_EVENT_MODE_CURSOR_ON[10];
-	struct DSTstruct dst_EVENT_MODE_CURSOR_OFF[10];
-	int event_STARTINPUT[10];
-	int event_FADEOUT[10];
-	struct DSTstruct dst_EVENT_LOADINGBG[5];
-	int horizontal;
+	struct SRCstruct src_BAR_MY_LAMP[10]{};
+	struct DSTstruct dst_BAR_MY_LAMP[10]{};
+	struct SRCstruct src_BAR_RIVAL_LAMP[10]{};
+	struct DSTstruct dst_BAR_RIVAL_LAMP[10]{};
+	struct SRCstruct src_BAR_RANK[10]{};
+	struct DSTstruct dst_BAR_RANK[10]{};
+	struct SRCstruct src_BAR_RIVAL[10]{};
+	struct DSTstruct dst_BAR_RIVAL[10]{};
+	struct SRCstruct src_BAR_STAR[10]{};
+	struct DSTstruct dst_BAR_STAR[10]{};
+	struct DSTstruct dst_BAR_STAGEFILE {};
+	struct SRCstruct src_MOUSECURSOR {};
+	struct DSTstruct dst_MOUSECURSOR {};
+	struct SRCstruct src_NOTE[20]{};
+	struct SRCstruct src_MINE[20]{};
+	struct SRCstruct src_LN_START[20]{};
+	struct SRCstruct src_LN_END[20]{};
+	struct SRCstruct src_LN_BODY[20]{};
+	struct SRCstruct src_AUTO_NOTE[20]{};
+	struct SRCstruct src_AUTO_MINE[20]{};
+	struct SRCstruct src_AUTO_LN_START[20]{};
+	struct SRCstruct src_AUTO_LN_END[20]{};
+	struct SRCstruct src_AUTO_LN_BODY[20]{};
+	struct DSTstruct dst_NOTE[20]{};
+	struct SRCstruct src_LINE[2]{};
+	struct DSTstruct dst_LINE[2]{};
+	struct SRCstruct src_JUDGELINE[2]{};
+	struct DSTstruct dst_JUDGELINE[2]{};
+	struct SRCstruct src_NOWJUDGE_1P[6]{};
+	struct DSTstruct dst_NOWJUDGE_1P[6]{};
+	struct SRCstruct src_NOWCOMBO_1P[6]{};
+	struct DSTstruct dst_NOWCOMBO_1P[6]{};
+	struct SRCstruct src_NOWJUDGE_2P[6]{};
+	struct DSTstruct dst_NOWJUDGE_2P[6]{};
+	struct SRCstruct src_NOWCOMBO_2P[6]{};
+	struct DSTstruct dst_NOWCOMBO_2P[6]{};
+	struct SRCstruct src_GROOVEGAUGE[2]{};
+	struct DSTstruct dst_GROOVEGAUGE[2]{};
+	double scratchAngle_1{};
+	double scratchAngle_2{};
+	struct SRCstruct src_GAUGECHART_1P[2]{};
+	struct DSTstruct dst_GAUGECHART_1P[2]{};
+	struct SRCstruct src_GAUGECHART_2P[2]{};
+	struct DSTstruct dst_GAUGECHART_2P[2]{};
+	struct SRCstruct src_SCORECHART[3]{};
+	struct DSTstruct dst_SCORECHART[3]{};
+	struct SRCstruct src_THUMBNAIL {};
+	struct DSTstruct dst_THUMBNAIL {};
+	struct SRCstruct src_README[2]{};
+	struct DSTstruct dst_README[2]{};
+	CSTR helpfilePath[10]{};
+	int helpfileCount{};
+	int flag_BGA{};
+	int scratchside_1{};
+	int scratchside_2{};
+	int flag_flip{};
+	int textmergin_1{};
+	int textmergin_2{};
+	struct DrawingBuf drBuf {};
+	CSTR fontname{};
+	struct SkinAdjust adjust {};
+	CSTR skinMD5{};
+	CSTR skFontname{};
+	int disableimagefont{}; /* bool */
+	CSTR customfileRANDOM[100]{};
+	CSTR customfile[100]{};
+	int customfile_count{};
+	int reloadbanner{};
+	struct SRCstruct src_EVENT_MODE_CURSOR {};
+	struct DSTstruct dst_EVENT_MODE_CURSOR_ON[10]{};
+	struct DSTstruct dst_EVENT_MODE_CURSOR_OFF[10]{};
+	int event_STARTINPUT[10]{};
+	int event_FADEOUT[10]{};
+	struct DSTstruct dst_EVENT_LOADINGBG[5]{};
+	int horizontal{};
 };
 
 struct MYRANKING {
@@ -939,16 +940,16 @@ struct AUDIO {
 };
 
 struct NoteStruct {
-	double bmsTiming;
-	double realTiming;
-	double val;
-	int active;
-	bool lnHeadFast;
-	double bmsTiming_ln;
-	double realTiming_ln;
-	int op; /* channel */
-	int mine; /* soundchannel/mine */
-	int stage;
+	double bmsTiming{};
+	double realTiming{};
+	double val{};
+	int active{};
+	bool lnHeadFast{};
+	double bmsTiming_ln{};
+	double realTiming_ln{};
+	int op{}; /* channel */
+	int mine{}; /* soundchannel/mine */
+	int stage{};
 };
 
 struct SONGSELECT {
@@ -1403,8 +1404,8 @@ struct NETWORK {
 struct game {
 	struct ConfigStruct config;
 	struct SONGSELECT sSelect;
-	struct skstruct skstruct;
-	struct skstruct skstruct2;
+	struct skstruct skstruct {};
+	struct skstruct skstruct2 {};
 	struct SkinManage skinData;
 	struct inputStructure KeyInput;
 	struct Timer timer1;

--- a/OpenLR2.manifest
+++ b/OpenLR2.manifest
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" manifestVersion="1.0">
+  <description>OpenLR2 - rewritten source code of bms player Lunatic Rave 2</description>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 and Windows 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+  <asmv3:application>
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">
+      <activeCodePage>UTF-8</activeCodePage>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>

--- a/OpenLR2_vs22.vcxproj
+++ b/OpenLR2_vs22.vcxproj
@@ -193,7 +193,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)lib\FMOD;$(ProjectDir)lib\DxLib;$(ProjectDir)lib\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <AdditionalOptions>/execution-charset:shift-JIS /arch:IA32 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/utf-8 /arch:IA32 %(AdditionalOptions)</AdditionalOptions>
       <FloatingPointModel>Precise</FloatingPointModel>
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
@@ -220,7 +220,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)lib\FMOD;$(ProjectDir)lib\DxLib;$(ProjectDir)lib\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <AdditionalOptions>/execution-charset:shift-JIS /arch:IA32  /fsanitize=address %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/utf-8 /arch:IA32  /fsanitize=address %(AdditionalOptions)</AdditionalOptions>
       <FloatingPointModel>Precise</FloatingPointModel>
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
@@ -249,7 +249,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)lib\FMOD;$(ProjectDir)lib\DxLib;$(ProjectDir)lib\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <AdditionalOptions>/execution-charset:shift-JIS /arch:IA32 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/utf-8 /arch:IA32 %(AdditionalOptions)</AdditionalOptions>
       <FloatingPointModel>Precise</FloatingPointModel>
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
@@ -275,7 +275,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)lib\FMOD;$(ProjectDir)lib\DxLib;$(ProjectDir)lib\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <AdditionalOptions>/execution-charset:shift-JIS %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <FloatingPointModel>Precise</FloatingPointModel>
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
@@ -299,7 +299,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)lib\FMOD;$(ProjectDir)lib\DxLib;$(ProjectDir)lib\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <AdditionalOptions>/execution-charset:shift-JIS /fsanitize=address %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/utf-8 /fsanitize=address %(AdditionalOptions)</AdditionalOptions>
       <FloatingPointModel>Precise</FloatingPointModel>
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
@@ -325,7 +325,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(ProjectDir)lib\FMOD;$(ProjectDir)lib\DxLib;$(ProjectDir)lib\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <AdditionalOptions>/execution-charset:shift-JIS %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <FloatingPointModel>Precise</FloatingPointModel>
       <LanguageStandard>stdcpp23</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>

--- a/SkinEditor/winWorkspace.cpp
+++ b/SkinEditor/winWorkspace.cpp
@@ -250,7 +250,6 @@ int WORKSPACE::LoadSkin(char* path) {
     for (int i = 0; i < 20; i++) g.skstruct.customfile[i].fillzero();
     g.skstruct.skinMD5.fillzero();
     g.skstruct.skFontname.fillzero();
-    memset(&g.skstruct, 0, sizeof(skstruct));
     for (int i = 0; i < 200; i++) g.skstruct.caption[i].fillzero();
     for (int i = 0; i < 200; i++) g.skstruct.caption[i].assign("(null)");
     for (int i = 0; i < 200; i++) g.skstruct.GrHandle[i] = -1;


### PR DESCRIPTION
Makes the game use UTF-8 strings internally. This makes it easier to maintain, and obsoletes the necessity of running the game in japanese locale.

ISSUES:
DxLib fails to generate some non-image fonts without locale anyway, even though it is using UTF-8 too. I couldn't figure this out.
Requires song.db rebuild, as CRC32 of non-ASCII paths changed. There is no way around it.
Some input and output data should be converted to/from SJIS. Maybe some output to LR2IR, some skins data (strings), charts.