### PR TITLE
Fix autoreload song scan database handling

### DIFF
--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -224,12 +224,6 @@ int SetUndefinedDifficulty(sqlite3 *sql) {
 	sqlite3_stmt *pStmt;
 	CSTR folder;
 	int mode, difficulty;
-	int shouldCommit;
-
-	shouldCommit = sqlite3_get_autocommit(sql);
-	if (shouldCommit && SQL_Run("BEGIN IMMEDIATE", sql) != 0) {
-		shouldCommit = 0;
-	}
 
 	sqlite3_prepare(sql, "SELECT difficulty,folder,mode,path FROM song ORDER BY folder,mode,karinotes", -1, &pStmt, NULL);
 	while (sqlite3_step(pStmt) == 100) {
@@ -256,9 +250,6 @@ int SetUndefinedDifficulty(sqlite3 *sql) {
 		}
 	}
 	sqlite3_finalize(pStmt);
-	if (shouldCommit) {
-		SQL_Run("COMMIT", sql);
-	}
 	return 1;
 }
 
@@ -1065,6 +1056,8 @@ int ChangeCourseID(sqlite3 *sql, int newID, int oldID, int type) {
 }
 
 
+// Returns the stored timestamp for a song/folder path, or -1 when no row exists.
+// SearchSongsFromPath uses this as the old "missing row" signal before insert/update.
 int GetRegisteredDateFromPath(const char *table, sqlite3 *sql, CSTR path) {
 	sqlite3_stmt *pStmt = NULL;
 	char str[1024];
@@ -1081,6 +1074,9 @@ int GetRegisteredDateFromPath(const char *table, sqlite3 *sql, CSTR path) {
 	return date;
 }
 
+// Checks whether an existing song row can be kept without reparsing the BMS file.
+// The timestamp check keeps the fast path for unchanged charts, while the CRC checks
+// repair legacy rows created with a stale parent/folder relationship.
 int IsRegisteredSongCurrent(sqlite3 *sql, CSTR path, int filetime) {
 	sqlite3_stmt *pStmt = NULL;
 	char str[1024];
@@ -1090,6 +1086,7 @@ int IsRegisteredSongCurrent(sqlite3 *sql, CSTR path, int filetime) {
 	CSTR expectedParent;
 	int ret = 0;
 
+	// folder is the physical chart directory; parent is where the chart appears in select.
 	expectedFolder = AssignCRC32(path.getDirectory());
 	expectedParent = AssignCRC32(path.getParentDirectory());
 
@@ -1137,6 +1134,7 @@ int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 				searchPath = root;
 				searchPath.add(findFileData.cFileName);
 				filetime = GetUnixtimeFromFiletime(findFileData.ftLastWriteTime);
+				// Skip expensive metadata parsing only when date and hierarchy CRCs are valid.
 				if (IsRegisteredSongCurrent(sql, searchPath, filetime) == 0) {
 					ErrorLogFmtAdd("曲を発見しました。　パス:%s\n", searchPath.body);
 					SQL_Run(sqlite3_snprintf(2048, str, "DELETE FROM song WHERE path = \'%q\'", searchPath.body), sql);
@@ -1176,6 +1174,8 @@ int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 			folderinfo.add("folderinfo.txt");
 			filetime = GetUnixtimeFromFiletime(findFileData.ftLastWriteTime);
 			oldtime = GetRegisteredDateFromPath("folder", sql, searchPath);
+			// The folder row timestamp only describes this folder entry.
+			// Child charts may still be missing, changed, or require parent/folder repair.
 			if (IsFileExist(folderinfo)) {
 				ret = 0;
 				if (oldtime < filetime) {
@@ -1235,7 +1235,8 @@ int ReloadSongsByQuery(CSTR query, sqlite3 *sql, CONFIG_JUKEBOX *jb) {
 	sqlite3_stmt *pStmt;
 	char sBuf[1024];
 	int cAlready = 0, cNot = 0, cChange = 0;
-	int shouldCommit;
+	// This query often reads song/folder, and the branches below can delete or insert
+	// into those same tables. Snapshot first, then finalize the SELECT before mutating.
 	std::vector<CSTR> pathList;
 	std::vector<int> timeList;
 
@@ -1266,6 +1267,7 @@ int ReloadSongsByQuery(CSTR query, sqlite3 *sql, CONFIG_JUKEBOX *jb) {
 			if (jb->numOfPath == 0 || is_path_in_jukebox){
 				int newTime;
 				int chg = IsFileChanged(time, str, &newTime);
+				// IsFileChanged only compares timestamps; force reinsert when hierarchy CRCs are stale.
 				if (chg == 0 && is_bms_file && IsRegisteredSongCurrent(sql, str, newTime) == 0) {
 					chg = 2;
 				}
@@ -1274,26 +1276,15 @@ int ReloadSongsByQuery(CSTR query, sqlite3 *sql, CONFIG_JUKEBOX *jb) {
 				}
 				else if (chg == 1) {
 					cNot++;
-					shouldCommit = sqlite3_get_autocommit(sql);
-					if (shouldCommit && SQL_Run("BEGIN IMMEDIATE", sql) != 0) {
-						shouldCommit = 0;
-					}
 					if (is_bms_file) {
 						SQL_Run(sqlite3_snprintf(512, sBuf, "DELETE FROM song WHERE path=\'%q\'", str.body), sql); 
 					}
 					else {
 						SQL_Run(sqlite3_snprintf(512, sBuf, "DELETE FROM folder WHERE path=\'%q\'", str.body), sql);
 					}
-					if (shouldCommit) {
-						SQL_Run("COMMIT", sql);
-					}
 				}
 				else if (chg == 2) {
 					cChange++;
-					shouldCommit = sqlite3_get_autocommit(sql);
-					if (shouldCommit && SQL_Run("BEGIN IMMEDIATE", sql) != 0) {
-						shouldCommit = 0;
-					}
 					if (is_bms_file) {
 						SQL_Run(sqlite3_snprintf(1024, sBuf, "DELETE FROM song WHERE path=\'%q\'", str.body), sql);
 						BMSMETA meta;
@@ -1327,25 +1318,15 @@ int ReloadSongsByQuery(CSTR query, sqlite3 *sql, CONFIG_JUKEBOX *jb) {
 							}
 						}
 					}
-					if (shouldCommit) {
-						SQL_Run("COMMIT", sql);
-					}
 				}
 				
 			}
 			else {
-				shouldCommit = sqlite3_get_autocommit(sql);
-				if (shouldCommit && SQL_Run("BEGIN IMMEDIATE", sql) != 0) {
-					shouldCommit = 0;
-				}
 				if (is_bms_file) {
 					SQL_Run(sqlite3_snprintf(512, sBuf, "DELETE FROM song WHERE path=\'%q\'", str.body), sql);
 				}
 				else {
 					SQL_Run(sqlite3_snprintf(512, sBuf, "DELETE FROM folder WHERE path=\'%q\'", str.body), sql);
-				}
-				if (shouldCommit) {
-					SQL_Run("COMMIT", sql);
 				}
 			}
 		}

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -4,6 +4,7 @@
 #include "filesystem.h"
 #include "filesystem.h"
 #include <iterator>
+#include <vector>
 
 #ifdef _WIN32
 #include <shellapi.h>
@@ -223,6 +224,12 @@ int SetUndefinedDifficulty(sqlite3 *sql) {
 	sqlite3_stmt *pStmt;
 	CSTR folder;
 	int mode, difficulty;
+	int shouldCommit;
+
+	shouldCommit = sqlite3_get_autocommit(sql);
+	if (shouldCommit && SQL_Run("BEGIN IMMEDIATE", sql) != 0) {
+		shouldCommit = 0;
+	}
 
 	sqlite3_prepare(sql, "SELECT difficulty,folder,mode,path FROM song ORDER BY folder,mode,karinotes", -1, &pStmt, NULL);
 	while (sqlite3_step(pStmt) == 100) {
@@ -249,6 +256,9 @@ int SetUndefinedDifficulty(sqlite3 *sql) {
 		}
 	}
 	sqlite3_finalize(pStmt);
+	if (shouldCommit) {
+		SQL_Run("COMMIT", sql);
+	}
 	return 1;
 }
 
@@ -1055,11 +1065,54 @@ int ChangeCourseID(sqlite3 *sql, int newID, int oldID, int type) {
 }
 
 
+int GetRegisteredDateFromPath(const char *table, sqlite3 *sql, CSTR path) {
+	sqlite3_stmt *pStmt = NULL;
+	char str[1024];
+	int date = -1;
+
+	sqlite3_snprintf(1024, str, "SELECT date FROM %s WHERE path = \'%q\'", table, path.body);
+	if (SQL_prepare(str, sql, &pStmt) != 0) {
+		return -1;
+	}
+	if (sqlite3_step(pStmt) == 100) {
+		date = sqlite3_column_int(pStmt, 0);
+	}
+	sqlite3_finalize(pStmt);
+	return date;
+}
+
+int IsRegisteredSongCurrent(sqlite3 *sql, CSTR path, int filetime) {
+	sqlite3_stmt *pStmt = NULL;
+	char str[1024];
+	const char *folder;
+	const char *parent;
+	CSTR expectedFolder;
+	CSTR expectedParent;
+	int ret = 0;
+
+	expectedFolder = AssignCRC32(path.getDirectory());
+	expectedParent = AssignCRC32(path.getParentDirectory());
+
+	sqlite3_snprintf(1024, str, "SELECT date,folder,parent FROM song WHERE path = \'%q\'", path.body);
+	if (SQL_prepare(str, sql, &pStmt) != 0) {
+		return 0;
+	}
+	if (sqlite3_step(pStmt) == 100) {
+		folder = (const char *)sqlite3_column_text(pStmt, 1);
+		parent = (const char *)sqlite3_column_text(pStmt, 2);
+		if (sqlite3_column_int(pStmt, 0) >= filetime && folder && parent && expectedFolder.isSame(folder) && expectedParent.isSame(parent)) {
+			ret = 1;
+		}
+	}
+	sqlite3_finalize(pStmt);
+	return ret;
+}
+
 int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 #ifdef _WIN32
 	HANDLE hFindFile;
 	_WIN32_FIND_DATAA findFileData;
-	int now,filetime;
+	int now,filetime,oldtime,ret;
 	char str[2048];
 	int count = 0;
 	
@@ -1073,6 +1126,10 @@ int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 	searchPath = root;
 	searchPath.add("*.*");
 	hFindFile = FindFirstFileA(searchPath, &findFileData);
+	if (hFindFile == INVALID_HANDLE_VALUE) {
+		ErrorLogTabSub();
+		return count;
+	}
 	now = GetNowUnixtime();
 	while (1) {
 		if ( ((findFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) || !(strcmp("..", findFileData.cFileName) && strcmp(".", findFileData.cFileName)) ) { // not directory
@@ -1080,24 +1137,31 @@ int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 				searchPath = root;
 				searchPath.add(findFileData.cFileName);
 				filetime = GetUnixtimeFromFiletime(findFileData.ftLastWriteTime);
-				ErrorLogFmtAdd("曲を発見しました。　パス:%s\n", searchPath.body);
-				ParseBMSMETA(&meta, searchPath, 1);
-				LoadBMSMETAFromDB(&meta, sql);
-				sqlite3_snprintf(2048, str, "INSERT INTO song (hash,title,subtitle,genre,artist,subartist,level,date,path,folder,stagefile,banner,backbmp,parent,maxbpm,minbpm,random,longnote,judge,mode,bga,difficulty,favorite,type,txt,karinotes,adddate,exlevel) VALUES(\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,%d,%d,%d,%d,%d,%d,0,0,%d,%d,%d,%d)",
-					meta.hash.body, meta.title.body, meta.subtitle.body, meta.genre.body, meta.artist.body, meta.subartist.body, meta.selLevel, filetime, searchPath.body, AssignCRC32(meta.folderpath).body, meta.stagefilepath.body, meta.bannerpath.body, meta.backBMPpath.body, AssignCRC32(meta.parentfolderpath).body, meta.maxbpm, meta.minbpm, meta.random, meta.longnote, meta.judge, meta.keymode, meta.bga, meta.difficulty, meta.hasTxt, meta.notecount, now, meta.exlevel);
-				SQL_Run(str, sql);
+				if (IsRegisteredSongCurrent(sql, searchPath, filetime) == 0) {
+					ErrorLogFmtAdd("曲を発見しました。　パス:%s\n", searchPath.body);
+					SQL_Run(sqlite3_snprintf(2048, str, "DELETE FROM song WHERE path = \'%q\'", searchPath.body), sql);
+					ParseBMSMETA(&meta, searchPath, 1);
+					LoadBMSMETAFromDB(&meta, sql);
+					sqlite3_snprintf(2048, str, "INSERT INTO song (hash,title,subtitle,genre,artist,subartist,level,date,path,folder,stagefile,banner,backbmp,parent,maxbpm,minbpm,random,longnote,judge,mode,bga,difficulty,favorite,type,txt,karinotes,adddate,exlevel) VALUES(\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,%d,%d,%d,%d,%d,%d,0,0,%d,%d,%d,%d)",
+						meta.hash.body, meta.title.body, meta.subtitle.body, meta.genre.body, meta.artist.body, meta.subartist.body, meta.selLevel, filetime, searchPath.body, AssignCRC32(meta.folderpath).body, meta.stagefilepath.body, meta.bannerpath.body, meta.backBMPpath.body, AssignCRC32(meta.parentfolderpath).body, meta.maxbpm, meta.minbpm, meta.random, meta.longnote, meta.judge, meta.keymode, meta.bga, meta.difficulty, meta.hasTxt, meta.notecount, now, meta.exlevel);
+					SQL_Run(str, sql);
+				}
 				count++;
 			}
 			else if (((findFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0) && IsLR2Folder(findFileData.cFileName)){
 				searchPath = root;
 				searchPath.add(findFileData.cFileName);
-				ErrorLogFmtAdd("カスタムフォルダを発見しました。　パス:%s\n", searchPath.body);
 				filetime = GetUnixtimeFromFiletime(findFileData.ftLastWriteTime);
-				ParseBMSMETA(&meta, searchPath, 1);
-				sqlite3_snprintf(2048, str, "INSERT INTO folder (path , title , parent , category , info_a , info_b , command , max , date , type , banner , adddate) VALUES(\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d , %d , 2 , \'%q\' , %d) ",
-					searchPath.body, meta.title.body, AssignCRC32(path).body, meta.genre.body, meta.artist.body, meta.subartist.body, meta.tag.body, meta.selLevel, filetime, meta.bannerpath.body, now);
-				if (SQL_Run(str, sql) == 0) {
-					ErrorLogFmtAdd("追加失敗 エラー内容 %s\n", sqlite3_errmsg(sql));
+				oldtime = GetRegisteredDateFromPath("folder", sql, searchPath);
+				if (oldtime < filetime) {
+					ErrorLogFmtAdd("カスタムフォルダを発見しました。　パス:%s\n", searchPath.body);
+					if (oldtime >= 0) {
+						SQL_Run(sqlite3_snprintf(2048, str, "DELETE FROM folder WHERE path = \'%q\'", searchPath.body), sql);
+					}
+					ParseBMSMETA(&meta, searchPath, 1);
+					sqlite3_snprintf(2048, str, "INSERT INTO folder (path , title , parent , category , info_a , info_b , command , max , date , type , banner , adddate) VALUES(\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d , %d , 2 , \'%q\' , %d) ",
+						searchPath.body, meta.title.body, AssignCRC32(path).body, meta.genre.body, meta.artist.body, meta.subartist.body, meta.tag.body, meta.selLevel, filetime, meta.bannerpath.body, now);
+					SQL_Run(str, sql);
 				}
 				count++;
 			}
@@ -1111,14 +1175,22 @@ int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 			CSTR folderinfo(searchPath);
 			folderinfo.add("folderinfo.txt");
 			filetime = GetUnixtimeFromFiletime(findFileData.ftLastWriteTime);
+			oldtime = GetRegisteredDateFromPath("folder", sql, searchPath);
 			if (IsFileExist(folderinfo)) {
-				ErrorLogAdd("ついでにフォルダインフォを発見しました\n");
-				ParseBMSMETA(&meta, folderinfo, 0);
-				if (meta.judge != 2) meta.judge = 1;
+				ret = 0;
+				if (oldtime < filetime) {
+					ErrorLogAdd("ついでにフォルダインフォを発見しました\n");
+					ParseBMSMETA(&meta, folderinfo, 0);
+					if (meta.judge != 2) meta.judge = 1;
 
-				sqlite3_snprintf(2048, str, "INSERT INTO folder (path , title , parent , category , info_a , info_b , command , max , date , type , banner , adddate) VALUES(\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d , %d , %d , \'%q\' , %d) ",
-					searchPath.body, meta.title.body, AssignCRC32(path).body, meta.genre.body, meta.artist.body, meta.subartist.body, meta.tag.body, meta.selLevel, filetime, meta.judge, meta.bannerpath.body, now);
-				if (SQL_Run(str, sql) == 0) {
+					if (oldtime >= 0) {
+						SQL_Run(sqlite3_snprintf(2048, str, "DELETE FROM folder WHERE path = \'%q\'", searchPath.body), sql);
+					}
+					sqlite3_snprintf(2048, str, "INSERT INTO folder (path , title , parent , category , info_a , info_b , command , max , date , type , banner , adddate) VALUES(\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d , %d , %d , \'%q\' , %d) ",
+						searchPath.body, meta.title.body, AssignCRC32(path).body, meta.genre.body, meta.artist.body, meta.subartist.body, meta.tag.body, meta.selLevel, filetime, meta.judge, meta.bannerpath.body, now);
+					ret = SQL_Run(str, sql);
+				}
+				if (ret == 0) {
 					ErrorLogAdd("再帰検索を行います。\n");
 					CSTR subPath(root);
 					subPath.add(findFileData.cFileName).add("\\");
@@ -1126,8 +1198,17 @@ int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 				}
 			}
 			else {
-				sqlite3_snprintf(2048, str, "INSERT INTO folder (path , title , parent , date , type  , adddate) VALUES(\'%q\',\'%q\',\'%q\',%d , 1 , %d )", searchPath.body, findFileData.cFileName, AssignCRC32(path).body, filetime, now);
-				if (SQL_Run(str, sql) == 0) {
+				ret = 0;
+				if (oldtime < filetime) {
+					if (oldtime >= 0) {
+						sqlite3_snprintf(2048, str, "UPDATE folder SET title = \'%q\' , parent = \'%q\' , date = %d , type = 1 , adddate = %d WHERE path = \'%q\'", findFileData.cFileName, AssignCRC32(path).body, filetime, now, searchPath.body);
+					}
+					else {
+						sqlite3_snprintf(2048, str, "INSERT INTO folder (path , title , parent , date , type  , adddate) VALUES(\'%q\',\'%q\',\'%q\',%d , 1 , %d )", searchPath.body, findFileData.cFileName, AssignCRC32(path).body, filetime, now);
+					}
+					ret = SQL_Run(str, sql);
+				}
+				if (ret == 0) {
 					ErrorLogAdd("再帰検索を行います。\n");
 					CSTR subPath(root);
 					subPath.add(findFileData.cFileName).add("\\");
@@ -1154,14 +1235,23 @@ int ReloadSongsByQuery(CSTR query, sqlite3 *sql, CONFIG_JUKEBOX *jb) {
 	sqlite3_stmt *pStmt;
 	char sBuf[1024];
 	int cAlready = 0, cNot = 0, cChange = 0;
+	int shouldCommit;
+	std::vector<CSTR> pathList;
+	std::vector<int> timeList;
 
 	GetTimeWrap();
 	SQL_prepare(query, sql, &pStmt);
 	const int now = GetNowUnixtime();
 
 	while (sqlite3_step(pStmt) == 100) {
-		const int time = sqlite3_column_int(pStmt, 1);
-		CSTR str = SQL_GetColumn(0, pStmt);
+		pathList.push_back(SQL_GetColumn(0, pStmt));
+		timeList.push_back(sqlite3_column_int(pStmt, 1));
+	}
+	sqlite3_finalize(pStmt);
+
+	for (size_t i = 0; i < pathList.size(); i++) {
+		const int time = timeList[i];
+		CSTR str = pathList[i];
 		if (!str.left(8).isSame("LR2files")) {
 			const bool is_bms_file = IsBmsFile(str);
 			const bool is_lr2folder = IsLR2Folder(str);
@@ -1175,21 +1265,35 @@ int ReloadSongsByQuery(CSTR query, sqlite3 *sql, CONFIG_JUKEBOX *jb) {
 
 			if (jb->numOfPath == 0 || is_path_in_jukebox){
 				int newTime;
-				const int chg = IsFileChanged(time, str, &newTime);
+				int chg = IsFileChanged(time, str, &newTime);
+				if (chg == 0 && is_bms_file && IsRegisteredSongCurrent(sql, str, newTime) == 0) {
+					chg = 2;
+				}
 				if (chg == 0) {
 					cAlready++;
 				}
 				else if (chg == 1) {
 					cNot++;
+					shouldCommit = sqlite3_get_autocommit(sql);
+					if (shouldCommit && SQL_Run("BEGIN IMMEDIATE", sql) != 0) {
+						shouldCommit = 0;
+					}
 					if (is_bms_file) {
 						SQL_Run(sqlite3_snprintf(512, sBuf, "DELETE FROM song WHERE path=\'%q\'", str.body), sql); 
 					}
 					else {
 						SQL_Run(sqlite3_snprintf(512, sBuf, "DELETE FROM folder WHERE path=\'%q\'", str.body), sql);
 					}
+					if (shouldCommit) {
+						SQL_Run("COMMIT", sql);
+					}
 				}
 				else if (chg == 2) {
 					cChange++;
+					shouldCommit = sqlite3_get_autocommit(sql);
+					if (shouldCommit && SQL_Run("BEGIN IMMEDIATE", sql) != 0) {
+						shouldCommit = 0;
+					}
 					if (is_bms_file) {
 						SQL_Run(sqlite3_snprintf(1024, sBuf, "DELETE FROM song WHERE path=\'%q\'", str.body), sql);
 						BMSMETA meta;
@@ -1223,33 +1327,42 @@ int ReloadSongsByQuery(CSTR query, sqlite3 *sql, CONFIG_JUKEBOX *jb) {
 							}
 						}
 					}
+					if (shouldCommit) {
+						SQL_Run("COMMIT", sql);
+					}
 				}
 				
 			}
 			else {
+				shouldCommit = sqlite3_get_autocommit(sql);
+				if (shouldCommit && SQL_Run("BEGIN IMMEDIATE", sql) != 0) {
+					shouldCommit = 0;
+				}
 				if (is_bms_file) {
 					SQL_Run(sqlite3_snprintf(512, sBuf, "DELETE FROM song WHERE path=\'%q\'", str.body), sql);
 				}
 				else {
 					SQL_Run(sqlite3_snprintf(512, sBuf, "DELETE FROM folder WHERE path=\'%q\'", str.body), sql);
 				}
+				if (shouldCommit) {
+					SQL_Run("COMMIT", sql);
+				}
 			}
 		}
 	}
-	sqlite3_finalize(pStmt);
 	GetTimeWrap();
 
 	if (cAlready == 0 && cNot == 0) {
 		if(cChange == 0){
-			ErrorLogFmtAdd("曲が見つかりません: %s\n", query.body);
+			ErrorLogFmtAdd("曲が見つかりません / No matching songs found: %s\n", query.body);
 			return 0;
 		}
 	}
 	else if (cChange == 0) {
-		ErrorLogFmtAdd("更新はありません\n");
+		ErrorLogFmtAdd("更新はありません / No updates\n");
 		return 1;
 	}
-	ErrorLogFmtAdd("更新しました。err %d update %d\n", cNot, cChange);
+	ErrorLogFmtAdd("更新しました / Updated. missing %d changed %d\n", cNot, cChange);
 	return 2;
 }
 

--- a/LR2/strclass.cpp
+++ b/LR2/strclass.cpp
@@ -528,7 +528,9 @@ CSTR CSTR::getDirectory() {
 }
 
 CSTR CSTR::getParentDirectory() {
-	return getDirectory().getDirectory();
+	CSTR dir(getDirectory());
+	dir.cutDirectorySeparator();
+	return dir.getDirectory();
 }
 
 CSTR& CSTR::cutDirectorySeparator() {


### PR DESCRIPTION
## Summary

This PR fixes issues in the song autoreload scan flow related to `song.db` handling and chart parent directory assignment.

## Changes

* Fixes a scan loop caused by mutating `.db` entries while iterating over a `SELECT` result (First iteration, i am working on a more global solution since the SELECT iterates two times, one for obtain the data from the table "folder" and other for DELETE/INSERT, which is slow af).
* Restores the parent folder behavior of the original LR2 so charts are linked to the main folder registered in the jukebox instead of being linked incorrectly by their own parent (i saw the previous change, and i think this is more robust, your choice).

## Why

The autoreload scan could behave incorrectly when the database was modified during the scan process. This could cause repeated scan behavior and incorrect parent directory links for charts loaded from `song.db`.

## Testing

* New client, make sure you don´t have song.db (its still slow btw)
* Make sure you have at least 200 folders on your main song folder
* You will see its going to loop at least two times, checking for outdated "date" column using -JOURNAL, which, it seems, its an intended behaviour because the autocommit is secure.
