### PR TITLE
refactor: replace avgbpm with mainbpm

### DIFF
--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -433,6 +433,7 @@ int ReadImageFont(CSTR filename, ImageFont *imgfont) {
 	if (strcmp(str1, imgfont->filepath)) {
 		imgfont->size = 0;
 		imgfont->kerning = 0;
+		imgfont->filepath[0] = '\0';
 		for (auto& [idx, chTex] : imgfont->chars) {
 			DeleteGraph(chTex.grHandle);
 			chTex.grHandle = -1;


### PR DESCRIPTION
I think avgbpm is rather useless, and adding mainbpm as 5th hs-fix mode requires modifying skins, else it is displayed as const. Its better to replace avgbpm.