### PR TITLE
fix: disable result QuickRestart for expert and class courses

### DIFF
--- a/LR2/Scene05_Result.cpp
+++ b/LR2/Scene05_Result.cpp
@@ -195,11 +195,6 @@ static void QuickRestart(game& game, bool newRandom) {
 	game.gameplay.flag_retry = newRandom ? 0 : 1;
 	game.gameplay.randomseed = newRandom ? 0 : game.gameplay.randomseed;
 
-	if ((game.gameplay.courseType == 0 || game.gameplay.courseType == 2) && game.gameplay.courseStageNow != 0) {
-		game.gameplay.courseStageNow = 0;
-		game.gameplay.flag_retry = 0;
-	}
-
 	if (game.gameplay.flag_retry == 0) ReleaseBGA(&game); // ugly place for this
 	StopAllKeysound(&game);
 }
@@ -296,7 +291,8 @@ int ProcI_Result(game *g) {
 				g->KeyInput.p2_buttonInput[1] == 2 || g->KeyInput.p2_buttonInput[3] == 2 || g->KeyInput.p2_buttonInput[5] == 2 || g->KeyInput.p2_buttonInput[7] == 2) 
 				&& (g->KeyInput.p1_buttonInput[2] == 2 || g->KeyInput.p1_buttonInput[4] == 2 || g->KeyInput.p1_buttonInput[6] == 2 ||
 					g->KeyInput.p2_buttonInput[2] == 2 || g->KeyInput.p2_buttonInput[4] == 2 || g->KeyInput.p2_buttonInput[6] == 2) 
-				&& g->gameplay.replay.status != 2 && g->config.play.m_lunaris == 0) {
+				&& g->gameplay.replay.status != 2 && g->config.play.m_lunaris == 0
+				&& g->gameplay.courseType != 0 && g->gameplay.courseType != 2) {
 
 				if (g->KeyInput.p1_buttonInput[2] == 2 || g->KeyInput.p2_buttonInput[2] == 2) QuickRestart(*g, true);
 				else QuickRestart(*g, false);


### PR DESCRIPTION
This code prevents QuickRestart from triggering during a course, which would otherwise cause the game to resume from the second stage. This results in the previous scores continuously accumulating, allowing players to obtain a much higher score than in a regular course playthrough.

Issue: https://github.com/GOMazk/OpenLR2/issues/103