### PR TITLE
RE issue: missing imagefont filepath reset

### DIFF
--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -433,6 +433,7 @@ int ReadImageFont(CSTR filename, ImageFont *imgfont) {
 	if (strcmp(str1, imgfont->filepath)) {
 		imgfont->size = 0;
 		imgfont->kerning = 0;
+		imgfont->filepath[0] = '\0';
 		for (auto& [idx, chTex] : imgfont->chars) {
 			DeleteGraph(chTex.grHandle);
 			chTex.grHandle = -1;


### PR DESCRIPTION
caused a bug that aborting imagefont loading due to failure to open the file lead to unloading of the old path font, and blocking the next font from same old path to load.