### PR TITLE
fix: scores accumulate during a normal restart + Incorrect starting s…

### DIFF
--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -1606,11 +1606,13 @@ int main(int argc, char** argv) {
 					if (gs.gameplay.courseType == 0 || gs.gameplay.courseType == 2) {
 						gs.gameplay.player[0].gaugeType = gs.gameplay.player[0].lastCourseGaugeType;
 						gs.gameplay.player[1].gaugeType = gs.gameplay.player[1].lastCourseGaugeType;
-						if (gs.gameplay.courseStageNow < gs.gameplay.courseStageCount -1 && gs.gameplay.player[0].clearType != 0 && (gs.gameplay.player[1].clearType != 0 || gs.config.play.battle != 1) && gs.gameplay.player[0].HP[gs.gameplay.player[0].gaugeType] >= 2.0) {
-							gs.gameplay.courseStageNow++;
-							gs.procSelecter = 4;
+						if (gs.procSelecter != 4) {
+							if (gs.gameplay.courseStageNow < gs.gameplay.courseStageCount -1 && gs.gameplay.player[0].clearType != 0 && (gs.gameplay.player[1].clearType != 0 || gs.config.play.battle != 1) && gs.gameplay.player[0].HP[gs.gameplay.player[0].gaugeType] >= 2.0) {
+								gs.gameplay.courseStageNow++;
+								gs.procSelecter = 4;
+							}
+							else gs.procSelecter = 13;
 						}
-						else gs.procSelecter = 13;
 					}
 					break;
 				case 6:
@@ -1645,7 +1647,7 @@ int main(int argc, char** argv) {
 							}
 						}
 					}	
-					gs.procSelecter = 2;
+					if (gs.procSelecter != 4) gs.procSelecter = 2;
 					StopSysSound(&gs);
 					break;
 				}

--- a/LR2/Scene05_Result.cpp
+++ b/LR2/Scene05_Result.cpp
@@ -196,7 +196,7 @@ static void QuickRestart(game& game, bool newRandom) {
 	game.gameplay.flag_retry = newRandom ? 0 : 1;
 	game.gameplay.randomseed = newRandom ? 0 : game.gameplay.randomseed;
 
-	if (game.gameplay.courseType == 0 || game.gameplay.courseType == 2) {
+	if ((game.gameplay.courseType == 0 || game.gameplay.courseType == 2) && game.gameplay.courseStageNow != 0) {
 		game.gameplay.courseStageNow = 0;
 		game.gameplay.flag_retry = 0;
 	}

--- a/LR2/Scene05_Result.cpp
+++ b/LR2/Scene05_Result.cpp
@@ -191,11 +191,12 @@ int Proc_Result(game *g, skstruct *sk, Timer *T) {
 }
 
 static void QuickRestart(game& game, bool newRandom) {
+	game.procPhase = 0;
 	game.procSelecter = 4;
 	game.gameplay.flag_retry = newRandom ? 0 : 1;
 	game.gameplay.randomseed = newRandom ? 0 : game.gameplay.randomseed;
 
-	if ((game.gameplay.courseType == 0 || game.gameplay.courseType == 2) && game.gameplay.courseStageNow != 0) {
+	if (game.gameplay.courseType == 0 || game.gameplay.courseType == 2) {
 		game.gameplay.courseStageNow = 0;
 		game.gameplay.flag_retry = 0;
 	}


### PR DESCRIPTION
This PR fixes the issue where a course starts from the second stage upon restart, as well as the issue of scores accumulating.

The QuickRestart logic has been modified because Scene05 executes it even during a normal restart. Please let me know if this part causes any issues.

Issue: https://github.com/GOMazk/OpenLR2/issues/103