### PR TITLE
wrong alloc size for SkinHeader in x64

### DIFF
--- a/LR2/LR2_skinmanage.cpp
+++ b/LR2/LR2_skinmanage.cpp
@@ -193,7 +193,7 @@ int InitSkinData(SkinManage *skm){
 }
 
 int ExpandSkinMax(SkinManage *skm){
-	skm->Data = (SkinHeader *)realloc(skm->Data, (skm->Max + 100) * 0xb14);
+	skm->Data = (SkinHeader *)realloc(skm->Data, (skm->Max + 100) * sizeof(SkinHeader));
 	assert(skm->Data != nullptr);
 	memset(skm->Data + skm->Max, 0, sizeof(SkinHeader) * 100);
 	if (skm->Max < skm->Max + 100) {

--- a/OpenLR2_vs22.vcxproj
+++ b/OpenLR2_vs22.vcxproj
@@ -298,7 +298,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(ProjectDir)lib\FMODex\;$(ProjectDir)lib\FMOD\;$(ProjectDir)lib\DxLib\;$(ProjectDir)lib\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>winmm.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
-      <StackReserveSize>4194304</StackReserveSize>
+      <StackReserveSize>10485760</StackReserveSize>
       <LargeAddressAware>true</LargeAddressAware>
     </Link>
     <Manifest>


### PR DESCRIPTION
Stack overflow crash in debug build, missing stack reserve size in build.
Wrong SkinHeader allocation size, due to hardcoded structure size.
Fixes x64 crash mentioned in https://github.com/GOMazk/OpenLR2/issues/73