### PR TITLE
fix render inconsistencies

### DIFF
--- a/LR2/LR2_skindraw.cpp
+++ b/LR2/LR2_skindraw.cpp
@@ -840,17 +840,17 @@ int LRDrawImg(int *grHandle, DSTdraw *dstD) {
 		vec4.y = y2 - ry;
 		VectorRotationZ(&vec4, &vec4, rad);
 		if (dstD->h != 0.0 && dstD->w != 0.0 && dstD->time >= 0) {
-			DrawModiGraphF((vec1.x + rx)  * skinsizeX, (vec1.y + ry)  * skinsizeY, (vec2.x + rx)  * skinsizeX, (vec2.y + ry)  * skinsizeY,
-				(vec3.x + rx)  * skinsizeX, (vec3.y + ry)  * skinsizeY, (vec4.x + rx)  * skinsizeX, (vec4.y + ry)  * skinsizeY, *grHandle, 1);
+			DrawModiGraph((vec1.x + rx) * skinsizeX + 0.5f, (vec1.y + ry) * skinsizeY + 0.5f, (vec2.x + rx) * skinsizeX + 0.5f, (vec2.y + ry) * skinsizeY + 0.5f,
+				(vec3.x + rx) * skinsizeX + 0.5f, (vec3.y + ry) * skinsizeY + 0.5f, (vec4.x + rx) * skinsizeX + 0.5f, (vec4.y + ry) * skinsizeY + 0.5f, *grHandle, 1);
 		}
 	}
 	else {
 		GetGraphSize(*grHandle, &xs, &ys);
 		GetTimeWrap();
 		if (dstD->isDrawBackbox) {
-			DrawBox(x1*skinsizeX, y1*skinsizeY, x2*skinsizeX, y2*skinsizeY, GetColor(0, 0, 0), true);
+			DrawBox(x1*skinsizeX + 0.5f, y1*skinsizeY + 0.5f, x2*skinsizeX + 0.5f, y2*skinsizeY + 0.5f, GetColor(0, 0, 0), true);
 		}
-		DrawExtendGraphF(x1*skinsizeX, y1*skinsizeY, x2*skinsizeX, y2*skinsizeY, *grHandle, 1);
+		DrawExtendGraph(x1*skinsizeX + 0.5f, y1*skinsizeY + 0.5f, x2*skinsizeX + 0.5f, y2*skinsizeY + 0.5f, *grHandle, 1);
 	}
 	return 1;
 }
@@ -937,7 +937,7 @@ void LRDrawText(int* grHandle, DSTdraw *dstd, CSTR *str, ImageFont *imF) {
 				}
 				xf *= wl;
 				if (ch != U' ' && ch != U'\n' && chTex.grHandle != -1) {
-					DrawExtendGraphF(dstd->x + wSum, dstd->y, dstd->x + wSum + xf, dstd->y + hl * yf, chTex.grHandle, 1);
+					DrawExtendGraph(dstd->x + wSum + 0.5f, dstd->y + 0.5f, dstd->x + wSum + xf + 0.5f, dstd->y + hl * yf + 0.5f, chTex.grHandle, 1);
 				}
 				wSum = imF->kerning * wl + xf + wSum;
 			}


### PR DESCRIPTION
First of all, DxLib has a bug with F variants of draw methods, where with certain input values it would incorrectly apply the UV, effectively shifting SRC coordinate by one pixel to the left, or up. This bug can be observed both in LR2 and OpenLR2 (LN body sometimes detaching from head and tail, gauge having gaps which are not supposed to be there, etc). It looks slightly different between LR2 and OpenLR2 because LR2 version of DxLib had another bug with position logic, which was fixed by the version we use in OpenLR2. You can see the comment about it in DxLib.h next to DX_DRAWFLOATCOORDTYPE_DIRECT3D9 define.

Using integer variants of draw methods instead of F variants, besides solving the problem with SRC coordinate shift, yields much better render consistency, textures have sharper edges and look much closer to their source image. Both in LR2 and previously in OpenLR2 you can observe a ton of render imperfections if you look closely and compare it to the source images, as well as some jitter in moving objects.

Please try this first and see if there are any downsides to this method. I don't think i noticed any.