### PR TITLE
refactor: let Linux build once again

### DIFF
--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cmath>
 #include <mutex>
 #include <ranges>
 #include <thread>

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -1,7 +1,10 @@
 #include "LR2_customir.h"
+
+#ifdef _WIN32
+
 #include "LR2_customir_api.h"
-#include "structure.h"
 #include "LR2_songmanage.h"
+#include "structure.h"
 
 #include <filesystem>
 #include <format>
@@ -500,3 +503,11 @@ void CUSTOMIR_MANAGER::SendScore(game& game, sqlite3* sql, int player) {
 		}
 	}, IRScoreInternal{ game, sql, player }, mModules));
 }
+#else
+
+CUSTOMIR_MANAGER::~CUSTOMIR_MANAGER() {};
+void CUSTOMIR_MANAGER::Initialize(const std::filesystem::path& directory) {};
+void CUSTOMIR_MANAGER::Login() {};
+void CUSTOMIR_MANAGER::SendScore(game& game, sqlite3* sql, int player) {};
+
+#endif // _WIN32

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -13,6 +13,7 @@
 
 #include <DxLib/DxLib.h>
 #include <libloaderapi.h>
+#include <wtypes.h>
 
 #if _WIN64
 #if _DEBUG
@@ -32,6 +33,24 @@ constexpr auto&& ARCH = ".x86";
 
 // TODO
 #define OverlayNotification ErrorLogFmtAdd
+
+class CustomIR {
+public:
+	CustomIR() = delete;
+	CustomIR(const std::filesystem::path& directory);
+	bool Initialize();
+	bool Login();
+	SendScoreStatus SendScore(const IRScoreV1& score);
+
+	[[nodiscard]] const std::string& Name() const { return mName; };
+private:
+	struct ModuleDeleter {
+		void operator()(std::remove_pointer_t<HMODULE>* handle);
+	};
+	std::unique_ptr<std::remove_pointer_t<HMODULE>, ModuleDeleter> mDllHandle;
+	std::string mName;
+	MethodTable mMethods;
+};
 
 CustomIR::CustomIR(const std::filesystem::path& _directory) {
 	for (auto& file : std::filesystem::directory_iterator(_directory)) {

--- a/LR2/LR2_customir.h
+++ b/LR2/LR2_customir.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 #include <type_traits>
+#include <vector>
 
 struct game;
 struct sqlite3;

--- a/LR2/LR2_customir.h
+++ b/LR2/LR2_customir.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "LR2_customir_api.h"
-
 #include <array>
 #include <filesystem>
 #include <future>
@@ -9,28 +7,9 @@
 #include <string>
 #include <type_traits>
 
-#include <wtypes.h>
-
 struct game;
 struct sqlite3;
-
-class CustomIR {
-public:
-	CustomIR() = delete;
-	CustomIR(const std::filesystem::path& directory);
-	bool Initialize();
-	bool Login();
-	SendScoreStatus SendScore(const IRScoreV1& score);
-
-	[[nodiscard]] const std::string& Name() const { return mName; };
-private:
-	struct ModuleDeleter {
-		void operator()(std::remove_pointer_t<HMODULE>* handle);
-	};
-	std::unique_ptr<std::remove_pointer_t<HMODULE>, ModuleDeleter> mDllHandle;
-	std::string mName;
-	MethodTable mMethods;
-};
+class CustomIR;
 
 class CUSTOMIR_MANAGER {
 public:

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -105,8 +105,14 @@ enum class SendScoreStatus: int {
 	Fail,
 };
 
+#ifndef _WIN32
+#define __cdecl
+#endif // _WIN32
 struct MethodTable {
 	const char*(__cdecl* GetName)() = nullptr;
 	bool(__cdecl* LoginV1)() = nullptr;
 	SendScoreStatus(__cdecl* SendScoreV1)(const IRScoreV1& score) = nullptr;
 };
+#ifndef _WIN32
+#undef __cdecl
+#endif // _WIN32

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -260,10 +260,12 @@ int main(int argc, char** argv) {
 			return -1;
 		}
 	}
-	//make beta3 score backup
-	CSTR pathScoreDBBackUp;
-	cstrSprintf(&pathScoreDBBackUp, "LR2files/Database/Score/%s.db_backup", gs.config.player.id.body);
-	CopyFile(pathScoreDB, pathScoreDBBackUp, true); //intended failure when exist
+	{
+		// make beta3 score backup
+		CSTR pathScoreDBBackUp;
+		cstrSprintf(&pathScoreDBBackUp, "LR2files/Database/Score/%s.db_backup", gs.config.player.id.body);
+		copy_if_not_exists(pathScoreDB.body, pathScoreDBBackUp.body);
+	}
 
 	gs.sSelect.playerPassMD5.assign(&gs.config.player.passMD5);
 	gs.sSelect.playerID.assign(&gs.config.player.id);

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1,8 +1,11 @@
 ﻿#include "Scene02_Songselect.h"
 #include "Engine.h"
 #include "LR2.h"
-#include <stdio.h>
 #include "filesystem.h"
+#include <format>
+#include <functional>
+#include <stdio.h>
+#include <string>
 #ifndef _WIN32
 #include "En_dxlibstub.h"
 #endif // _WIN32


### PR DESCRIPTION
No functional changes on Windows. This lets OpenLR2 compile on Linux again, if you plug in dxlib-for-linux. That is still waiting on us dropping the .sln build.