### PR TITLE
Custom ir/api header

### DIFF
--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -1,9 +1,15 @@
 #pragma once
 
+// CustomIR public ABI between OpenLR2 host and third-party IR DLLs.
+// DLLs export GetMethodTable(MethodTable&); leave unimplemented slots as nullptr.
+// MethodTable and struct layouts are append-only: do not reorder slots or change IRScoreV1 fields.
+// Module implementation guide: ExampleIR/README.md
+
 #include <string>
 #include <array>
 #include <vector>
 
+// Play/course result payload for SendScoreV1 (submitted after a chart finishes).
 struct IRScoreV1 {
 	struct SONG {
 		std::string hash;
@@ -100,12 +106,14 @@ struct IRScoreV1 {
 	} graphs{};
 };
 
+// SendScoreV1 return value.
 enum class SendScoreStatus: int {
 	Ok = 0,
 	Retry,
 	Fail,
 };
 
+// Shared query input for Fetch*V1 slots (song metadata + option fingerprint).
 struct IRRankQueryV1 {
 	IRScoreV1::SONG song{};
 	IRScoreV1::SETTINGS settings{};
@@ -114,16 +122,19 @@ struct IRRankQueryV1 {
 	int clearType{};
 };
 
+// FetchResultRankV1 output; result-screen rank display (skin #92/#93). rank/playerCount 0 = unknown.
 struct IRRankResultV1 {
 	int rank{};
 	int playerCount{};
 };
 
+// FetchChartStatsV1 output; song-select chart stats. clearDistribution indexed by clear type.
 struct IRChartStatsV1 {
 	int playerCount{};
 	std::array<int, 6> clearDistribution{};
 };
 
+// One row in FetchLeaderboardV1 output; F3 in-game ranking board entry.
 struct IRLeaderboardEntryV1 {
 	int rank{};
 	int playerId{};
@@ -142,6 +153,7 @@ struct IRLeaderboardEntryV1 {
 	std::string displayName;
 };
 
+// FetchLeaderboardV1 output; F3 in-game ranking board.
 struct IRLeaderboardResultV1 {
 	int playerCount{};
 	int myRank{};
@@ -149,6 +161,7 @@ struct IRLeaderboardResultV1 {
 	std::vector<IRLeaderboardEntryV1> entries;
 };
 
+// FetchRivalChartV1 output; song-select rival row.
 struct IRRivalChartV1 {
 	int playerId{};
 	int exscore{};
@@ -166,18 +179,21 @@ struct IRRivalChartV1 {
 	bool hasPlay{};
 };
 
+// Return value for all fetch MethodTable slots.
 enum class FetchRankStatus: int {
 	Ok = 0,
 	Retry,
 	Fail,
 };
 
+// GetProviderMetaV1 output; F5 web ranking URL templates ({hash} placeholder).
 struct IRProviderMetaV1 {
 	const char* webRankingChartUrlTemplate = nullptr;
 	const char* webRankingCourseUrlTemplate = nullptr;
 	const char* apiVersion = nullptr;
 };
 
+// FetchIrGhostV1 query; play-scene ghost target (e.g. g-battle rival).
 struct IRGhostQueryV1 {
 	IRScoreV1::SONG song{};
 	int mode = 0;
@@ -185,6 +201,7 @@ struct IRGhostQueryV1 {
 	int targetPlayerId = 0;
 };
 
+// FetchIrGhostV1 output; play-scene ghost replay data.
 struct IRGhostResultV1 {
 	std::string displayName;
 	std::string ghostData;

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -113,7 +113,7 @@ enum class SendScoreStatus: int {
 	Fail,
 };
 
-// Shared query input for Fetch*V1 slots (song metadata + option fingerprint).
+// Shared query input for Get*V1 slots (song metadata + option fingerprint).
 struct IRRankQueryV1 {
 	IRScoreV1::SONG song{};
 	IRScoreV1::SETTINGS settings{};
@@ -122,19 +122,19 @@ struct IRRankQueryV1 {
 	int clearType{};
 };
 
-// FetchResultRankV1 output; result-screen rank display (skin #92/#93). rank/playerCount 0 = unknown.
+// GetResultRankV1 output; result-screen rank display (skin #92/#93). rank/playerCount 0 = unknown.
 struct IRRankResultV1 {
 	int rank{};
 	int playerCount{};
 };
 
-// FetchChartStatsV1 output; song-select chart stats. clearDistribution indexed by clear type.
+// GetChartStatsV1 output; song-select chart stats. clearDistribution indexed by clear type.
 struct IRChartStatsV1 {
 	int playerCount{};
 	std::array<int, 6> clearDistribution{};
 };
 
-// One row in FetchLeaderboardV1 output; F3 in-game ranking board entry.
+// One row in GetLeaderboardV1 output; F3 in-game ranking board entry.
 struct IRLeaderboardEntryV1 {
 	int rank{};
 	int playerId{};
@@ -153,7 +153,7 @@ struct IRLeaderboardEntryV1 {
 	std::string displayName;
 };
 
-// FetchLeaderboardV1 output; F3 in-game ranking board.
+// GetLeaderboardV1 output; F3 in-game ranking board.
 struct IRLeaderboardResultV1 {
 	int playerCount{};
 	int myRank{};
@@ -161,7 +161,7 @@ struct IRLeaderboardResultV1 {
 	std::vector<IRLeaderboardEntryV1> entries;
 };
 
-// FetchRivalChartV1 output; song-select rival row.
+// GetRivalChartV1 output; song-select rival row.
 struct IRRivalChartV1 {
 	int playerId{};
 	int exscore{};
@@ -179,8 +179,8 @@ struct IRRivalChartV1 {
 	bool hasPlay{};
 };
 
-// Return value for all fetch MethodTable slots.
-enum class FetchRankStatus: int {
+// Return value for all Get*V1 MethodTable slots.
+enum class GetStatus: int {
 	Ok = 0,
 	Retry,
 	Fail,
@@ -193,7 +193,7 @@ struct IRProviderMetaV1 {
 	const char* apiVersion = nullptr;
 };
 
-// FetchIrGhostV1 query; play-scene ghost target (e.g. g-battle rival).
+// GetIrGhostV1 query; play-scene ghost target (e.g. g-battle rival).
 struct IRGhostQueryV1 {
 	IRScoreV1::SONG song{};
 	int mode = 0;
@@ -201,7 +201,7 @@ struct IRGhostQueryV1 {
 	int targetPlayerId = 0;
 };
 
-// FetchIrGhostV1 output; play-scene ghost replay data.
+// GetIrGhostV1 output; play-scene ghost replay data.
 struct IRGhostResultV1 {
 	std::string displayName;
 	std::string ghostData;
@@ -218,10 +218,10 @@ struct MethodTable {
 	const char*(__cdecl* GetName)() = nullptr;
 	bool(__cdecl* LoginV1)() = nullptr;
 	SendScoreStatus(__cdecl* SendScoreV1)(const IRScoreV1& score) = nullptr;
-	FetchRankStatus(__cdecl* FetchResultRankV1)(const IRRankQueryV1& query, IRRankResultV1& out) = nullptr;
-	FetchRankStatus(__cdecl* FetchChartStatsV1)(const IRRankQueryV1& query, IRChartStatsV1& out) = nullptr;
-	FetchRankStatus(__cdecl* FetchLeaderboardV1)(const IRRankQueryV1& query, IRLeaderboardResultV1& out, int limit, int offset) = nullptr;
-	FetchRankStatus(__cdecl* FetchRivalChartV1)(int rivalPlayerId, const IRRankQueryV1& query, IRRivalChartV1& out) = nullptr;
+	GetStatus(__cdecl* GetResultRankV1)(const IRRankQueryV1& query, IRRankResultV1& out) = nullptr;
+	GetStatus(__cdecl* GetChartStatsV1)(const IRRankQueryV1& query, IRChartStatsV1& out) = nullptr;
+	GetStatus(__cdecl* GetLeaderboardV1)(const IRRankQueryV1& query, IRLeaderboardResultV1& out, int limit, int offset) = nullptr;
+	GetStatus(__cdecl* GetRivalChartV1)(int rivalPlayerId, const IRRankQueryV1& query, IRRivalChartV1& out) = nullptr;
 	void(__cdecl* GetProviderMetaV1)(IRProviderMetaV1& out) = nullptr;
-	FetchRankStatus(__cdecl* FetchIrGhostV1)(const IRGhostQueryV1& query, IRGhostResultV1& out) = nullptr;
+	GetStatus(__cdecl* GetIrGhostV1)(const IRGhostQueryV1& query, IRGhostResultV1& out) = nullptr;
 };

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <array>
+#include <vector>
 
 struct IRScoreV1 {
 	struct SONG {
@@ -105,8 +106,105 @@ enum class SendScoreStatus: int {
 	Fail,
 };
 
+struct IRRankQueryV1 {
+	IRScoreV1::SONG song{};
+	IRScoreV1::SETTINGS settings{};
+	IRScoreV1::STATE state{};
+	int exscore{};
+	int clearType{};
+};
+
+struct IRRankResultV1 {
+	int rank{};
+	int playerCount{};
+};
+
+struct IRChartStatsV1 {
+	int playerCount{};
+	std::array<int, 6> clearDistribution{};
+};
+
+struct IRLeaderboardEntryV1 {
+	int rank{};
+	int playerId{};
+	int exscore{};
+	int clearType{};
+	int pgreat{};
+	int great{};
+	int good{};
+	int bad{};
+	int poor{};
+	int maxcombo{};
+	int minbp{};
+	int playcount{};
+	int optionPacked{};
+	int keymode{};
+	std::string displayName;
+};
+
+struct IRLeaderboardResultV1 {
+	int playerCount{};
+	int myRank{};
+	int myPlayerId{};
+	std::vector<IRLeaderboardEntryV1> entries;
+};
+
+struct IRRivalChartV1 {
+	int playerId{};
+	int exscore{};
+	int clearType{};
+	int pgreat{};
+	int great{};
+	int good{};
+	int bad{};
+	int poor{};
+	int maxcombo{};
+	int minbp{};
+	int playcount{};
+	int rank{};
+	std::string displayName;
+	bool hasPlay{};
+};
+
+enum class FetchRankStatus: int {
+	Ok = 0,
+	Retry,
+	Fail,
+};
+
+struct IRProviderMetaV1 {
+	const char* webRankingChartUrlTemplate = nullptr;
+	const char* webRankingCourseUrlTemplate = nullptr;
+	const char* apiVersion = nullptr;
+};
+
+struct IRGhostQueryV1 {
+	IRScoreV1::SONG song{};
+	int mode = 0;
+	int viewerPlayerId = 0;
+	int targetPlayerId = 0;
+};
+
+struct IRGhostResultV1 {
+	std::string displayName;
+	std::string ghostData;
+	int optionDigit1{};
+	int optionDigit2{};
+	int optionDigit3{};
+	int optionDigit4{};
+	int randomSeed{};
+	int averageExscore{};
+	bool hasPlay{};
+};
+
 struct MethodTable {
 	const char*(__cdecl* GetName)() = nullptr;
 	bool(__cdecl* LoginV1)() = nullptr;
 	SendScoreStatus(__cdecl* SendScoreV1)(const IRScoreV1& score) = nullptr;
+	FetchRankStatus(__cdecl* FetchResultRankV1)(const IRRankQueryV1& query, IRRankResultV1& out) = nullptr;
+	FetchRankStatus(__cdecl* FetchChartStatsV1)(const IRRankQueryV1& query, IRChartStatsV1& out) = nullptr;
+	FetchRankStatus(__cdecl* FetchLeaderboardV1)(const IRRankQueryV1& query, IRLeaderboardResultV1& out, int limit, int offset) = nullptr;
+	FetchRankStatus(__cdecl* FetchRivalChartV1)(int rivalPlayerId, const IRRankQueryV1& query, IRRivalChartV1& out) = nullptr;
+	void(__cdecl* GetProviderMetaV1)(IRProviderMetaV1& out) = nullptr;
+	FetchRankStatus(__cdecl* FetchIrGhostV1)(const IRGhostQueryV1& query, IRGhostResultV1& out) = nullptr;
 };


### PR DESCRIPTION
Extends `LR2_customir_api.h` with types and `MethodTable` slots for IR rank/stats/leaderboard/rival/ghost data.

- Read slots use `Get*V1` + `GetStatus`; score submit stays `SendScoreV1` + `SendScoreStatus`
- New slots default to `nullptr` — existing IR DLLs keep working unchanged
- Adds ABI comments (append-only contract, UI mapping hints)