### PR TITLE
feat(ir): apply exlevel.xml locally even when LR2IR is unreachable 

### DIFF
--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -383,34 +383,42 @@ static int ParseRivalData(int ID) {
 	return 1;
 }
 
+// Download insane difficulty list into LR2files/Database/exlevel.xml.
 int NETWORK::GetInsaneList() {
-
-	TiXmlDocument *hXml;
-	TiXmlElement *cur;
-	sqlite3 *pSongDB;
-
 	cstrSprintf(&this->param," ");
 	this->target_URL = "http://www.dream-pro.info/~lavalse/LR2IR/2/getinsanelist.cgi";
-	if (HTTPrequest() == 1) {
-		this->httpResult.toFile(fs::make_preferred("LR2files/Database/exlevel.xml").data());
-		printfDx("発狂難度リストをダウンロードしました。 / Downloaded the Insane difficulty list.\n");
-		ErrorLogFmtAdd("発狂難度リストをダウンロードしました。 / Downloaded the Insane difficulty list.\n");
-	}
-	else{
+	if (HTTPrequest() != 1) {
 		printfDx("発狂難度リストのダウンロードに失敗しました。 / Failed to download the Insane difficulty list.\n");
 		ErrorLogFmtAdd("発狂難度リストのダウンロードに失敗しました。 / Failed to download the Insane difficulty list.\n");
+		ScreenFlip();
+		ProcessMessage();
+		return 0;
 	}
+	this->httpResult.toFile(fs::make_preferred("LR2files/Database/exlevel.xml").data());
+	printfDx("発狂難度リストをダウンロードしました。 / Downloaded the Insane difficulty list.\n");
+	ErrorLogFmtAdd("発狂難度リストをダウンロードしました。 / Downloaded the Insane difficulty list.\n");
 	ScreenFlip();
+	ProcessMessage();
+	return 1;
+}
 
-	std::string path = fs::make_preferred("LR2files/Database/exlevel.xml").data();
-	hXml = new TiXmlDocument(path.c_str());
+// Apply song exlevel from LR2files/Database/exlevel.xml.
+int NETWORK::ApplyInsaneList() {
+	printfDx("発狂難度データベースを更新しています... / Updating the Insane difficulty database...\n");
+	ScreenFlip();
+	ProcessMessage();
+
+	const std::string path = fs::make_preferred("LR2files/Database/exlevel.xml").data();
+
+	TiXmlDocument *hXml = new TiXmlDocument(path.c_str());
+
 	if (!parse_cp932_xml(hXml, path.c_str())) {
 		delete(hXml);
 		printfDx("発狂レベルリストにアクセスできません。 / Cannot access the Insane level list.\n");
 		ErrorLogFmtAdd("発狂難度リストにアクセスできません。 / Cannot access the Insane level list.\n");
 		return 0;
 	}
-	cur = hXml->FirstChildElement("list");
+	TiXmlElement *cur = hXml->FirstChildElement("list");
 	if (!cur) {
 		delete(hXml);
 		printfDx("発狂レベルリストの読み込みに失敗しました。 / Failed to load the Insane level list.\n");
@@ -425,6 +433,7 @@ int NETWORK::GetInsaneList() {
 
 	CSTR query;
 	std::string hash;
+	sqlite3 *pSongDB;
 	sqlite3_open(fs::make_preferred("LR2files/Database/song.db").data(), &pSongDB);
 	SQL_Run("BEGIN", pSongDB);
 	while (cur) {

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -393,12 +393,12 @@ int NETWORK::GetInsaneList() {
 	this->target_URL = "http://www.dream-pro.info/~lavalse/LR2IR/2/getinsanelist.cgi";
 	if (HTTPrequest() == 1) {
 		this->httpResult.toFile(fs::make_preferred("LR2files/Database/exlevel.xml").data());
-		printfDx("発狂難度リストをダウンロードしました。\n");
-		ErrorLogFmtAdd("発狂難度リストをダウンロードしました。\n");
+		printfDx("発狂難度リストをダウンロードしました。 / Downloaded the Insane difficulty list.\n");
+		ErrorLogFmtAdd("発狂難度リストをダウンロードしました。 / Downloaded the Insane difficulty list.\n");
 	}
 	else{
-		printfDx("発狂難度リストの更新に失敗しました。");
-		ErrorLogFmtAdd("発狂難度リストの更新に失敗しました。\n");
+		printfDx("発狂難度リストのダウンロードに失敗しました。 / Failed to download the Insane difficulty list.\n");
+		ErrorLogFmtAdd("発狂難度リストのダウンロードに失敗しました。 / Failed to download the Insane difficulty list.\n");
 	}
 	ScreenFlip();
 
@@ -406,20 +406,20 @@ int NETWORK::GetInsaneList() {
 	hXml = new TiXmlDocument(path.c_str());
 	if (!parse_cp932_xml(hXml, path.c_str())) {
 		delete(hXml);
-		printfDx("発狂レベルリストにアクセスできません。\n");
-		ErrorLogFmtAdd("発狂難度リストにアクセスできません。\n");
+		printfDx("発狂レベルリストにアクセスできません。 / Cannot access the Insane level list.\n");
+		ErrorLogFmtAdd("発狂難度リストにアクセスできません。 / Cannot access the Insane level list.\n");
 		return 0;
 	}
 	cur = hXml->FirstChildElement("list");
 	if (!cur) {
 		delete(hXml);
-		printfDx("発狂レベルリストの読み込みに失敗しました。\n");
+		printfDx("発狂レベルリストの読み込みに失敗しました。 / Failed to load the Insane level list.\n");
 		return 0;
 	}
 	cur = cur->FirstChildElement("song");
 	if (!cur) {
 		delete(hXml);
-		printfDx("発狂レベルリストの更新はありません。\n");
+		printfDx("発狂レベルリストの更新はありません。 / No update for the Insane level list.\n");
 		return 0;
 	}
 

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -418,8 +418,11 @@ int main(int argc, char** argv) {
 			: fs::make_preferred("LR2files/Database/song.db").data(), &sql3);
 	LoadLR2CustomFolder(sql3, &gs.config.jukebox, pathScoreDB, gs.is_starter, gs.cmd_directplay);
 	if (gs.cmd_directplay == false) {
-		if (gs.config.network.lr2ir == 1 && (((unsigned char)gs.config.jukebox.customfolder & 0x80) != 0)) {
-			gs.net.GetInsaneList();
+		if (((unsigned char)gs.config.jukebox.customfolder & 0x80) != 0) {
+			if (gs.config.network.lr2ir == 1) {
+				gs.net.GetInsaneList();
+			}
+			gs.net.ApplyInsaneList();
 		}
 		if (gs.is_starter == false) {
 			printfDx(LR2VERSIONSTRING"\n");

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -418,6 +418,9 @@ int main(int argc, char** argv) {
 			: fs::make_preferred("LR2files/Database/song.db").data(), &sql3);
 	LoadLR2CustomFolder(sql3, &gs.config.jukebox, pathScoreDB, gs.is_starter, gs.cmd_directplay);
 	if (gs.cmd_directplay == false) {
+		if (loadingGrHandle > 0) {
+			DrawGraph(0, 0, loadingGrHandle, 0);
+		}
 		if (((unsigned char)gs.config.jukebox.customfolder & 0x80) != 0) {
 			if (gs.config.network.lr2ir == 1) {
 				gs.net.GetInsaneList();
@@ -427,15 +430,9 @@ int main(int argc, char** argv) {
 		if (gs.is_starter == false) {
 			printfDx(LR2VERSIONSTRING"\n");
 			printfDx("PUSH ANY KEY\n");
-			if (loadingGrHandle > 0) {
-				DrawGraph(0, 0, loadingGrHandle, 0);
-			}
 			ScreenFlip();
 			if (WaitInput(&gs.KeyInput) == -1) return 0;
 			printfDx("READY");
-		}
-		if (loadingGrHandle > 0) {
-			DrawGraph(0, 0, loadingGrHandle, 0);
 		}
 		ScreenFlip();
 	}

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1402,6 +1402,7 @@ struct NETWORK {
 	CUSTOMIR_MANAGER customIR;
 
 	int GetInsaneList();
+	int ApplyInsaneList();
 
 	void ParseRankingXml(const char* path);
 


### PR DESCRIPTION
Fixes https://github.com/GOMazk/OpenLR2/issues/118 "Insane table doesn´t update now that LR2IR is dead"

---

This is going to be a short one, but in short, it separated exlevel.xml reading from internet connection.

exlevel.xml could also be used on a future for owners of customIRs for upload their own list of tables so, for someone who is making a client its also useful, specially with parallel processing.

On an ideal point, customIRs could work together for bring an standard to the exlevel.xml so, everyone could upload the most played tables AND personal ones automatically without the need of bemusicseeker.