### PR TITLE
fix(songmanage): increment values behind pointers (RE issue)

### DIFF
--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -2282,7 +2282,7 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 			int diffCycle = *diffFilter;
 			do {
 				if (*diffFilter == 0) break;
-				*diffFilter++;
+				*diffFilter += 1;
 				if (*diffFilter >= 6) *diffFilter = 0;
 				if (ss->filter.ignoredifficultyall && *diffFilter == 0) *diffFilter = 1;
 			} while (diffcount[*diffFilter] == 0);
@@ -2315,7 +2315,7 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 		}
 		else{
 			int modeCycle = *mode;
-			for (*mode = modeCycle + 1; *mode != modeCycle; *mode++) {
+			for (*mode = modeCycle + 1; *mode != modeCycle; *mode += 1) {
 				if (*mode == 8) *mode = 0;
 				if (ss->filter.ignorekeyall == 1 && *mode == 0) *mode = 1;
 				if (ss->filter.ignorekeysingle == 1 && *mode == 1) *mode = 2;


### PR DESCRIPTION
`*ptr++;` increments the pointer first and then just dereferences it, instead of incrementing the value behind the pointer. Grep for `\*\w+\+\+`.
All hail Clang -Wunused-value.

Fixes https://github.com/GOMazk/OpenLR2/issues/53 "Incorrect 'play style' fallback when opening .lr2folder".
Fixes https://github.com/GOMazk/OpenLR2/issues/54 "'PLAY STYLE' can be incorrectly changed".