### PR TITLE
fix(songmanage): add missing genre reset to BMSMETA (LR2 bug)

### DIFF
--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -2598,32 +2598,34 @@ int LoadLR2CustomFolder(sqlite3 *sql, CONFIG_JUKEBOX *jb, CSTR scoreDBpath, char
 	return 1;
 }
 
-int InitBMSMETA(BMSMETA *meta) {
-	meta->title.fillzero();
-	meta->subtitle.fillzero();
-	meta->artist.fillzero();
-	meta->subartist.fillzero();
-	meta->hash.fillzero();
-	meta->filename.fillzero();
-	meta->stagefilepath.fillzero();
-	meta->bannerpath.fillzero();
-	meta->parentfolderpath.fillzero();
-	meta->folderpath.fillzero();
-	meta->tag.fillzero();
-	meta->backBMPpath.fillzero();
-	meta->filepath.fillzero();
-	meta->selLevel = 0;
-	meta->exlevel = 0;
-	meta->notecount = 0;
-	meta->maxbpm = 0;
-	meta->minbpm = 0;
-	meta->longnote = 0;
-	meta->random = 0;
-	meta->bga = 0;
-	meta->hasTxt = 0;
-	meta->keymode = 5;
-	meta->difficulty = -1;
-	meta->judge = 2;
+int InitBMSMETA(BMSMETA *meta_) {
+	auto& meta = *meta_;
+	meta.hash.fillzero();
+	meta.title.fillzero();
+	meta.subtitle.fillzero();
+	meta.artist.fillzero();
+	meta.subartist.fillzero();
+	meta.genre.fillzero();
+	meta.filepath.fillzero();
+	meta.filename.fillzero();
+	meta.stagefilepath.fillzero();
+	meta.bannerpath.fillzero();
+	meta.backBMPpath.fillzero();
+	meta.parentfolderpath.fillzero();
+	meta.folderpath.fillzero();
+	meta.tag.fillzero();
+	meta.notecount = 0;
+	meta.maxbpm = 0;
+	meta.minbpm = 0;
+	meta.keymode = 5;
+	meta.longnote = 0;
+	meta.selLevel = 0;
+	meta.exlevel = 0;
+	meta.judge = 2;
+	meta.difficulty = -1;
+	meta.random = 0;
+	meta.bga = 0;
+	meta.hasTxt = 0;
 	return 1;
 }
 


### PR DESCRIPTION
Fixes https://github.com/GOMazk/OpenLR2/issues/120 "Charts with undefined #GENRE may display the #GENRE from other chart".

Reproduce by creating two .bms files, named 'a' and 'b', first with a `#GENRE` statement, second without, add the folder to your jukebox and remove song.db before each restart.

Initialization order in patch changed to match the order of fields in the struct.