### PR TITLE
Load/Update external IR record to player.db locally

### DIFF
--- a/LR2/LR2_ghost.cpp
+++ b/LR2/LR2_ghost.cpp
@@ -764,6 +764,30 @@ CSTR ReadGhost(sqlite3 *sql, CSTR songMD5) {
 	return ghostdata;
 }
 
+CSTR ReadIRGhost(sqlite3* sql, CSTR songMD5) {
+	ErrorLogAdd("データベースからゴーストを読み込みます\n");
+
+	sqlite3_stmt* pStmt;
+	if (sqlite3_prepare_v3(sql, "SELECT ghost FROM imported_score WHERE hash = ?", -1, 0, &pStmt, nullptr) != SQLITE_OK) {
+		ErrorLogAdd("sqlite3_prepare_v3 error\n");
+	}
+	if (sqlite3_bind_text(pStmt, 1, songMD5.body, songMD5.length(), nullptr) != SQLITE_OK) {
+		ErrorLogAdd("sqlite3_bind_text error\n");
+	}
+
+	CSTR ghostdata;
+	if (sqlite3_step(pStmt) == SQLITE_ROW) {
+		ghostdata.resize(sqlite3_column_bytes(pStmt, 0));
+		// Cast safety: it's safe to cast from unsigned char* to char*
+		ghostdata = reinterpret_cast<const char*>(sqlite3_column_text(pStmt, 0));
+	}
+	if (sqlite3_finalize(pStmt) != SQLITE_OK) {
+		ErrorLogAdd("sqlite3_finalize error\n");
+	}
+
+	return ghostdata;
+}
+
 int ReadGhostToScore(sqlite3 *sql, CSTR songMD5, PLAYSCORE *score) {
 	CSTR ghostdata = ReadGhost(sql, songMD5);
 
@@ -772,6 +796,18 @@ int ReadGhostToScore(sqlite3 *sql, CSTR songMD5, PLAYSCORE *score) {
 		return 1;
 	}
 	
+	score->DecodeGhostData(ghostdata);
+	return 1;
+}
+
+int ReadIRGhostToScore(sqlite3* sql, CSTR songMD5, PLAYSCORE* score) {
+	CSTR ghostdata = ReadIRGhost(sql, songMD5);
+
+	if (ghostdata.length() == 0) {
+		score->InitJudgeQueue();
+		return 1;
+	}
+
 	score->DecodeGhostData(ghostdata);
 	return 1;
 }

--- a/LR2/LR2_ghost.cpp
+++ b/LR2/LR2_ghost.cpp
@@ -740,7 +740,7 @@ int WriteGhostInDatabase(sqlite3 *sql, CSTR songMD5, PLAYSCORE *score) {
 	return 0;
 }
 
-CSTR ReadGhost(sqlite3 *sql, CSTR songMD5, bool useImportedGhost = false) {
+CSTR ReadGhost(sqlite3 *sql, CSTR songMD5, bool useImportedGhost) {
 	ErrorLogAdd("データベースからゴーストを読み込みます\n");
 
 	const std::string query = std::format("SELECT ghost FROM {} WHERE hash = ?", useImportedGhost ? "imported_score" : "score");
@@ -766,7 +766,7 @@ CSTR ReadGhost(sqlite3 *sql, CSTR songMD5, bool useImportedGhost = false) {
 	return ghostdata;
 }
 
-int ReadGhostToScore(sqlite3 *sql, CSTR songMD5, PLAYSCORE *score, bool useImportedGhost = false) {
+int ReadGhostToScore(sqlite3 *sql, CSTR songMD5, PLAYSCORE *score, bool useImportedGhost) {
 	CSTR ghostdata = ReadGhost(sql, songMD5, useImportedGhost);
 
 	if (ghostdata.length() == 0) {

--- a/LR2/LR2_ghost.cpp
+++ b/LR2/LR2_ghost.cpp
@@ -740,11 +740,13 @@ int WriteGhostInDatabase(sqlite3 *sql, CSTR songMD5, PLAYSCORE *score) {
 	return 0;
 }
 
-CSTR ReadGhost(sqlite3 *sql, CSTR songMD5) {
+CSTR ReadGhost(sqlite3 *sql, CSTR songMD5, bool useImportedGhost = false) {
 	ErrorLogAdd("データベースからゴーストを読み込みます\n");
 
+	const std::string query = std::format("SELECT ghost FROM {} WHERE hash = ?", useImportedGhost ? "imported_score" : "score");
+	
 	sqlite3_stmt *pStmt;
-	if (sqlite3_prepare_v3(sql, "SELECT ghost FROM score WHERE hash = ?", -1, 0, &pStmt, nullptr) != SQLITE_OK) {
+	if (sqlite3_prepare_v3(sql, query.c_str(), -1, 0, &pStmt, nullptr) != SQLITE_OK) {
 		ErrorLogAdd("sqlite3_prepare_v3 error\n");
 	}
 	if (sqlite3_bind_text(pStmt, 1, songMD5.body, songMD5.length(), nullptr) != SQLITE_OK) {
@@ -764,50 +766,14 @@ CSTR ReadGhost(sqlite3 *sql, CSTR songMD5) {
 	return ghostdata;
 }
 
-CSTR ReadIRGhost(sqlite3* sql, CSTR songMD5) {
-	ErrorLogAdd("データベースからゴーストを読み込みます\n");
-
-	sqlite3_stmt* pStmt;
-	if (sqlite3_prepare_v3(sql, "SELECT ghost FROM imported_score WHERE hash = ?", -1, 0, &pStmt, nullptr) != SQLITE_OK) {
-		ErrorLogAdd("sqlite3_prepare_v3 error\n");
-	}
-	if (sqlite3_bind_text(pStmt, 1, songMD5.body, songMD5.length(), nullptr) != SQLITE_OK) {
-		ErrorLogAdd("sqlite3_bind_text error\n");
-	}
-
-	CSTR ghostdata;
-	if (sqlite3_step(pStmt) == SQLITE_ROW) {
-		ghostdata.resize(sqlite3_column_bytes(pStmt, 0));
-		// Cast safety: it's safe to cast from unsigned char* to char*
-		ghostdata = reinterpret_cast<const char*>(sqlite3_column_text(pStmt, 0));
-	}
-	if (sqlite3_finalize(pStmt) != SQLITE_OK) {
-		ErrorLogAdd("sqlite3_finalize error\n");
-	}
-
-	return ghostdata;
-}
-
-int ReadGhostToScore(sqlite3 *sql, CSTR songMD5, PLAYSCORE *score) {
-	CSTR ghostdata = ReadGhost(sql, songMD5);
+int ReadGhostToScore(sqlite3 *sql, CSTR songMD5, PLAYSCORE *score, bool useImportedGhost = false) {
+	CSTR ghostdata = ReadGhost(sql, songMD5, useImportedGhost);
 
 	if (ghostdata.length() == 0) {
 		score->InitJudgeQueue();
 		return 1;
 	}
 	
-	score->DecodeGhostData(ghostdata);
-	return 1;
-}
-
-int ReadIRGhostToScore(sqlite3* sql, CSTR songMD5, PLAYSCORE* score) {
-	CSTR ghostdata = ReadIRGhost(sql, songMD5);
-
-	if (ghostdata.length() == 0) {
-		score->InitJudgeQueue();
-		return 1;
-	}
-
 	score->DecodeGhostData(ghostdata);
 	return 1;
 }

--- a/LR2/LR2_ghost.h
+++ b/LR2/LR2_ghost.h
@@ -4,7 +4,5 @@
 #include "Engine.h"
 
 int WriteGhostInDatabase(sqlite3 * sql, CSTR songMD5, PLAYSCORE * score);
-int ReadGhostToScore(sqlite3 * sql, CSTR songMD5, PLAYSCORE * score);
-int ReadIRGhostToScore(sqlite3* sql, CSTR songMD5, PLAYSCORE* score);
-CSTR ReadGhost(sqlite3 * sql, CSTR songMD5);
-CSTR ReadIRGhost(sqlite3 * sql, CSTR songMD5);
+int ReadGhostToScore(sqlite3 * sql, CSTR songMD5, PLAYSCORE * score, bool useImportedGhost = false);
+CSTR ReadGhost(sqlite3 * sql, CSTR songMD5, bool useImportedGhost = false);

--- a/LR2/LR2_ghost.h
+++ b/LR2/LR2_ghost.h
@@ -5,4 +5,6 @@
 
 int WriteGhostInDatabase(sqlite3 * sql, CSTR songMD5, PLAYSCORE * score);
 int ReadGhostToScore(sqlite3 * sql, CSTR songMD5, PLAYSCORE * score);
+int ReadIRGhostToScore(sqlite3* sql, CSTR songMD5, PLAYSCORE* score);
 CSTR ReadGhost(sqlite3 * sql, CSTR songMD5);
+CSTR ReadIRGhost(sqlite3 * sql, CSTR songMD5);

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -7,7 +7,6 @@
 #include "LR2_statplay.h"
 #include "Scenes.h"
 #include "filesystem.h"
-#include "filesystem.h"
 #include <DxLib/DxLib.h>
 
 #ifndef _WIN32
@@ -20,7 +19,7 @@ bool GetOptionFlag_dst(game *gs, int option) {
 	bool ret = (option >= 0);
 	if (!ret) option = -option;
 	const SONGDATA& songData = gs->sSelect.bmsList[gs->sSelect.cur_song];
-	const std::optional<STATUS>& myIRbest = songData.myIRbest;
+	const STATUS& mybest = songData.myIRbest.has_value() ? *songData.myIRbest : songData.mybest;
 
 	switch (option) {
 		case 0:
@@ -294,251 +293,247 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 100: //TODO : make more readable
 			if (gs->config.play.battle == 2) {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_db : songData.mybest.clear_db) == 0) return ret;
+				if (mybest.clear_db == 0) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_ex : songData.mybest.clear_ex) == 0) return ret;
+				if (mybest.clear_ex == 0) return ret;
 			}
 			else if(gs->config.play.battle == 3){
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_sd : songData.mybest.clear_sd) == 0) return ret;
+				if (mybest.clear_sd == 0) return ret;
 			}
 			else {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) == 0) return ret;
+				if (mybest.clear == 0) return ret;
 			}
 			break;
 		case 101:
 			if (gs->config.play.battle == 2) {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_db : songData.mybest.clear_db) == 1) return ret;
+				if (mybest.clear_db == 1) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_ex : songData.mybest.clear_ex) == 1) return ret;
+				if (mybest.clear_ex == 1) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_sd : songData.mybest.clear_sd) == 1) return ret;
+				if (mybest.clear_sd == 1) return ret;
 			}
 			else {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) == 1) return ret;
+				if (mybest.clear == 1) return ret;
 			}
 			break;
 		case 102:
 			if (gs->config.play.battle == 2) {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_db : songData.mybest.clear_db) == 2) return ret;
+				if (mybest.clear_db == 2) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_ex : songData.mybest.clear_ex) == 2) return ret;
+				if (mybest.clear_ex == 2) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_sd : songData.mybest.clear_sd) == 2) return ret;
+				if (mybest.clear_sd == 2) return ret;
 			}
 			else {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) == 2) return ret;
+				if (mybest.clear == 2) return ret;
 			}
 			break;
 		case 103:
 			if (gs->config.play.battle == 2) {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_db : songData.mybest.clear_db) == 3) return ret;
+				if (mybest.clear_db == 3) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_ex : songData.mybest.clear_ex) == 3) return ret;
+				if (mybest.clear_ex == 3) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_sd : songData.mybest.clear_sd) == 3) return ret;
+				if (mybest.clear_sd == 3) return ret;
 			}
 			else {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) == 3) return ret;
+				if (mybest.clear == 3) return ret;
 			}
 			break;
 		case 104:
 			if (gs->config.play.battle == 2) {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_db : songData.mybest.clear_db) == 4) return ret;
+				if (mybest.clear_db == 4) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_ex : songData.mybest.clear_ex) == 4) return ret;
+				if (mybest.clear_ex == 4) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_sd : songData.mybest.clear_sd) == 4) return ret;
+				if (mybest.clear_sd == 4) return ret;
 			}
 			else {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) == 4) return ret;
+				if (mybest.clear == 4) return ret;
 			}
 			break;
 		case 105:
 			if (gs->config.play.battle == 2) {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_db : songData.mybest.clear_db) == 5) return ret;
+				if (mybest.clear_db == 5) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_ex : songData.mybest.clear_ex) == 5) return ret;
+				if (mybest.clear_ex == 5) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_sd : songData.mybest.clear_sd) == 5) return ret;
+				if (mybest.clear_sd == 5) return ret;
 			}
 			else {
 				if (songData.keymode <= 0) return !ret;
-				if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) == 5) return ret;
+				if (mybest.clear == 5) return ret;
 			}
 			break;
 
 		case 110:
-			if (songData.keymode > 0 &&
-				(myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) &&
-				(myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) > 7)
+			if (songData.keymode > 0 && mybest.clear && mybest.rank > 7)
 				return ret;
 			break;
 		
 		case 111:
 			if (songData.keymode <= 0) return !ret;
-			if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) < 1) return !ret;
-			if ((myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) > 6 && (myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) < 8) return ret; //why???
+			if (mybest.clear < 1) return !ret;
+			if (mybest.rank > 6 && mybest.rank < 8) return ret; //why???
 			break;
 		case 112:
 			if (songData.keymode <= 0) return !ret;
-			if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) < 1) return !ret;
-			if ((myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) > 5 && (myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) < 7) return ret;
+			if (mybest.clear < 1) return !ret;
+			if (mybest.rank > 5 && mybest.rank < 7) return ret;
 			break;
 		case 113:
 			if (songData.keymode <= 0) return !ret;
-			if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) < 1) return !ret;
-			if ((myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) > 4 && (myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) < 6) return ret;
+			if (mybest.clear < 1) return !ret;
+			if (mybest.rank > 4 && mybest.rank < 6) return ret;
 			break;
 		case 114:
 			if (songData.keymode <= 0) return !ret;
-			if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) < 1) return !ret;
-			if ((myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) > 3 && (myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) < 5) return ret;
+			if (mybest.clear < 1) return !ret;
+			if (mybest.rank > 3 && mybest.rank < 5) return ret;
 			break;
 		case 115:
 			if (songData.keymode <= 0) return !ret;
-			if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) < 1) return !ret;
-			if ((myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) > 2 && (myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) < 4) return ret;
+			if (mybest.clear < 1) return !ret;
+			if (mybest.rank > 2 && mybest.rank < 4) return ret;
 			break;
 		case 116:
 			if (songData.keymode <= 0) return !ret;
-			if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) < 1) return !ret;
-			if ((myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) > 1 && (myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) < 3) return ret;
+			if (mybest.clear < 1) return !ret;
+			if (mybest.rank > 1 && mybest.rank < 3) return ret;
 			break;
 		case 117:
-			if (songData.keymode > 0 &&
-				(myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) > 0 &&
-				(myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) < 2)
+			if (songData.keymode > 0 && mybest.clear > 0 && mybest.rank < 2)
 				return ret;
 			break;
 
 		case 118:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 1) return ret;
+			if (mybest.op_history & 1) return ret;
 			break;
 		case 119:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 2) return ret;
+			if (mybest.op_history & 2) return ret;
 			break;
 		case 120:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 4) return ret;
+			if (mybest.op_history & 4) return ret;
 			break;
 		case 121:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 8) return ret;
+			if (mybest.op_history & 8) return ret;
 			break;
 		case 122:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x10) return ret;
+			if (mybest.op_history & 0x10) return ret;
 			break;
 		case 123:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x20) return ret;
+			if (mybest.op_history & 0x20) return ret;
 			break;
 		case 124:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x40) return ret;
+			if (mybest.op_history & 0x40) return ret;
 			break;
 		case 125:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x80) return ret;
+			if (mybest.op_history & 0x80) return ret;
 			break;
 		case 126:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x100) return ret;
+			if (mybest.op_history & 0x100) return ret;
 			break;
 		case 127:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x200) return ret;
+			if (mybest.op_history & 0x200) return ret;
 			break;
 		case 128:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x400) return ret;
+			if (mybest.op_history & 0x400) return ret;
 			break;
 		case 129:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x800) return ret;
+			if (mybest.op_history & 0x800) return ret;
 			break;
 		case 130:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x1000) return ret;
+			if (mybest.op_history & 0x1000) return ret;
 			break;
 		case 131:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x2000) return ret;
+			if (mybest.op_history & 0x2000) return ret;
 			break;
 		case 132:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x4000) return ret;
+			if (mybest.op_history & 0x4000) return ret;
 			break;
 		case 133:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x8000) return ret;
+			if (mybest.op_history & 0x8000) return ret;
 			break;
 		case 134:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x10000) return ret;
+			if (mybest.op_history & 0x10000) return ret;
 			break;
 		case 135:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x20000) return ret;
+			if (mybest.op_history & 0x20000) return ret;
 			break;
 		case 136:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x40000) return ret;
+			if (mybest.op_history & 0x40000) return ret;
 			break;
 		case 137:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x80000) return ret;
+			if (mybest.op_history & 0x80000) return ret;
 			break;
 		case 138:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x100000) return ret;
+			if (mybest.op_history & 0x100000) return ret;
 			break;
 		case 139:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x200000) return ret;
+			if (mybest.op_history & 0x200000) return ret;
 			break;
 		case 140:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x400000) return ret;
+			if (mybest.op_history & 0x400000) return ret;
 			break;
 		case 141:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x800000) return ret;
+			if (mybest.op_history & 0x800000) return ret;
 			break;
 		case 142:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x1000000) return ret;
+			if (mybest.op_history & 0x1000000) return ret;
 			break;
 		case 143:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x2000000) return ret;
+			if (mybest.op_history & 0x2000000) return ret;
 			break;
 		case 144:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x4000000) return ret;
+			if (mybest.op_history & 0x4000000) return ret;
 			break;
 		case 145:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x8000000) return ret;
+			if (mybest.op_history & 0x8000000) return ret;
 			break;
 		case 146:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x10000000) return ret;
+			if (mybest.op_history & 0x10000000) return ret;
 			break;
 		case 147:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x20000000) return ret;
+			if (mybest.op_history & 0x20000000) return ret;
 			break;
 		case 148:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x40000000) return ret;
+			if (mybest.op_history & 0x40000000) return ret;
 			break;
 		case 149:
-			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x80000000) return ret;
+			if (mybest.op_history & 0x80000000) return ret;
 			break;
 
 		case 150:
@@ -1424,7 +1419,7 @@ bool GetOptionFlag_dst(game *gs, int option) {
 			break;
 
 		case 626:
-			if (myIRbest.has_value()) return ret;
+			if (songData.myIRbest.has_value()) return ret;
 			break;
 			
 		case 640:
@@ -1634,7 +1629,7 @@ bool GetOptionFlag_dst(game *gs, int option) {
 uint SetObjectValue_Num(game *g, int op) {
 	DATEDATA Date;
 	const SONGDATA& songData = g->sSelect.bmsList[g->sSelect.cur_song];
-	const std::optional<STATUS>& myIRbest = songData.myIRbest;
+	const STATUS& mybest = songData.myIRbest.has_value() ? *songData.myIRbest : songData.mybest;
 
 	switch (op) {
 		case 10:
@@ -1747,31 +1742,24 @@ uint SetObjectValue_Num(game *g, int op) {
 
 		case 70:
 			if (g->sSelect.metaSelected.keymode == 7 || g->sSelect.metaSelected.keymode == 14)
-				return myIRbest.has_value() ?
-				songData.myIRbest.value().stat_score : songData.mybest.stat_score;
+				return mybest.stat_score;
 			else
-				return myIRbest.has_value() ?
-				songData.myIRbest.value().stat_score / 20 * 10 : songData.mybest.stat_score / 20 * 10;
+				return mybest.stat_score / 20 * 10;
 		case 71:
-			return myIRbest.has_value() ? songData.myIRbest.value().stat_exscore : songData.mybest.stat_exscore;
+			return mybest.stat_exscore;
 		case 72:
-			return myIRbest.has_value() ? (songData.myIRbest.value().total_notes * 2) : (songData.mybest.total_notes * 2);
+			return mybest.total_notes * 2;
 		case 73:
-			if (myIRbest.has_value()) {
-				if (songData.myIRbest.value().total_notes)
-					return (songData.myIRbest.value().stat_exscore * 100) / (songData.myIRbest.value().total_notes * 2);
-				if (songData.mybest.total_notes)
-					return (songData.mybest.stat_exscore * 100) / (songData.mybest.total_notes * 2);
+			if (mybest.total_notes) {
+				return (mybest.stat_exscore * 100) / (mybest.total_notes * 2);
 			}
 			break;
 		case 74:
-			return myIRbest.has_value() ? songData.myIRbest.value().total_notes : songData.mybest.total_notes;
+			return mybest.total_notes;
 		case 75:
-			return myIRbest.has_value() ? songData.myIRbest.value().stat_maxcombo : songData.mybest.stat_maxcombo;
+			return mybest.stat_maxcombo;
 		case 76:
-			return myIRbest.has_value() ?
-				(songData.myIRbest.value().minbp != -1) * songData.myIRbest.value().minbp :
-				(songData.mybest.minbp != -1) * songData.mybest.minbp;
+			return (mybest.minbp != -1) * mybest.minbp;
 		case 77:
 			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.playcount;
 		case 78:
@@ -1779,44 +1767,34 @@ uint SetObjectValue_Num(game *g, int op) {
 		case 79:
 			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.playcount - g->sSelect.bmsList[g->sSelect.cur_song].mybest.clearcount;
 		case 80:
-			return myIRbest.has_value() ? songData.myIRbest.value().stat_pgreat : songData.mybest.stat_pgreat;
+			return mybest.stat_pgreat;
 		case 81:
-			return myIRbest.has_value() ? songData.myIRbest.value().stat_great : songData.mybest.stat_great;
+			return mybest.stat_great;
 		case 82:
-			return myIRbest.has_value() ? songData.myIRbest.value().stat_good : songData.mybest.stat_good;
+			return mybest.stat_good;
 		case 83:
-			return myIRbest.has_value() ? songData.myIRbest.value().stat_bad : songData.mybest.stat_bad;
+			return mybest.stat_bad;
 		case 84:
-			return myIRbest.has_value() ? songData.myIRbest.value().stat_poor : songData.mybest.stat_poor;
+			return mybest.stat_poor;
 		case 85:
-			if (myIRbest.has_value() && songData.myIRbest.value().total_notes)
-				return (songData.myIRbest.value().stat_pgreat * 100) / songData.myIRbest.value().total_notes;
-			if (songData.mybest.total_notes)
-				return (songData.mybest.stat_pgreat * 100) / songData.mybest.total_notes;
+			if (mybest.total_notes)
+				return (mybest.stat_pgreat * 100) / mybest.total_notes;
 			break;
 		case 86:
-			if (myIRbest.has_value() && songData.myIRbest.value().total_notes)
-				return (songData.myIRbest.value().stat_great * 100) / songData.myIRbest.value().total_notes;
-			if (songData.mybest.total_notes)
-				return (songData.mybest.stat_great * 100) / songData.mybest.total_notes;
+			if (mybest.total_notes)
+				return (mybest.stat_great * 100) / mybest.total_notes;
 			break;
 		case 87:
-			if (myIRbest.has_value() && songData.myIRbest.value().total_notes)
-				return (songData.myIRbest.value().stat_good * 100) / songData.myIRbest.value().total_notes;
-			if (songData.mybest.total_notes)
-				return (songData.mybest.stat_good * 100) / songData.mybest.total_notes;
+			if (mybest.total_notes)
+				return (mybest.stat_good * 100) / mybest.total_notes;
 			break;
 		case 88:
-			if (myIRbest.has_value() && songData.myIRbest.value().total_notes)
-				return (songData.myIRbest.value().stat_bad * 100) / songData.myIRbest.value().total_notes;
-			if (songData.mybest.total_notes)
-				return (songData.mybest.stat_bad * 100) / songData.mybest.total_notes;
+			if (mybest.total_notes)
+				return (mybest.stat_bad * 100) / mybest.total_notes;
 			break;
 		case 89:
-			if (myIRbest.has_value() && songData.myIRbest.value().total_notes)
-				return (songData.myIRbest.value().stat_poor * 100) / songData.myIRbest.value().total_notes;
-			if (songData.mybest.total_notes)
-				return (songData.mybest.stat_poor * 100) / songData.mybest.total_notes;
+			if (mybest.total_notes)
+				return (mybest.stat_poor * 100) / mybest.total_notes;
 			break;
 		case 90:
 		case 290:
@@ -1831,9 +1809,7 @@ uint SetObjectValue_Num(game *g, int op) {
 		case 94:
 			return songData.mybest.IRclearRate;
 		case 95:
-			return myIRbest.has_value() ?
-				songData.myIRbest.value().stat_exscore - songData.rivalRecord.stat_exscore : 
-				songData.mybest.stat_exscore - songData.rivalRecord.stat_exscore;
+			return mybest.stat_exscore - songData.rivalRecord.stat_exscore;
 		case 96:
 			return songData.level;
 
@@ -2256,7 +2232,7 @@ int SetObjectValue_Bargraph(game *g) {
 
 	float max, val;
 	const SONGDATA& songData = g->sSelect.bmsList[g->sSelect.cur_song];
-	const std::optional<STATUS>& myIRbest = songData.myIRbest;
+	const STATUS& mybest = songData.myIRbest.has_value() ? *songData.myIRbest : songData.mybest;
 
 	for (int i = 0; i < g->skstruct.otherObject[5].srcSize; i++) {
 
@@ -2443,49 +2419,49 @@ int SetObjectValue_Bargraph(game *g) {
 					break;
 
 				case 40:
-					max = myIRbest.has_value() ? songData.myIRbest.value().total_notes : songData.mybest.total_notes;
-					val = myIRbest.has_value() ? songData.myIRbest.value().stat_pgreat : songData.mybest.stat_pgreat;
+					max = mybest.total_notes;
+					val = mybest.stat_pgreat;
 					break;
 
 				case 41:
-					max = myIRbest.has_value() ? songData.myIRbest.value().total_notes : songData.mybest.total_notes;
-					val = myIRbest.has_value() ? songData.myIRbest.value().stat_great : songData.mybest.stat_great;
+					max = mybest.total_notes;
+					val = mybest.stat_great;
 					break;
 
 				case 42:
-					max = myIRbest.has_value() ? songData.myIRbest.value().total_notes : songData.mybest.total_notes;
-					val = myIRbest.has_value() ? songData.myIRbest.value().stat_good : songData.mybest.stat_good;
+					max = mybest.total_notes;
+					val = mybest.stat_good;
 					break;
 
 				case 43:
-					max = myIRbest.has_value() ? songData.myIRbest.value().total_notes : songData.mybest.total_notes;
-					val = myIRbest.has_value() ? songData.myIRbest.value().stat_bad : songData.mybest.stat_bad;
+					max = mybest.total_notes;
+					val = mybest.stat_bad;
 					break;
 
 				case 44:
-					max = myIRbest.has_value() ? songData.myIRbest.value().total_notes : songData.mybest.total_notes;
-					val = myIRbest.has_value() ? songData.myIRbest.value().stat_poor : songData.mybest.stat_poor;
+					max = mybest.total_notes;
+					val = mybest.stat_poor;
 					break;
 
 				case 45:
-					max = myIRbest.has_value() ? songData.myIRbest.value().total_notes : songData.mybest.total_notes;
-					val = myIRbest.has_value() ? songData.myIRbest.value().stat_maxcombo : songData.mybest.stat_maxcombo;
+					max = mybest.total_notes;
+					val = mybest.stat_maxcombo;
 					break;
 
 				case 46:
 					if ((songData.keymode == 7) || (songData.keymode == 0xe)) {
 						max = 20000.0;
-						val = myIRbest.has_value() ? songData.myIRbest.value().stat_score : songData.mybest.stat_score;
+						val = mybest.stat_score;
 					}
 					else {
 						max = 10000.0;
-						val = myIRbest.has_value() ? songData.myIRbest.value().stat_score : songData.mybest.stat_score;
+						val = mybest.stat_score;
 					}
 					break;
 
 				case 47:
-					max = myIRbest.has_value() ? (songData.myIRbest.value().total_notes * 2) : (songData.mybest.total_notes * 2);
-					val = myIRbest.has_value() ? songData.myIRbest.value().stat_exscore : songData.mybest.stat_exscore;
+					max = mybest.total_notes * 2;
+					val = mybest.stat_exscore;
 					break;
 			}
 

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -1418,7 +1418,7 @@ bool GetOptionFlag_dst(game *gs, int option) {
 			if (gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.stat_exscore > 0) return ret;
 			break;
 		case 626:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.isIRDerivedRecord > 0) return ret;
+			return gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.isIRDerivedRecord;
 			break;
 
 		case 640:

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -19,13 +19,13 @@ bool GetOptionFlag_dst(game *gs, int option) {
 	int t = 0;
 	bool ret = (option >= 0);
 	if (!ret) option = -option;
-
+	const SONGDATA& songData = gs->sSelect.bmsList[gs->sSelect.cur_song];
 
 	switch (option) {
 		case 0:
 			return true;
 		case 1:
-			t = gs->sSelect.bmsList[gs->sSelect.cur_song].folderType;
+			t = songData.folderType;
 			if (t == 1) return ret;
 			if (t == 2) return ret;
 			if (t == 3) return ret;
@@ -35,24 +35,24 @@ bool GetOptionFlag_dst(game *gs, int option) {
 			break;
 
 		case 2:
-			t = gs->sSelect.bmsList[gs->sSelect.cur_song].folderType;
+			t = songData.folderType;
 			if (t == 0) return ret;
 			if (t == 5) return ret;
 			break;
 
 		case 3:
-			t = gs->sSelect.bmsList[gs->sSelect.cur_song].folderType;
+			t = songData.folderType;
 			if (t == 8) return ret;
 			break;
 
 		case 4:
-			t = gs->sSelect.bmsList[gs->sSelect.cur_song].folderType;
+			t = songData.folderType;
 			if (t == 7) return ret;
 			if (t == 9) return ret;
 			break;
 
 		case 5:
-			t = gs->sSelect.bmsList[gs->sSelect.cur_song].folderType;
+			t = songData.folderType;
 			if (t == 0) return ret;
 			if (t == 5) return ret;
 			if (t == 8) return ret;
@@ -234,15 +234,15 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 72:
 		case 73:
 		case 74:
-			t = gs->sSelect.bmsList[gs->sSelect.cur_song].keymode;
+			t = songData.keymode;
 			if (t == 5 || t == 10) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].difficultyLevel[option - 70] <= gs->config.select.levelbarflash_5) return ret;
+				if (songData.difficultyLevel[option - 70] <= gs->config.select.levelbarflash_5) return ret;
 			}
 			else if (t == 7 || t == 14) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].difficultyLevel[option - 70] <= gs->config.select.levelbarflash_7) return ret;
+				if (songData.difficultyLevel[option - 70] <= gs->config.select.levelbarflash_7) return ret;
 			}
 			else if (t == 9) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].difficultyLevel[option - 70] <= gs->config.select.levelbarflash_9) return ret;
+				if (songData.difficultyLevel[option - 70] <= gs->config.select.levelbarflash_9) return ret;
 			}
 			break;
 
@@ -251,15 +251,15 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 77:
 		case 78:
 		case 79:
-			t = gs->sSelect.bmsList[gs->sSelect.cur_song].keymode;
+			t = songData.keymode;
 			if (t == 5 || t == 10) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].difficultyLevel[option - 75] > gs->config.select.levelbarflash_5) return ret;
+				if (songData.difficultyLevel[option - 75] > gs->config.select.levelbarflash_5) return ret;
 			}
 			else if (t == 7 || t == 14) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].difficultyLevel[option - 75] > gs->config.select.levelbarflash_7) return ret;
+				if (songData.difficultyLevel[option - 75] > gs->config.select.levelbarflash_7) return ret;
 			}
 			else if (t == 9) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].difficultyLevel[option - 75] > gs->config.select.levelbarflash_9) return ret;
+				if (songData.difficultyLevel[option - 75] > gs->config.select.levelbarflash_9) return ret;
 			}
 			break;
 
@@ -292,248 +292,252 @@ bool GetOptionFlag_dst(game *gs, int option) {
 			
 		case 100: //TODO : make more readable
 			if (gs->config.play.battle == 2) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear_db == 0) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_db : songData.mybest.clear_db) == 0) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear_ex == 0) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_ex : songData.mybest.clear_ex) == 0) return ret;
 			}
 			else if(gs->config.play.battle == 3){
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear_sd == 0) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_sd : songData.mybest.clear_sd) == 0) return ret;
 			}
 			else {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear == 0) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) == 0) return ret;
 			}
 			break;
 		case 101:
 			if (gs->config.play.battle == 2) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear_db == 1) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_db : songData.mybest.clear_db) == 1) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear_ex == 1) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_ex : songData.mybest.clear_ex) == 1) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear_sd == 1) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_sd : songData.mybest.clear_sd) == 1) return ret;
 			}
 			else {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear == 1) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) == 1) return ret;
 			}
 			break;
 		case 102:
 			if (gs->config.play.battle == 2) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear_db == 2) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_db : songData.mybest.clear_db) == 2) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear_ex == 2) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_ex : songData.mybest.clear_ex) == 2) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear_sd == 2) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_sd : songData.mybest.clear_sd) == 2) return ret;
 			}
 			else {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear == 2) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) == 2) return ret;
 			}
 			break;
 		case 103:
 			if (gs->config.play.battle == 2) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear_db == 3) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_db : songData.mybest.clear_db) == 3) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear_ex == 3) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_ex : songData.mybest.clear_ex) == 3) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear_sd == 3) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_sd : songData.mybest.clear_sd) == 3) return ret;
 			}
 			else {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear == 3) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) == 3) return ret;
 			}
 			break;
 		case 104:
 			if (gs->config.play.battle == 2) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear_db == 4) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_db : songData.mybest.clear_db) == 4) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear_ex == 4) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_ex : songData.mybest.clear_ex) == 4) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear_sd == 4) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_sd : songData.mybest.clear_sd) == 4) return ret;
 			}
 			else {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear == 4) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) == 4) return ret;
 			}
 			break;
 		case 105:
 			if (gs->config.play.battle == 2) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear_db == 5) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_db : songData.mybest.clear_db) == 5) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear_ex == 5) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_ex : songData.mybest.clear_ex) == 5) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear_sd == 5) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_sd : songData.mybest.clear_sd) == 5) return ret;
 			}
 			else {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear == 5) return ret;
+				if (songData.keymode <= 0) return !ret;
+				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) == 5) return ret;
 			}
 			break;
 
 		case 110:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.rank > 7)
+			if (songData.keymode > 0 &&
+				(songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) &&
+				(songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) > 7)
 				return ret;
 			break;
 		
 		case 111:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear < 1) return !ret;
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.rank > 6 && gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.rank < 8) return ret; //why???
+			if (songData.keymode <= 0) return !ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) < 1) return !ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) > 6 && (songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) < 8) return ret; //why???
 			break;
 		case 112:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear < 1) return !ret;
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.rank > 5 && gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.rank < 7) return ret;
+			if (songData.keymode <= 0) return !ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) < 1) return !ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) > 5 && (songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) < 7) return ret;
 			break;
 		case 113:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear < 1) return !ret;
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.rank > 4 && gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.rank < 6) return ret;
+			if (songData.keymode <= 0) return !ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) < 1) return !ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) > 4 && (songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) < 6) return ret;
 			break;
 		case 114:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear < 1) return !ret;
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.rank > 3 && gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.rank < 5) return ret;
+			if (songData.keymode <= 0) return !ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) < 1) return !ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) > 3 && (songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) < 5) return ret;
 			break;
 		case 115:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear < 1) return !ret;
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.rank > 2 && gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.rank < 4) return ret;
+			if (songData.keymode <= 0) return !ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) < 1) return !ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) > 2 && (songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) < 4) return ret;
 			break;
 		case 116:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode <= 0) return !ret;
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear < 1) return !ret;
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.rank > 1 && gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.rank < 3) return ret;
+			if (songData.keymode <= 0) return !ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) < 1) return !ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) > 1 && (songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) < 3) return ret;
 			break;
 		case 117:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.clear > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.rank < 2)
+			if (songData.keymode > 0 &&
+				(songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) > 0 &&
+				(songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) < 2)
 				return ret;
 			break;
 
 		case 118:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 1) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 1) return ret;
 			break;
 		case 119:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 2) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 2) return ret;
 			break;
 		case 120:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 4) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 4) return ret;
 			break;
 		case 121:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 8) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 8) return ret;
 			break;
 		case 122:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x10) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x10) return ret;
 			break;
 		case 123:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x20) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x20) return ret;
 			break;
 		case 124:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x40) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x40) return ret;
 			break;
 		case 125:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x80) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x80) return ret;
 			break;
 		case 126:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x100) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x100) return ret;
 			break;
 		case 127:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x200) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x200) return ret;
 			break;
 		case 128:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x400) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x400) return ret;
 			break;
 		case 129:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x800) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x800) return ret;
 			break;
 		case 130:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x1000) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x1000) return ret;
 			break;
 		case 131:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x2000) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x2000) return ret;
 			break;
 		case 132:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x4000) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x4000) return ret;
 			break;
 		case 133:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x8000) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x8000) return ret;
 			break;
 		case 134:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x10000) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x10000) return ret;
 			break;
 		case 135:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x20000) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x20000) return ret;
 			break;
 		case 136:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x40000) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x40000) return ret;
 			break;
 		case 137:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x80000) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x80000) return ret;
 			break;
 		case 138:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x100000) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x100000) return ret;
 			break;
 		case 139:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x200000) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x200000) return ret;
 			break;
 		case 140:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x400000) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x400000) return ret;
 			break;
 		case 141:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x800000) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x800000) return ret;
 			break;
 		case 142:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x1000000) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x1000000) return ret;
 			break;
 		case 143:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x2000000) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x2000000) return ret;
 			break;
 		case 144:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x4000000) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x4000000) return ret;
 			break;
 		case 145:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x8000000) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x8000000) return ret;
 			break;
 		case 146:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x10000000) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x10000000) return ret;
 			break;
 		case 147:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x20000000) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x20000000) return ret;
 			break;
 		case 148:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x40000000) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x40000000) return ret;
 			break;
 		case 149:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.op_history & 0x80000000) return ret;
+			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x80000000) return ret;
 			break;
 
 		case 150:
@@ -580,97 +584,97 @@ bool GetOptionFlag_dst(game *gs, int option) {
 			break;
 
 		case 170:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].bga == 0) return ret;
+			if (songData.bga == 0) return ret;
 			break;
 		case 171:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].bga == 1)return ret;
+			if (songData.bga == 1)return ret;
 			break;
 		case 172:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].longnote == 0) return ret;
+			if (songData.longnote == 0) return ret;
 			break;
 		case 173:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].longnote == 1)return ret;
+			if (songData.longnote == 1)return ret;
 			break;
 		case 174:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].txt == 0)return ret;
+			if (songData.txt == 0)return ret;
 			break;
 		case 175:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].txt > 0) return ret;
+			if (songData.txt > 0) return ret;
 			break;
 		case 176:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].maxBPM == gs->sSelect.bmsList[gs->sSelect.cur_song].minBPM) return ret;
+			if (songData.maxBPM == songData.minBPM) return ret;
 			break;
 		case 177:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].maxBPM != gs->sSelect.bmsList[gs->sSelect.cur_song].minBPM) return ret;
+			if (songData.maxBPM != songData.minBPM) return ret;
 			break;
 		case 178:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].random == 0) return ret;
+			if (songData.random == 0) return ret;
 			break;
 		case 179:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].random == 1) return ret;
+			if (songData.random == 1) return ret;
 			break;
 			
 		case 180:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].judge < 1) return ret;
+			if (songData.judge < 1) return ret;
 			break;
 		case 181:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].judge == 1) return ret;
+			if (songData.judge == 1) return ret;
 			break;
 		case 182:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].judge == 2) return ret;
+			if (songData.judge == 2) return ret;
 			break;
 		case 183:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].judge > 2) return ret;
+			if (songData.judge > 2) return ret;
 			break;
 
 		case 185:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode == 5 || gs->sSelect.bmsList[gs->sSelect.cur_song].keymode == 10) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].level < 10) return ret;
+			if (songData.keymode == 5 || songData.keymode == 10) {
+				if (songData.level < 10) return ret;
 			}
-			else if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode == 7 || gs->sSelect.bmsList[gs->sSelect.cur_song].keymode == 14) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].level < 13) return ret;
+			else if (songData.keymode == 7 || songData.keymode == 14) {
+				if (songData.level < 13) return ret;
 			}
-			else if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode == 9) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].level < 43) return ret;
+			else if (songData.keymode == 9) {
+				if (songData.level < 43) return ret;
 			}
 			break;
 		case 186:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode == 5 || gs->sSelect.bmsList[gs->sSelect.cur_song].keymode == 10) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].level > 9) return ret;
+			if (songData.keymode == 5 || songData.keymode == 10) {
+				if (songData.level > 9) return ret;
 			}
-			else if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode == 7 || gs->sSelect.bmsList[gs->sSelect.cur_song].keymode == 14) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].level > 12) return ret;
+			else if (songData.keymode == 7 || songData.keymode == 14) {
+				if (songData.level > 12) return ret;
 			}
-			else if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode == 9) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].level > 42) return ret;
+			else if (songData.keymode == 9) {
+				if (songData.level > 42) return ret;
 			}
 			break;
 
 		case 190:
 			if (gs->procSelecter == 7) return !ret;
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].isStagefile == 0)return ret;
+			if (songData.isStagefile == 0)return ret;
 			break;
 		case 191:
 			if (gs->procSelecter == 7) return !ret;
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].isStagefile == 1)return ret;
+			if (songData.isStagefile == 1)return ret;
 			break;
 		case 192:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].isBanner == 0)return ret;
+			if (songData.isBanner == 0)return ret;
 			break;
 		case 193:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].isBanner == 1)return ret;
+			if (songData.isBanner == 1)return ret;
 			break;
 		case 194:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].isBackBMP == 0)return ret;
+			if (songData.isBackBMP == 0)return ret;
 			break;
 		case 195:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].isBackBMP == 1) return ret;
+			if (songData.isBackBMP == 1) return ret;
 			break;
 		case 196:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].replayExist == 0) return ret;
+			if (songData.replayExist == 0) return ret;
 			break;
 		case 197:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].replayExist == 1)return ret;
+			if (songData.replayExist == 1)return ret;
 			break;
 
 		case 200:
@@ -971,16 +975,16 @@ bool GetOptionFlag_dst(game *gs, int option) {
 			if ((gs->gameplay.courseStageNow == gs->gameplay.courseStageCount - 1) && gs->gameplay.courseStageCount > 0) return ret;
 			break;
 		case 290:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].courseType != -1) return ret;
+			if (songData.courseType != -1) return ret;
 			break;
 		case 291:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].courseType == 1) return ret;
+			if (songData.courseType == 1) return ret;
 			break;
 		case 292:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].courseType == 0) return ret;
+			if (songData.courseType == 0) return ret;
 			break;
 		case 293:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].courseType == 2) return ret;
+			if (songData.courseType == 2) return ret;
 			break;
 
 			//300 is smae 220
@@ -1144,10 +1148,10 @@ bool GetOptionFlag_dst(game *gs, int option) {
 			if (gs->gameplay.trialClear) return ret;
 			break;
 		case 334:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.IRranking == 0) {
+			if (songData.mybest.IRranking == 0) {
 				if (gs->sSelect.oldIRrank > 0) return ret;
 			}
-			else if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.IRranking < gs->sSelect.oldIRrank) return ret;
+			else if (songData.mybest.IRranking < gs->sSelect.oldIRrank) return ret;
 			break;
 		case 335:
 			if (gs->gameplay.player[gs->skstruct.flag_flip].totalnotes != 0
@@ -1234,7 +1238,7 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 502:
 		case 503:
 		case 504:
-			if ((gs->sSelect.bmsList[gs->sSelect.cur_song].folderType == 0 || gs->sSelect.bmsList[gs->sSelect.cur_song].folderType == 5) && gs->sSelect.bmsList[gs->sSelect.cur_song].difficultyLevel[option - 500] == -1)
+			if ((songData.folderType == 0 || songData.folderType == 5) && songData.difficultyLevel[option - 500] == -1)
 				return ret;
 			break;
 		case 505:
@@ -1242,7 +1246,7 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 507:
 		case 508:
 		case 509:
-			if ((gs->sSelect.bmsList[gs->sSelect.cur_song].folderType == 0 || gs->sSelect.bmsList[gs->sSelect.cur_song].folderType == 5) && gs->sSelect.bmsList[gs->sSelect.cur_song].difficultyLevel[option - 505] != -1)
+			if ((songData.folderType == 0 || songData.folderType == 5) && songData.difficultyLevel[option - 505] != -1)
 				return ret;
 			break;
 		case 510:
@@ -1250,7 +1254,7 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 512:
 		case 513:
 		case 514:
-			if ((gs->sSelect.bmsList[gs->sSelect.cur_song].folderType == 0 || gs->sSelect.bmsList[gs->sSelect.cur_song].folderType == 5) && gs->sSelect.bmsList[gs->sSelect.cur_song].difficultyExist[option - 510] == 1)
+			if ((songData.folderType == 0 || songData.folderType == 5) && songData.difficultyExist[option - 510] == 1)
 				return ret;
 			break;
 		case 515:
@@ -1258,7 +1262,7 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 517:
 		case 518:
 		case 519:
-			if ((gs->sSelect.bmsList[gs->sSelect.cur_song].folderType == 0 || gs->sSelect.bmsList[gs->sSelect.cur_song].folderType == 5) && gs->sSelect.bmsList[gs->sSelect.cur_song].difficultyExist[option - 515] > 1)
+			if ((songData.folderType == 0 || songData.folderType == 5) && songData.difficultyExist[option - 515] > 1)
 				return ret;
 			break;
 		case 520:
@@ -1267,8 +1271,8 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 523:
 		case 524:
 		case 525:
-			if ((gs->sSelect.bmsList[gs->sSelect.cur_song].folderType == 0 || gs->sSelect.bmsList[gs->sSelect.cur_song].folderType == 5) && gs->config.play.is_extra != 1 && gs->config.play.battle != 2 && gs->config.play.battle != 3
-				&& gs->sSelect.bmsList[gs->sSelect.cur_song].difficultyLevelBarLamp[0] == option - 520)
+			if ((songData.folderType == 0 || songData.folderType == 5) && gs->config.play.is_extra != 1 && gs->config.play.battle != 2 && gs->config.play.battle != 3
+				&& songData.difficultyLevelBarLamp[0] == option - 520)
 				return ret;
 			break;
 		case 530:
@@ -1277,8 +1281,8 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 533:
 		case 534:
 		case 535:
-			if ((gs->sSelect.bmsList[gs->sSelect.cur_song].folderType == 0 || gs->sSelect.bmsList[gs->sSelect.cur_song].folderType == 5) && gs->config.play.is_extra != 1 && gs->config.play.battle != 2 && gs->config.play.battle != 3
-				&& gs->sSelect.bmsList[gs->sSelect.cur_song].difficultyLevelBarLamp[1] == option - 530)
+			if ((songData.folderType == 0 || songData.folderType == 5) && gs->config.play.is_extra != 1 && gs->config.play.battle != 2 && gs->config.play.battle != 3
+				&& songData.difficultyLevelBarLamp[1] == option - 530)
 				return ret;
 			break;
 		case 540:
@@ -1287,8 +1291,8 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 543:
 		case 544:
 		case 545:
-			if ((gs->sSelect.bmsList[gs->sSelect.cur_song].folderType == 0 || gs->sSelect.bmsList[gs->sSelect.cur_song].folderType == 5) && gs->config.play.is_extra != 1 && gs->config.play.battle != 2 && gs->config.play.battle != 3
-				&& gs->sSelect.bmsList[gs->sSelect.cur_song].difficultyLevelBarLamp[2] == option - 540)
+			if ((songData.folderType == 0 || songData.folderType == 5) && gs->config.play.is_extra != 1 && gs->config.play.battle != 2 && gs->config.play.battle != 3
+				&& songData.difficultyLevelBarLamp[2] == option - 540)
 				return ret;
 			break;
 		case 550:
@@ -1297,8 +1301,8 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 553:
 		case 554:
 		case 555:
-			if ((gs->sSelect.bmsList[gs->sSelect.cur_song].folderType == 0 || gs->sSelect.bmsList[gs->sSelect.cur_song].folderType == 5) && gs->config.play.is_extra != 1 && gs->config.play.battle != 2 && gs->config.play.battle != 3
-				&& gs->sSelect.bmsList[gs->sSelect.cur_song].difficultyLevelBarLamp[3] == option - 550)
+			if ((songData.folderType == 0 || songData.folderType == 5) && gs->config.play.is_extra != 1 && gs->config.play.battle != 2 && gs->config.play.battle != 3
+				&& songData.difficultyLevelBarLamp[3] == option - 550)
 				return ret;
 			break;
 		case 560:
@@ -1307,14 +1311,14 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 563:
 		case 564:
 		case 565:
-			if ((gs->sSelect.bmsList[gs->sSelect.cur_song].folderType == 0 || gs->sSelect.bmsList[gs->sSelect.cur_song].folderType == 5) && gs->config.play.is_extra != 1 && gs->config.play.battle != 2 && gs->config.play.battle != 3
-				&& gs->sSelect.bmsList[gs->sSelect.cur_song].difficultyLevelBarLamp[4] == option - 560)
+			if ((songData.folderType == 0 || songData.folderType == 5) && gs->config.play.is_extra != 1 && gs->config.play.battle != 2 && gs->config.play.battle != 3
+				&& songData.difficultyLevelBarLamp[4] == option - 560)
 				return ret;
 			break;
 
 		case 570: //TOFIX : forgot break?
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].folderType == 7)return ret;
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].folderType == 9)return ret;
+			if (songData.folderType == 7)return ret;
+			if (songData.folderType == 9)return ret;
 		case 580:
 		case 581:
 		case 582:
@@ -1325,13 +1329,13 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 587:
 		case 588:
 		case 589:
-			if (gs->sSelect.course.isMakingCourse == 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].courseStageCount > option - 580) return ret;
+			if (gs->sSelect.course.isMakingCourse == 0 && songData.courseStageCount > option - 580) return ret;
 			break;
 		case 571: //TOFIX : forgot break?
 			if (gs->sSelect.course.isMakingCourse == 1) return ret;
 		case 572: //TOFIX : forgot break?
 			if (gs->sSelect.course.isMakingCourse == 0) return ret;
-			if(gs->sSelect.bmsList[gs->sSelect.cur_song].courseStageDifficulty[0] == option - 700) return ret;
+			if(songData.courseStageDifficulty[0] == option - 700) return ret;
 			break;
 			
 		case 590:
@@ -1412,124 +1416,124 @@ bool GetOptionFlag_dst(game *gs, int option) {
 			break;
 
 		case 624:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.stat_exscore == 0) return ret;
+			if (songData.rivalRecord.stat_exscore == 0) return ret;
 			break;
 		case 625:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.stat_exscore > 0) return ret;
+			if (songData.rivalRecord.stat_exscore > 0) return ret;
 			break;
 
 		case 626:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.isIRDerivedRecord) return ret;
+			if (songData.hasIRDerivedRecord) return ret;
 			break;
 			
 		case 640:
 			if (gs->config.play.battle == 2) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear_db == 0) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear_db == 0) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear_ex == 0) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear_ex == 0) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear_sd == 0) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear_sd == 0) return ret;
 			}
 			else {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear == 0) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear == 0) return ret;
 			}
 			break;
 		case 641:
 			if (gs->config.play.battle == 2) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear_db == 1) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear_db == 1) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear_ex == 1) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear_ex == 1) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear_sd == 1) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear_sd == 1) return ret;
 			}
 			else {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear == 1) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear == 1) return ret;
 			}
 			break;
 		case 642:
 			if (gs->config.play.battle == 2) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear_db == 2) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear_db == 2) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear_ex == 2) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear_ex == 2) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear_sd == 2) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear_sd == 2) return ret;
 			}
 			else {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear == 2) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear == 2) return ret;
 			}
 			break;
 		case 643:
 			if (gs->config.play.battle == 2) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear_db == 3) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear_db == 3) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear_ex == 3) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear_ex == 3) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear_sd == 3) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear_sd == 3) return ret;
 			}
 			else {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear == 3) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear == 3) return ret;
 			}
 			break;
 		case 644:
 			if (gs->config.play.battle == 2) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear_db == 4) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear_db == 4) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear_ex == 4) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear_ex == 4) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear_sd == 4) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear_sd == 4) return ret;
 			}
 			else {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear == 4) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear == 4) return ret;
 			}
 			break;
 		case 645:
 			if (gs->config.play.battle == 2) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear_db == 5) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear_db == 5) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear_ex == 5) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear_ex == 5) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear_sd == 5) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear_sd == 5) return ret;
 			}
 			else {
-				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear == 5) return ret;
+				if (songData.keymode > 0 && songData.rivalRecord.clear == 5) return ret;
 			}
 			break;
 			
 		case 650:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear >= 1 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.rank >= 8) return ret;
+			if (songData.keymode > 0 && songData.rivalRecord.clear >= 1 && songData.rivalRecord.rank >= 8) return ret;
 			break;
 		case 651:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear >= 1 && 7 <= gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.rank && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.rank < 8) return ret;
+			if (songData.keymode > 0 && songData.rivalRecord.clear >= 1 && 7 <= songData.rivalRecord.rank && songData.rivalRecord.rank < 8) return ret;
 			break;
 		case 652:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear >= 1 && 6 <= gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.rank && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.rank < 7) return ret;
+			if (songData.keymode > 0 && songData.rivalRecord.clear >= 1 && 6 <= songData.rivalRecord.rank && songData.rivalRecord.rank < 7) return ret;
 			break;
 		case 653:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear >= 1 && 5 <= gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.rank && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.rank < 6) return ret;
+			if (songData.keymode > 0 && songData.rivalRecord.clear >= 1 && 5 <= songData.rivalRecord.rank && songData.rivalRecord.rank < 6) return ret;
 			break;
 		case 654:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear >= 1 && 4 <= gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.rank && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.rank < 5) return ret;
+			if (songData.keymode > 0 && songData.rivalRecord.clear >= 1 && 4 <= songData.rivalRecord.rank && songData.rivalRecord.rank < 5) return ret;
 			break;
 		case 655:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear >= 1 && 3 <= gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.rank && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.rank < 4) return ret;
+			if (songData.keymode > 0 && songData.rivalRecord.clear >= 1 && 3 <= songData.rivalRecord.rank && songData.rivalRecord.rank < 4) return ret;
 			break;
 		case 656:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear >= 1 && 2 <= gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.rank && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.rank < 3) return ret;
+			if (songData.keymode > 0 && songData.rivalRecord.clear >= 1 && 2 <= songData.rivalRecord.rank && songData.rivalRecord.rank < 3) return ret;
 			break;
 		case 657:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear >= 1 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.rank < 2) return ret;
+			if (songData.keymode > 0 && songData.rivalRecord.clear >= 1 && songData.rivalRecord.rank < 2) return ret;
 			break;
 
 		case 700:
@@ -1538,7 +1542,7 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 703:
 		case 704:
 		case 705:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].courseStageDifficulty[0] == option - 700) return ret;
+			if (songData.courseStageDifficulty[0] == option - 700) return ret;
 			break;
 		case 710:
 		case 711:
@@ -1546,7 +1550,7 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 713:
 		case 714:
 		case 715:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].courseStageDifficulty[1] == option - 710) return ret;
+			if (songData.courseStageDifficulty[1] == option - 710) return ret;
 			break;
 		case 720:
 		case 721:
@@ -1554,7 +1558,7 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 723:
 		case 724:
 		case 725:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].courseStageDifficulty[2] == option - 720) return ret;
+			if (songData.courseStageDifficulty[2] == option - 720) return ret;
 			break;
 		case 730:
 		case 731:
@@ -1562,7 +1566,7 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 733:
 		case 734:
 		case 735:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].courseStageDifficulty[3] == option - 730) return ret;
+			if (songData.courseStageDifficulty[3] == option - 730) return ret;
 			break;
 		case 740:
 		case 741:
@@ -1570,7 +1574,7 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 743:
 		case 744:
 		case 745:
-			if (gs->sSelect.bmsList[gs->sSelect.cur_song].courseStageDifficulty[4] == option - 740) return ret;
+			if (songData.courseStageDifficulty[4] == option - 740) return ret;
 			break;
 
 		case 800:
@@ -1628,6 +1632,7 @@ bool GetOptionFlag_dst(game *gs, int option) {
 
 uint SetObjectValue_Num(game *g, int op) {
 	DATEDATA Date;
+	const SONGDATA& songData = g->sSelect.bmsList[g->sSelect.cur_song];
 
 	switch (op) {
 		case 10:
@@ -1740,24 +1745,31 @@ uint SetObjectValue_Num(game *g, int op) {
 
 		case 70:
 			if (g->sSelect.metaSelected.keymode == 7 || g->sSelect.metaSelected.keymode == 14)
-				return g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_score; 
-			else 
-				return g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_score / 20 * 10;
+				return songData.hasIRDerivedRecord ?
+				songData.myIRbest.stat_score : songData.mybest.stat_score;
+			else
+				return songData.hasIRDerivedRecord ?
+				songData.myIRbest.stat_score / 20 * 10 : songData.mybest.stat_score / 20 * 10;
 		case 71:
-			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_exscore;
+			return songData.hasIRDerivedRecord ? songData.myIRbest.stat_exscore : songData.mybest.stat_exscore;
 		case 72:
-			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes * 2;
+			return songData.hasIRDerivedRecord ? (songData.myIRbest.total_notes * 2) : (songData.mybest.total_notes * 2);
 		case 73:
-			if (g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes) {
-				return (g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_exscore * 100) / (g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes * 2);
+			if (songData.hasIRDerivedRecord) {
+				if (songData.myIRbest.total_notes)
+					return (songData.myIRbest.stat_exscore * 100) / (songData.myIRbest.total_notes * 2);
+				if (songData.mybest.total_notes)
+					return (songData.mybest.stat_exscore * 100) / (songData.mybest.total_notes * 2);
 			}
 			break;
 		case 74:
-			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes;
+			return songData.hasIRDerivedRecord ? songData.myIRbest.total_notes : songData.mybest.total_notes;
 		case 75:
-			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_maxcombo;
+			return songData.hasIRDerivedRecord ? songData.myIRbest.stat_maxcombo : songData.mybest.stat_maxcombo;
 		case 76:
-			return (g->sSelect.bmsList[g->sSelect.cur_song].mybest.minbp != -1) * g->sSelect.bmsList[g->sSelect.cur_song].mybest.minbp;
+			return songData.hasIRDerivedRecord ?
+				(songData.myIRbest.minbp != -1) * songData.myIRbest.minbp :
+				(songData.mybest.minbp != -1) * songData.mybest.minbp;
 		case 77:
 			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.playcount;
 		case 78:
@@ -1765,51 +1777,63 @@ uint SetObjectValue_Num(game *g, int op) {
 		case 79:
 			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.playcount - g->sSelect.bmsList[g->sSelect.cur_song].mybest.clearcount;
 		case 80:
-			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_pgreat;
+			return songData.hasIRDerivedRecord ? songData.myIRbest.stat_pgreat : songData.mybest.stat_pgreat;
 		case 81:
-			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_great;
+			return songData.hasIRDerivedRecord ? songData.myIRbest.stat_great : songData.mybest.stat_great;
 		case 82:
-			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_good;
+			return songData.hasIRDerivedRecord ? songData.myIRbest.stat_good : songData.mybest.stat_good;
 		case 83:
-			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_bad;
+			return songData.hasIRDerivedRecord ? songData.myIRbest.stat_bad : songData.mybest.stat_bad;
 		case 84:
-			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_poor;
+			return songData.hasIRDerivedRecord ? songData.myIRbest.stat_poor : songData.mybest.stat_poor;
 		case 85:
-			if (g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes) 
-				return (g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_pgreat * 100) / g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes;
+			if (songData.hasIRDerivedRecord && songData.myIRbest.total_notes)
+				return (songData.myIRbest.stat_pgreat * 100) / songData.myIRbest.total_notes;
+			if (songData.mybest.total_notes)
+				return (songData.mybest.stat_pgreat * 100) / songData.mybest.total_notes;
 			break;
 		case 86:
-			if (g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes)
-				return (g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_great * 100) / g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes;
+			if (songData.hasIRDerivedRecord && songData.myIRbest.total_notes)
+				return (songData.myIRbest.stat_great * 100) / songData.myIRbest.total_notes;
+			if (songData.mybest.total_notes)
+				return (songData.mybest.stat_great * 100) / songData.mybest.total_notes;
 			break;
 		case 87:
-			if (g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes)
-				return (g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_good * 100) / g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes;
+			if (songData.hasIRDerivedRecord && songData.myIRbest.total_notes)
+				return (songData.myIRbest.stat_good * 100) / songData.myIRbest.total_notes;
+			if (songData.mybest.total_notes)
+				return (songData.mybest.stat_good * 100) / songData.mybest.total_notes;
 			break;
 		case 88:
-			if (g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes)
-				return (g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_bad * 100) / g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes;
+			if (songData.hasIRDerivedRecord && songData.myIRbest.total_notes)
+				return (songData.myIRbest.stat_bad * 100) / songData.myIRbest.total_notes;
+			if (songData.mybest.total_notes)
+				return (songData.mybest.stat_bad * 100) / songData.mybest.total_notes;
 			break;
 		case 89:
-			if (g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes)
-				return (g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_poor * 100) / g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes;
+			if (songData.hasIRDerivedRecord && songData.myIRbest.total_notes)
+				return (songData.myIRbest.stat_poor * 100) / songData.myIRbest.total_notes;
+			if (songData.mybest.total_notes)
+				return (songData.mybest.stat_poor * 100) / songData.mybest.total_notes;
 			break;
 		case 90:
 		case 290:
-			return (g->sSelect.bmsList[g->sSelect.cur_song].maxBPM) ? g->sSelect.bmsList[g->sSelect.cur_song].maxBPM : -1;
+			return (songData.maxBPM) ? songData.maxBPM : -1;
 		case 91:
 		case 291:
-			return (g->sSelect.bmsList[g->sSelect.cur_song].minBPM) ? g->sSelect.bmsList[g->sSelect.cur_song].minBPM : -1;
+			return (songData.minBPM) ? songData.minBPM : -1;
 		case 92:
-			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.IRranking;
+			return songData.mybest.IRranking;
 		case 93:
-			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.IRplayercount;
+			return songData.mybest.IRplayercount;
 		case 94:
-			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.IRclearRate;
+			return songData.mybest.IRclearRate;
 		case 95:
-			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_exscore - g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.stat_exscore;
+			return songData.hasIRDerivedRecord ?
+				songData.myIRbest.stat_exscore - songData.rivalRecord.stat_exscore : 
+				songData.mybest.stat_exscore - songData.rivalRecord.stat_exscore;
 		case 96:
-			return g->sSelect.bmsList[g->sSelect.cur_song].level;
+			return songData.level;
 
 		case 100:
 			if (g->sSelect.metaSelected.keymode == 7 || g->sSelect.metaSelected.keymode == 14)
@@ -2130,91 +2154,91 @@ uint SetObjectValue_Num(game *g, int op) {
 			return (g->net.waitTime - GetTimeLapse(177, &g->timer1)) / 1000.0;
 
 		case 250:
-			return g->sSelect.bmsList[g->sSelect.cur_song].courseLevel[0];
+			return songData.courseLevel[0];
 		case 251:
-			return g->sSelect.bmsList[g->sSelect.cur_song].courseLevel[1];
+			return songData.courseLevel[1];
 		case 252:
-			return g->sSelect.bmsList[g->sSelect.cur_song].courseLevel[2];
+			return songData.courseLevel[2];
 		case 253:
-			return g->sSelect.bmsList[g->sSelect.cur_song].courseLevel[3];
+			return songData.courseLevel[3];
 		case 254:
-			return g->sSelect.bmsList[g->sSelect.cur_song].courseLevel[4];
+			return songData.courseLevel[4];
 		case 255:
-			return g->sSelect.bmsList[g->sSelect.cur_song].courseLevel[5];
+			return songData.courseLevel[5];
 		case 256:
-			return g->sSelect.bmsList[g->sSelect.cur_song].courseLevel[6];
+			return songData.courseLevel[6];
 		case 257:
-			return g->sSelect.bmsList[g->sSelect.cur_song].courseLevel[7];
+			return songData.courseLevel[7];
 		case 258:
-			return g->sSelect.bmsList[g->sSelect.cur_song].courseLevel[8];
+			return songData.courseLevel[8];
 		case 259:
-			return g->sSelect.bmsList[g->sSelect.cur_song].courseLevel[9];
+			return songData.courseLevel[9];
 
 		case 270:
 			if ((g->sSelect.metaSelected.keymode != 7) && (g->sSelect.metaSelected.keymode != 14)) {
-				return (g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.stat_score / 20) * 10;
+				return (songData.rivalRecord.stat_score / 20) * 10;
 			}
-			return g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.stat_score;
+			return songData.rivalRecord.stat_score;
 		case 271:
-			return g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.stat_exscore;
+			return songData.rivalRecord.stat_exscore;
 		case 272:
-			return g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.total_notes * 2;
+			return songData.rivalRecord.total_notes * 2;
 		case 273:
-			if (g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.total_notes != 0)
-				return g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.stat_exscore * 100 / (g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.total_notes * 2);
+			if (songData.rivalRecord.total_notes != 0)
+				return songData.rivalRecord.stat_exscore * 100 / (songData.rivalRecord.total_notes * 2);
 			break;
 		case 274:
-			return g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.total_notes;
+			return songData.rivalRecord.total_notes;
 		case 275:
-			return g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.stat_maxcombo;
+			return songData.rivalRecord.stat_maxcombo;
 		case 276:
-			if (g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.minbp == -1) return 0;
-			return g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.minbp;
+			if (songData.rivalRecord.minbp == -1) return 0;
+			return songData.rivalRecord.minbp;
 		case 277:
-			return g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.playcount;
+			return songData.rivalRecord.playcount;
 		case 278:
-			return g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.clearcount;
+			return songData.rivalRecord.clearcount;
 		case 279:
-			return g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.playcount - g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.clearcount;
+			return songData.rivalRecord.playcount - songData.rivalRecord.clearcount;
 		case 280:
-			return g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.stat_pgreat;
+			return songData.rivalRecord.stat_pgreat;
 		case 281:
-			return g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.stat_great;
+			return songData.rivalRecord.stat_great;
 		case 282:
-			return g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.stat_good;
+			return songData.rivalRecord.stat_good;
 		case 283:
-			return g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.stat_bad;
+			return songData.rivalRecord.stat_bad;
 		case 284:
-			return g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.stat_poor;
+			return songData.rivalRecord.stat_poor;
 		case 285:
-			if (g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.total_notes != 0) {
-				return (g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.stat_pgreat * 100) / g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.total_notes;
+			if (songData.rivalRecord.total_notes != 0) {
+				return (songData.rivalRecord.stat_pgreat * 100) / songData.rivalRecord.total_notes;
 			}
 			break;
 		case 286:
-			if (g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.total_notes != 0) {
-				return (g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.stat_great * 100) / g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.total_notes;
+			if (songData.rivalRecord.total_notes != 0) {
+				return (songData.rivalRecord.stat_great * 100) / songData.rivalRecord.total_notes;
 			}
 			break;
 		case 287:
-			if (g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.total_notes != 0) {
-				return (g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.stat_good * 100) / g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.total_notes;
+			if (songData.rivalRecord.total_notes != 0) {
+				return (songData.rivalRecord.stat_good * 100) / songData.rivalRecord.total_notes;
 			}
 			break;
 		case 288:
-			if (g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.total_notes != 0) {
-				return (g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.stat_bad * 100) / g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.total_notes;
+			if (songData.rivalRecord.total_notes != 0) {
+				return (songData.rivalRecord.stat_bad * 100) / songData.rivalRecord.total_notes;
 			}
 			break;
 		case 289:
-			if (g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.total_notes != 0) {
-				return (g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.stat_poor * 100) / g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.total_notes;
+			if (songData.rivalRecord.total_notes != 0) {
+				return (songData.rivalRecord.stat_poor * 100) / songData.rivalRecord.total_notes;
 			}
 			break;
 			//290 is same 90
 			//291 is same 91
 		case 292:
-			return g->sSelect.bmsList[g->sSelect.cur_song].rivalRecord.IRranking;
+			return songData.rivalRecord.IRranking;
 			//293 is same 180
 		case 294: //TOFIX : IR clear rate
 			break;
@@ -2229,6 +2253,7 @@ uint SetObjectValue_Num(game *g, int op) {
 int SetObjectValue_Bargraph(game *g) {
 
 	float max, val;
+	const SONGDATA& songData = g->sSelect.bmsList[g->sSelect.cur_song];
 
 	for (int i = 0; i < g->skstruct.otherObject[5].srcSize; i++) {
 
@@ -2250,17 +2275,17 @@ int SetObjectValue_Bargraph(game *g) {
 					break;
 
 				case 3:
-					if (g->sSelect.bmsList[g->sSelect.cur_song].keymode == 5 || g->sSelect.bmsList[g->sSelect.cur_song].keymode == 10) {
+					if (songData.keymode == 5 || songData.keymode == 10) {
 						max = 9.0;
-						val = g->sSelect.bmsList[g->sSelect.cur_song].level;
+						val = songData.level;
 					}
-					else if (g->sSelect.bmsList[g->sSelect.cur_song].keymode == 7 || g->sSelect.bmsList[g->sSelect.cur_song].keymode == 14) {
+					else if (songData.keymode == 7 || songData.keymode == 14) {
 						max = 12.0;
-						val = g->sSelect.bmsList[g->sSelect.cur_song].level;
+						val = songData.level;
 					}
-					else if (g->sSelect.bmsList[g->sSelect.cur_song].keymode == 9) {
+					else if (songData.keymode == 9) {
 						max = 42.0;
-						val = g->sSelect.bmsList[g->sSelect.cur_song].level;
+						val = songData.level;
 					}
 					else continue;
 					break;
@@ -2270,15 +2295,15 @@ int SetObjectValue_Bargraph(game *g) {
 				case 7:
 				case 8:
 				case 9:
-					if (g->sSelect.bmsList[g->sSelect.cur_song].keymode == 5 || g->sSelect.bmsList[g->sSelect.cur_song].keymode == 10) {
+					if (songData.keymode == 5 || songData.keymode == 10) {
 						max = g->config.select.levelbarflash_5;
 						val = g->sSelect.levelIndicatorAnimation[g->skstruct.otherObject[5].src[i].op1 - 5];
 					}
-					else if (g->sSelect.bmsList[g->sSelect.cur_song].keymode == 7 || g->sSelect.bmsList[g->sSelect.cur_song].keymode == 14) {
+					else if (songData.keymode == 7 || songData.keymode == 14) {
 						max = g->config.select.levelbarflash_7;
 						val = g->sSelect.levelIndicatorAnimation[g->skstruct.otherObject[5].src[i].op1 - 5];
 					}
-					else if (g->sSelect.bmsList[g->sSelect.cur_song].keymode == 9) {
+					else if (songData.keymode == 9) {
 						max = g->config.select.levelbarflash_9;
 						val = g->sSelect.levelIndicatorAnimation[g->skstruct.otherObject[5].src[i].op1 - 5];
 					}
@@ -2415,49 +2440,49 @@ int SetObjectValue_Bargraph(game *g) {
 					break;
 
 				case 40:
-					max = g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes;
-					val = g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_pgreat;
+					max = songData.hasIRDerivedRecord ? songData.myIRbest.total_notes : songData.mybest.total_notes;
+					val = songData.hasIRDerivedRecord ? songData.myIRbest.stat_pgreat : songData.mybest.stat_pgreat;
 					break;
 
 				case 41:
-					max = g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes;
-					val = g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_great;
+					max = songData.hasIRDerivedRecord ? songData.myIRbest.total_notes : songData.mybest.total_notes;
+					val = songData.hasIRDerivedRecord ? songData.myIRbest.stat_great : songData.mybest.stat_great;
 					break;
 
 				case 42:
-					max = g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes;
-					val = g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_good;
+					max = songData.hasIRDerivedRecord ? songData.myIRbest.total_notes : songData.mybest.total_notes;
+					val = songData.hasIRDerivedRecord ? songData.myIRbest.stat_good : songData.mybest.stat_good;
 					break;
 
 				case 43:
-					max = g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes;
-					val = g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_bad;
+					max = songData.hasIRDerivedRecord ? songData.myIRbest.total_notes : songData.mybest.total_notes;
+					val = songData.hasIRDerivedRecord ? songData.myIRbest.stat_bad : songData.mybest.stat_bad;
 					break;
 
 				case 44:
-					max = g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes;
-					val = g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_poor;
+					max = songData.hasIRDerivedRecord ? songData.myIRbest.total_notes : songData.mybest.total_notes;
+					val = songData.hasIRDerivedRecord ? songData.myIRbest.stat_poor : songData.mybest.stat_poor;
 					break;
 
 				case 45:
-					max = g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes;
-					val = g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_maxcombo;
+					max = songData.hasIRDerivedRecord ? songData.myIRbest.total_notes : songData.mybest.total_notes;
+					val = songData.hasIRDerivedRecord ? songData.myIRbest.stat_maxcombo : songData.mybest.stat_maxcombo;
 					break;
 
 				case 46:
-					if ((g->sSelect.bmsList[g->sSelect.cur_song].keymode == 7) || (g->sSelect.bmsList[g->sSelect.cur_song].keymode == 0xe)) {
+					if ((songData.keymode == 7) || (songData.keymode == 0xe)) {
 						max = 20000.0;
-						val = g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_score;
+						val = songData.hasIRDerivedRecord ? songData.myIRbest.stat_score : songData.mybest.stat_score;
 					}
 					else {
 						max = 10000.0;
-						val = g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_score;
+						val = songData.hasIRDerivedRecord ? songData.myIRbest.stat_score : songData.mybest.stat_score;
 					}
 					break;
 
 				case 47:
-					max = (g->sSelect.bmsList[g->sSelect.cur_song].mybest.total_notes * 2);
-					val = g->sSelect.bmsList[g->sSelect.cur_song].mybest.stat_exscore;
+					max = songData.hasIRDerivedRecord ? (songData.myIRbest.total_notes * 2) : (songData.mybest.total_notes * 2);
+					val = songData.hasIRDerivedRecord ? songData.myIRbest.stat_exscore : songData.mybest.stat_exscore;
 					break;
 			}
 

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -20,6 +20,7 @@ bool GetOptionFlag_dst(game *gs, int option) {
 	bool ret = (option >= 0);
 	if (!ret) option = -option;
 	const SONGDATA& songData = gs->sSelect.bmsList[gs->sSelect.cur_song];
+	const std::optional<STATUS>& myIRbest = songData.myIRbest;
 
 	switch (option) {
 		case 0:
@@ -293,251 +294,251 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 100: //TODO : make more readable
 			if (gs->config.play.battle == 2) {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_db : songData.mybest.clear_db) == 0) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_db : songData.mybest.clear_db) == 0) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_ex : songData.mybest.clear_ex) == 0) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_ex : songData.mybest.clear_ex) == 0) return ret;
 			}
 			else if(gs->config.play.battle == 3){
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_sd : songData.mybest.clear_sd) == 0) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_sd : songData.mybest.clear_sd) == 0) return ret;
 			}
 			else {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) == 0) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) == 0) return ret;
 			}
 			break;
 		case 101:
 			if (gs->config.play.battle == 2) {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_db : songData.mybest.clear_db) == 1) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_db : songData.mybest.clear_db) == 1) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_ex : songData.mybest.clear_ex) == 1) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_ex : songData.mybest.clear_ex) == 1) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_sd : songData.mybest.clear_sd) == 1) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_sd : songData.mybest.clear_sd) == 1) return ret;
 			}
 			else {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) == 1) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) == 1) return ret;
 			}
 			break;
 		case 102:
 			if (gs->config.play.battle == 2) {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_db : songData.mybest.clear_db) == 2) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_db : songData.mybest.clear_db) == 2) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_ex : songData.mybest.clear_ex) == 2) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_ex : songData.mybest.clear_ex) == 2) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_sd : songData.mybest.clear_sd) == 2) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_sd : songData.mybest.clear_sd) == 2) return ret;
 			}
 			else {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) == 2) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) == 2) return ret;
 			}
 			break;
 		case 103:
 			if (gs->config.play.battle == 2) {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_db : songData.mybest.clear_db) == 3) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_db : songData.mybest.clear_db) == 3) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_ex : songData.mybest.clear_ex) == 3) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_ex : songData.mybest.clear_ex) == 3) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_sd : songData.mybest.clear_sd) == 3) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_sd : songData.mybest.clear_sd) == 3) return ret;
 			}
 			else {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) == 3) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) == 3) return ret;
 			}
 			break;
 		case 104:
 			if (gs->config.play.battle == 2) {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_db : songData.mybest.clear_db) == 4) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_db : songData.mybest.clear_db) == 4) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_ex : songData.mybest.clear_ex) == 4) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_ex : songData.mybest.clear_ex) == 4) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_sd : songData.mybest.clear_sd) == 4) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_sd : songData.mybest.clear_sd) == 4) return ret;
 			}
 			else {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) == 4) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) == 4) return ret;
 			}
 			break;
 		case 105:
 			if (gs->config.play.battle == 2) {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_db : songData.mybest.clear_db) == 5) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_db : songData.mybest.clear_db) == 5) return ret;
 			}
 			else if (gs->config.play.is_extra == 1) {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_ex : songData.mybest.clear_ex) == 5) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_ex : songData.mybest.clear_ex) == 5) return ret;
 			}
 			else if (gs->config.play.battle == 3) {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear_sd : songData.mybest.clear_sd) == 5) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear_sd : songData.mybest.clear_sd) == 5) return ret;
 			}
 			else {
 				if (songData.keymode <= 0) return !ret;
-				if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) == 5) return ret;
+				if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) == 5) return ret;
 			}
 			break;
 
 		case 110:
 			if (songData.keymode > 0 &&
-				(songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) &&
-				(songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) > 7)
+				(myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) &&
+				(myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) > 7)
 				return ret;
 			break;
 		
 		case 111:
 			if (songData.keymode <= 0) return !ret;
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) < 1) return !ret;
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) > 6 && (songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) < 8) return ret; //why???
+			if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) < 1) return !ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) > 6 && (myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) < 8) return ret; //why???
 			break;
 		case 112:
 			if (songData.keymode <= 0) return !ret;
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) < 1) return !ret;
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) > 5 && (songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) < 7) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) < 1) return !ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) > 5 && (myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) < 7) return ret;
 			break;
 		case 113:
 			if (songData.keymode <= 0) return !ret;
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) < 1) return !ret;
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) > 4 && (songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) < 6) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) < 1) return !ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) > 4 && (myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) < 6) return ret;
 			break;
 		case 114:
 			if (songData.keymode <= 0) return !ret;
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) < 1) return !ret;
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) > 3 && (songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) < 5) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) < 1) return !ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) > 3 && (myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) < 5) return ret;
 			break;
 		case 115:
 			if (songData.keymode <= 0) return !ret;
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) < 1) return !ret;
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) > 2 && (songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) < 4) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) < 1) return !ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) > 2 && (myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) < 4) return ret;
 			break;
 		case 116:
 			if (songData.keymode <= 0) return !ret;
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) < 1) return !ret;
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) > 1 && (songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) < 3) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) < 1) return !ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) > 1 && (myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) < 3) return ret;
 			break;
 		case 117:
 			if (songData.keymode > 0 &&
-				(songData.hasIRDerivedRecord ? songData.myIRbest.clear : songData.mybest.clear) > 0 &&
-				(songData.hasIRDerivedRecord ? songData.myIRbest.rank : songData.mybest.rank) < 2)
+				(myIRbest.has_value() ? songData.myIRbest.value().clear : songData.mybest.clear) > 0 &&
+				(myIRbest.has_value() ? songData.myIRbest.value().rank : songData.mybest.rank) < 2)
 				return ret;
 			break;
 
 		case 118:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 1) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 1) return ret;
 			break;
 		case 119:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 2) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 2) return ret;
 			break;
 		case 120:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 4) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 4) return ret;
 			break;
 		case 121:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 8) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 8) return ret;
 			break;
 		case 122:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x10) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x10) return ret;
 			break;
 		case 123:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x20) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x20) return ret;
 			break;
 		case 124:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x40) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x40) return ret;
 			break;
 		case 125:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x80) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x80) return ret;
 			break;
 		case 126:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x100) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x100) return ret;
 			break;
 		case 127:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x200) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x200) return ret;
 			break;
 		case 128:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x400) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x400) return ret;
 			break;
 		case 129:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x800) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x800) return ret;
 			break;
 		case 130:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x1000) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x1000) return ret;
 			break;
 		case 131:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x2000) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x2000) return ret;
 			break;
 		case 132:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x4000) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x4000) return ret;
 			break;
 		case 133:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x8000) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x8000) return ret;
 			break;
 		case 134:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x10000) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x10000) return ret;
 			break;
 		case 135:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x20000) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x20000) return ret;
 			break;
 		case 136:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x40000) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x40000) return ret;
 			break;
 		case 137:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x80000) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x80000) return ret;
 			break;
 		case 138:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x100000) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x100000) return ret;
 			break;
 		case 139:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x200000) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x200000) return ret;
 			break;
 		case 140:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x400000) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x400000) return ret;
 			break;
 		case 141:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x800000) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x800000) return ret;
 			break;
 		case 142:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x1000000) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x1000000) return ret;
 			break;
 		case 143:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x2000000) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x2000000) return ret;
 			break;
 		case 144:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x4000000) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x4000000) return ret;
 			break;
 		case 145:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x8000000) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x8000000) return ret;
 			break;
 		case 146:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x10000000) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x10000000) return ret;
 			break;
 		case 147:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x20000000) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x20000000) return ret;
 			break;
 		case 148:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x40000000) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x40000000) return ret;
 			break;
 		case 149:
-			if ((songData.hasIRDerivedRecord ? songData.myIRbest.op_history : songData.mybest.op_history) & 0x80000000) return ret;
+			if ((myIRbest.has_value() ? songData.myIRbest.value().op_history : songData.mybest.op_history) & 0x80000000) return ret;
 			break;
 
 		case 150:
@@ -1423,7 +1424,7 @@ bool GetOptionFlag_dst(game *gs, int option) {
 			break;
 
 		case 626:
-			if (songData.hasIRDerivedRecord) return ret;
+			if (myIRbest.has_value()) return ret;
 			break;
 			
 		case 640:
@@ -1633,6 +1634,7 @@ bool GetOptionFlag_dst(game *gs, int option) {
 uint SetObjectValue_Num(game *g, int op) {
 	DATEDATA Date;
 	const SONGDATA& songData = g->sSelect.bmsList[g->sSelect.cur_song];
+	const std::optional<STATUS>& myIRbest = songData.myIRbest;
 
 	switch (op) {
 		case 10:
@@ -1745,30 +1747,30 @@ uint SetObjectValue_Num(game *g, int op) {
 
 		case 70:
 			if (g->sSelect.metaSelected.keymode == 7 || g->sSelect.metaSelected.keymode == 14)
-				return songData.hasIRDerivedRecord ?
-				songData.myIRbest.stat_score : songData.mybest.stat_score;
+				return myIRbest.has_value() ?
+				songData.myIRbest.value().stat_score : songData.mybest.stat_score;
 			else
-				return songData.hasIRDerivedRecord ?
-				songData.myIRbest.stat_score / 20 * 10 : songData.mybest.stat_score / 20 * 10;
+				return myIRbest.has_value() ?
+				songData.myIRbest.value().stat_score / 20 * 10 : songData.mybest.stat_score / 20 * 10;
 		case 71:
-			return songData.hasIRDerivedRecord ? songData.myIRbest.stat_exscore : songData.mybest.stat_exscore;
+			return myIRbest.has_value() ? songData.myIRbest.value().stat_exscore : songData.mybest.stat_exscore;
 		case 72:
-			return songData.hasIRDerivedRecord ? (songData.myIRbest.total_notes * 2) : (songData.mybest.total_notes * 2);
+			return myIRbest.has_value() ? (songData.myIRbest.value().total_notes * 2) : (songData.mybest.total_notes * 2);
 		case 73:
-			if (songData.hasIRDerivedRecord) {
-				if (songData.myIRbest.total_notes)
-					return (songData.myIRbest.stat_exscore * 100) / (songData.myIRbest.total_notes * 2);
+			if (myIRbest.has_value()) {
+				if (songData.myIRbest.value().total_notes)
+					return (songData.myIRbest.value().stat_exscore * 100) / (songData.myIRbest.value().total_notes * 2);
 				if (songData.mybest.total_notes)
 					return (songData.mybest.stat_exscore * 100) / (songData.mybest.total_notes * 2);
 			}
 			break;
 		case 74:
-			return songData.hasIRDerivedRecord ? songData.myIRbest.total_notes : songData.mybest.total_notes;
+			return myIRbest.has_value() ? songData.myIRbest.value().total_notes : songData.mybest.total_notes;
 		case 75:
-			return songData.hasIRDerivedRecord ? songData.myIRbest.stat_maxcombo : songData.mybest.stat_maxcombo;
+			return myIRbest.has_value() ? songData.myIRbest.value().stat_maxcombo : songData.mybest.stat_maxcombo;
 		case 76:
-			return songData.hasIRDerivedRecord ?
-				(songData.myIRbest.minbp != -1) * songData.myIRbest.minbp :
+			return myIRbest.has_value() ?
+				(songData.myIRbest.value().minbp != -1) * songData.myIRbest.value().minbp :
 				(songData.mybest.minbp != -1) * songData.mybest.minbp;
 		case 77:
 			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.playcount;
@@ -1777,42 +1779,42 @@ uint SetObjectValue_Num(game *g, int op) {
 		case 79:
 			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.playcount - g->sSelect.bmsList[g->sSelect.cur_song].mybest.clearcount;
 		case 80:
-			return songData.hasIRDerivedRecord ? songData.myIRbest.stat_pgreat : songData.mybest.stat_pgreat;
+			return myIRbest.has_value() ? songData.myIRbest.value().stat_pgreat : songData.mybest.stat_pgreat;
 		case 81:
-			return songData.hasIRDerivedRecord ? songData.myIRbest.stat_great : songData.mybest.stat_great;
+			return myIRbest.has_value() ? songData.myIRbest.value().stat_great : songData.mybest.stat_great;
 		case 82:
-			return songData.hasIRDerivedRecord ? songData.myIRbest.stat_good : songData.mybest.stat_good;
+			return myIRbest.has_value() ? songData.myIRbest.value().stat_good : songData.mybest.stat_good;
 		case 83:
-			return songData.hasIRDerivedRecord ? songData.myIRbest.stat_bad : songData.mybest.stat_bad;
+			return myIRbest.has_value() ? songData.myIRbest.value().stat_bad : songData.mybest.stat_bad;
 		case 84:
-			return songData.hasIRDerivedRecord ? songData.myIRbest.stat_poor : songData.mybest.stat_poor;
+			return myIRbest.has_value() ? songData.myIRbest.value().stat_poor : songData.mybest.stat_poor;
 		case 85:
-			if (songData.hasIRDerivedRecord && songData.myIRbest.total_notes)
-				return (songData.myIRbest.stat_pgreat * 100) / songData.myIRbest.total_notes;
+			if (myIRbest.has_value() && songData.myIRbest.value().total_notes)
+				return (songData.myIRbest.value().stat_pgreat * 100) / songData.myIRbest.value().total_notes;
 			if (songData.mybest.total_notes)
 				return (songData.mybest.stat_pgreat * 100) / songData.mybest.total_notes;
 			break;
 		case 86:
-			if (songData.hasIRDerivedRecord && songData.myIRbest.total_notes)
-				return (songData.myIRbest.stat_great * 100) / songData.myIRbest.total_notes;
+			if (myIRbest.has_value() && songData.myIRbest.value().total_notes)
+				return (songData.myIRbest.value().stat_great * 100) / songData.myIRbest.value().total_notes;
 			if (songData.mybest.total_notes)
 				return (songData.mybest.stat_great * 100) / songData.mybest.total_notes;
 			break;
 		case 87:
-			if (songData.hasIRDerivedRecord && songData.myIRbest.total_notes)
-				return (songData.myIRbest.stat_good * 100) / songData.myIRbest.total_notes;
+			if (myIRbest.has_value() && songData.myIRbest.value().total_notes)
+				return (songData.myIRbest.value().stat_good * 100) / songData.myIRbest.value().total_notes;
 			if (songData.mybest.total_notes)
 				return (songData.mybest.stat_good * 100) / songData.mybest.total_notes;
 			break;
 		case 88:
-			if (songData.hasIRDerivedRecord && songData.myIRbest.total_notes)
-				return (songData.myIRbest.stat_bad * 100) / songData.myIRbest.total_notes;
+			if (myIRbest.has_value() && songData.myIRbest.value().total_notes)
+				return (songData.myIRbest.value().stat_bad * 100) / songData.myIRbest.value().total_notes;
 			if (songData.mybest.total_notes)
 				return (songData.mybest.stat_bad * 100) / songData.mybest.total_notes;
 			break;
 		case 89:
-			if (songData.hasIRDerivedRecord && songData.myIRbest.total_notes)
-				return (songData.myIRbest.stat_poor * 100) / songData.myIRbest.total_notes;
+			if (myIRbest.has_value() && songData.myIRbest.value().total_notes)
+				return (songData.myIRbest.value().stat_poor * 100) / songData.myIRbest.value().total_notes;
 			if (songData.mybest.total_notes)
 				return (songData.mybest.stat_poor * 100) / songData.mybest.total_notes;
 			break;
@@ -1829,8 +1831,8 @@ uint SetObjectValue_Num(game *g, int op) {
 		case 94:
 			return songData.mybest.IRclearRate;
 		case 95:
-			return songData.hasIRDerivedRecord ?
-				songData.myIRbest.stat_exscore - songData.rivalRecord.stat_exscore : 
+			return myIRbest.has_value() ?
+				songData.myIRbest.value().stat_exscore - songData.rivalRecord.stat_exscore : 
 				songData.mybest.stat_exscore - songData.rivalRecord.stat_exscore;
 		case 96:
 			return songData.level;
@@ -2254,6 +2256,7 @@ int SetObjectValue_Bargraph(game *g) {
 
 	float max, val;
 	const SONGDATA& songData = g->sSelect.bmsList[g->sSelect.cur_song];
+	const std::optional<STATUS>& myIRbest = songData.myIRbest;
 
 	for (int i = 0; i < g->skstruct.otherObject[5].srcSize; i++) {
 
@@ -2440,49 +2443,49 @@ int SetObjectValue_Bargraph(game *g) {
 					break;
 
 				case 40:
-					max = songData.hasIRDerivedRecord ? songData.myIRbest.total_notes : songData.mybest.total_notes;
-					val = songData.hasIRDerivedRecord ? songData.myIRbest.stat_pgreat : songData.mybest.stat_pgreat;
+					max = myIRbest.has_value() ? songData.myIRbest.value().total_notes : songData.mybest.total_notes;
+					val = myIRbest.has_value() ? songData.myIRbest.value().stat_pgreat : songData.mybest.stat_pgreat;
 					break;
 
 				case 41:
-					max = songData.hasIRDerivedRecord ? songData.myIRbest.total_notes : songData.mybest.total_notes;
-					val = songData.hasIRDerivedRecord ? songData.myIRbest.stat_great : songData.mybest.stat_great;
+					max = myIRbest.has_value() ? songData.myIRbest.value().total_notes : songData.mybest.total_notes;
+					val = myIRbest.has_value() ? songData.myIRbest.value().stat_great : songData.mybest.stat_great;
 					break;
 
 				case 42:
-					max = songData.hasIRDerivedRecord ? songData.myIRbest.total_notes : songData.mybest.total_notes;
-					val = songData.hasIRDerivedRecord ? songData.myIRbest.stat_good : songData.mybest.stat_good;
+					max = myIRbest.has_value() ? songData.myIRbest.value().total_notes : songData.mybest.total_notes;
+					val = myIRbest.has_value() ? songData.myIRbest.value().stat_good : songData.mybest.stat_good;
 					break;
 
 				case 43:
-					max = songData.hasIRDerivedRecord ? songData.myIRbest.total_notes : songData.mybest.total_notes;
-					val = songData.hasIRDerivedRecord ? songData.myIRbest.stat_bad : songData.mybest.stat_bad;
+					max = myIRbest.has_value() ? songData.myIRbest.value().total_notes : songData.mybest.total_notes;
+					val = myIRbest.has_value() ? songData.myIRbest.value().stat_bad : songData.mybest.stat_bad;
 					break;
 
 				case 44:
-					max = songData.hasIRDerivedRecord ? songData.myIRbest.total_notes : songData.mybest.total_notes;
-					val = songData.hasIRDerivedRecord ? songData.myIRbest.stat_poor : songData.mybest.stat_poor;
+					max = myIRbest.has_value() ? songData.myIRbest.value().total_notes : songData.mybest.total_notes;
+					val = myIRbest.has_value() ? songData.myIRbest.value().stat_poor : songData.mybest.stat_poor;
 					break;
 
 				case 45:
-					max = songData.hasIRDerivedRecord ? songData.myIRbest.total_notes : songData.mybest.total_notes;
-					val = songData.hasIRDerivedRecord ? songData.myIRbest.stat_maxcombo : songData.mybest.stat_maxcombo;
+					max = myIRbest.has_value() ? songData.myIRbest.value().total_notes : songData.mybest.total_notes;
+					val = myIRbest.has_value() ? songData.myIRbest.value().stat_maxcombo : songData.mybest.stat_maxcombo;
 					break;
 
 				case 46:
 					if ((songData.keymode == 7) || (songData.keymode == 0xe)) {
 						max = 20000.0;
-						val = songData.hasIRDerivedRecord ? songData.myIRbest.stat_score : songData.mybest.stat_score;
+						val = myIRbest.has_value() ? songData.myIRbest.value().stat_score : songData.mybest.stat_score;
 					}
 					else {
 						max = 10000.0;
-						val = songData.hasIRDerivedRecord ? songData.myIRbest.stat_score : songData.mybest.stat_score;
+						val = myIRbest.has_value() ? songData.myIRbest.value().stat_score : songData.mybest.stat_score;
 					}
 					break;
 
 				case 47:
-					max = songData.hasIRDerivedRecord ? (songData.myIRbest.total_notes * 2) : (songData.mybest.total_notes * 2);
-					val = songData.hasIRDerivedRecord ? songData.myIRbest.stat_exscore : songData.mybest.stat_exscore;
+					max = myIRbest.has_value() ? (songData.myIRbest.value().total_notes * 2) : (songData.mybest.total_notes * 2);
+					val = myIRbest.has_value() ? songData.myIRbest.value().stat_exscore : songData.mybest.stat_exscore;
 					break;
 			}
 

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -1419,9 +1419,9 @@ bool GetOptionFlag_dst(game *gs, int option) {
 			break;
 
 		case 626:
-			return gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.isIRDerivedRecord;
+			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.isIRDerivedRecord) return ret;
 			break;
-
+			
 		case 640:
 			if (gs->config.play.battle == 2) {
 				if (gs->sSelect.bmsList[gs->sSelect.cur_song].keymode > 0 && gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.clear_db == 0) return ret;

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -1417,6 +1417,7 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 625:
 			if (gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.stat_exscore > 0) return ret;
 			break;
+
 		case 626:
 			return gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.isIRDerivedRecord;
 			break;

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -1417,6 +1417,9 @@ bool GetOptionFlag_dst(game *gs, int option) {
 		case 625:
 			if (gs->sSelect.bmsList[gs->sSelect.cur_song].rivalRecord.stat_exscore > 0) return ret;
 			break;
+		case 626:
+			if (gs->sSelect.bmsList[gs->sSelect.cur_song].mybest.isIRDerivedRecord > 0) return ret;
+			break;
 
 		case 640:
 			if (gs->config.play.battle == 2) {
@@ -2214,8 +2217,6 @@ uint SetObjectValue_Num(game *g, int op) {
 			//293 is same 180
 		case 294: //TOFIX : IR clear rate
 			break;
-		case 300:
-			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.isIRDerivedRecord;
 		case 295: return g->gameplay.randomLayoutForDisplay[0]; // LR2OOL SP and DP 1P random
 		case 418: return g->gameplay.randomLayoutForDisplay[1]; // LR2OOL DP 2P random
 	}

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -2214,6 +2214,8 @@ uint SetObjectValue_Num(game *g, int op) {
 			//293 is same 180
 		case 294: //TOFIX : IR clear rate
 			break;
+		case 300:
+			return g->sSelect.bmsList[g->sSelect.cur_song].mybest.isIRDerivedRecord;
 		case 295: return g->gameplay.randomLayoutForDisplay[0]; // LR2OOL SP and DP 1P random
 		case 418: return g->gameplay.randomLayoutForDisplay[1]; // LR2OOL DP 2P random
 	}

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -294,23 +294,23 @@ void LoadIRDerivedRecord(sqlite3* sql, SONGDATA& sd) {
 				myIRbest.stat_score = mybest.stat_score;
 			}
 			
-			// total_notes can be zero
-			myIRbest.total_notes = std::max(mybest.total_notes, totalnotes);
-
-			// STATUS.clear == 5 means full combo
-			myIRbest.minbp = mybest.clear == 5 ? std::min(mybest.minbp, minbp) : minbp;
-			myIRbest.stat_maxcombo = mybest.clear == 5 ? totalnotes : std::max(mybest.stat_maxcombo, maxcombo);
-
-			// ignore playcounts
-			myIRbest.playcount = mybest.playcount;
-			myIRbest.clearcount = mybest.clearcount;
-			myIRbest.failcount = mybest.failcount;
-
 			myIRbest.clear = std::max(mybest.clear, clear);
 			myIRbest.clear_db = std::max(mybest.clear_db, clear_db);
 			myIRbest.clear_sd = std::max(mybest.clear_sd, clear_sd);
 			myIRbest.clear_ex = std::max(mybest.clear_ex, clear_ex);
 			myIRbest.complete = std::max(mybest.complete, complete);
+
+			// total_notes can be zero
+			myIRbest.total_notes = std::max(mybest.total_notes, totalnotes);
+
+			// STATUS.clear == 5 means full combo
+			myIRbest.minbp = myIRbest.clear == 5 ? std::min(mybest.minbp, minbp) : minbp;
+			myIRbest.stat_maxcombo = myIRbest.clear == 5 ? totalnotes : std::max(mybest.stat_maxcombo, maxcombo);
+
+			// ignore playcounts
+			myIRbest.playcount = mybest.playcount;
+			myIRbest.clearcount = mybest.clearcount;
+			myIRbest.failcount = mybest.failcount;
 
 			myIRbest.op_history = mybest.op_history;
 			sd.myIRbest = myIRbest;

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -2304,15 +2304,26 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 								}
 							}
 						}
+
+						CSTR IR_DERIVED_RECORD_HASH = "IR_DERIVED_RECORD";
 						CSTR bestHash;
 						bestHash = SQL_GetColumn(46, pStmt);
-						if (isSameScoreHash(&song.mybest, &ss->playerPassMD5, &song.hash, &bestHash)) {
+
+						bool isIRDerived = bestHash.isSame(IR_DERIVED_RECORD_HASH);
+						if (isSameScoreHash(&song.mybest, &ss->playerPassMD5, &song.hash, &bestHash) || isIRDerived) {
 							song.mybest.stat_exscore = song.mybest.stat_great + song.mybest.stat_pgreat * 2;
 							if (song.mybest.total_notes > 0) {
 								song.mybest.stat_score = ((song.mybest.stat_good + song.mybest.stat_exscore * 2) * 50000) /	song.mybest.total_notes;
 							}
 							if ((song.mybest.minbp == 0) && (song.mybest.clear != 5)) {
 								song.mybest.minbp = -1;
+							}
+
+							if (isIRDerived) {
+								song.mybest.isIRDerivedRecord = 1;
+							}
+							else {
+								song.mybest.isIRDerivedRecord = 0;
 							}
 						}
 						else {

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -1716,12 +1716,23 @@ int SearchCourseFromDB(sqlite3 *sql, SONGSELECT *ss, int keys, int multistagemod
 		song.mybest.rseed = sqlite3_column_int(pStmt, 27);
 		song.mybest.complete = sqlite3_column_int(pStmt, 28);
 		str = SQL_GetColumn(22, pStmt);
-		if (isSameScoreHash(&song.mybest, &ss->playerPassMD5, &song.hash, &str)) {
+
+		CSTR IR_DERIVED_RECORD_HASH = "IR_DERIVED_RECORD";
+		bool isIRDerivedRecord = str.isSame(IR_DERIVED_RECORD_HASH);
+
+		if (isSameScoreHash(&song.mybest, &ss->playerPassMD5, &song.hash, &str) || isIRDerivedRecord) {
 			song.mybest.stat_exscore = song.mybest.stat_great + song.mybest.stat_pgreat * 2;
 			if (song.mybest.stat_score > 0) {
 				song.mybest.stat_score = (song.mybest.stat_good + song.mybest.stat_exscore) * 2 * 50000 / song.mybest.total_notes;
 			}
 			if (song.mybest.minbp == 0 && song.mybest.clear != 5) song.mybest.minbp = -1;
+
+			if (isIRDerivedRecord) {
+				song.mybest.isIRDerivedRecord = 1;
+			}
+			else {
+				song.mybest.isIRDerivedRecord = 0;
+			}
 		}
 		else {
 			song.mybest = {};

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -19,6 +19,9 @@
 
 int EnabledInsane;
 static constexpr auto&& IR_DERIVED_RECORD_HASH = "IR_DERIVED_RECORD";
+static constexpr auto&& IR_RECORD_COLUMNS =
+"clear, perfect, great, good, bad, poor, totalnotes, maxcombo, minbp, "
+"rank, rate, clear_db, clear_sd, clear_ex, op_best, rseed, complete";
 
 namespace {
 
@@ -226,44 +229,44 @@ bool ParseTextCommand(BMSMETA& meta, CSTR& line) {
 
 // IR Records are locally compared and updated to the original record in lr2.
 void LoadIRDerivedRecord(sqlite3* sql, SONGDATA& sd) {
-	const char* sqlQuery = "SELECT * FROM imported_score WHERE hash = ?;";
+	const std::string sqlQuery = std::format("SELECT {} FROM imported_score WHERE hash = ?;", IR_RECORD_COLUMNS);
 	sqlite3_stmt* stmt;
-	if (sqlite3_prepare_v2(sql, sqlQuery, -1, &stmt, nullptr) == SQLITE_OK) {
+	if (sqlite3_prepare_v2(sql, sqlQuery.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
 		sqlite3_bind_text(stmt, 1, sd.hash.body, -1, SQLITE_STATIC);
 		int stepResult = sqlite3_step(stmt);
 
 		if (stepResult == SQLITE_ROW) {
 
-			STATUS& myIRbest = sd.myIRbest;
+			STATUS myIRbest;
 			const STATUS& mybest = sd.mybest;
 
-			int clear = sqlite3_column_int(stmt, 1);
-			int pgreat = sqlite3_column_int(stmt, 2);
-			int great = sqlite3_column_int(stmt, 3);
-			int good = sqlite3_column_int(stmt, 4);
-			int bad = sqlite3_column_int(stmt, 5);
-			int poor = sqlite3_column_int(stmt, 6);
-			int total_notes = sqlite3_column_int(stmt, 7);
-			int maxcombo = sqlite3_column_int(stmt, 8);
-			int minbp = sqlite3_column_int(stmt, 9);
-			int rank = sqlite3_column_int(stmt, 13);
-			int rate = sqlite3_column_int(stmt, 14);
-			int clear_db = sqlite3_column_int(stmt, 15);
-			int clear_sd = sqlite3_column_int(stmt, 19);
-			int clear_ex = sqlite3_column_int(stmt, 20);
-			int op_best = sqlite3_column_int(stmt, 21);
-			int rseed = sqlite3_column_int(stmt, 22);
-			int complete = sqlite3_column_int(stmt, 23);
+			int clear = sqlite3_column_int(stmt, 0);
+			int perfect = sqlite3_column_int(stmt, 1);
+			int great = sqlite3_column_int(stmt, 2);
+			int good = sqlite3_column_int(stmt, 3);
+			int bad = sqlite3_column_int(stmt, 4);
+			int poor = sqlite3_column_int(stmt, 5);
+			int totalnotes = sqlite3_column_int(stmt, 6);
+			int maxcombo = sqlite3_column_int(stmt, 7);
+			int minbp = sqlite3_column_int(stmt, 8);
+			int rank = sqlite3_column_int(stmt, 9);
+			int rate = sqlite3_column_int(stmt, 10);
+			int clear_db = sqlite3_column_int(stmt, 11);
+			int clear_sd = sqlite3_column_int(stmt, 12);
+			int clear_ex = sqlite3_column_int(stmt, 13);
+			int op_best = sqlite3_column_int(stmt, 14);
+			int rseed = sqlite3_column_int(stmt, 15);
+			int complete = sqlite3_column_int(stmt, 16);
 
-			int stat_score = (good + great * 2 + pgreat * 4) * 50000 / total_notes;
-			int stat_exscore = pgreat * 2 + great;
+			int stat_score = (good + great * 2 + perfect * 4) * 50000 / totalnotes;
+			int stat_exscore = perfect * 2 + great;
 			if (!minbp) {
 				minbp = bad + poor;
 			}
 
 			if (stat_exscore > mybest.stat_exscore)
 			{
-				myIRbest.stat_pgreat = pgreat;
+				myIRbest.stat_pgreat = perfect;
 				myIRbest.stat_great = great;
 				myIRbest.stat_good = good;
 				myIRbest.stat_bad = bad;
@@ -293,7 +296,7 @@ void LoadIRDerivedRecord(sqlite3* sql, SONGDATA& sd) {
 			}
 			
 			// total_notes can be zero
-			myIRbest.total_notes = std::max(mybest.total_notes, total_notes);
+			myIRbest.total_notes = std::max(mybest.total_notes, totalnotes);
 			// STATUS.clear == 5 means full combo
 			myIRbest.minbp = mybest.clear == 5 ? std::min(mybest.minbp, minbp) : minbp;
 			myIRbest.stat_maxcombo = std::max(mybest.stat_maxcombo, maxcombo);
@@ -310,7 +313,7 @@ void LoadIRDerivedRecord(sqlite3* sql, SONGDATA& sd) {
 			myIRbest.complete = std::max(mybest.complete, complete);
 
 			myIRbest.op_history = mybest.op_history;
-			sd.hasIRDerivedRecord = true;
+			sd.myIRbest = myIRbest;
 		}
 
 		sqlite3_finalize(stmt);
@@ -425,10 +428,9 @@ SONGDATA * COPY_SONGDATA(SONGDATA *s1, SONGDATA *s2){
 	s1->courseType = s2->courseType;
 	s1->courseIR = s2->courseIR;
 	s1->grHandle = s2->grHandle;
-	s1->hasIRDerivedRecord = s2->hasIRDerivedRecord;
 	
+	s1->myIRbest = s2->myIRbest;
 	memcpy(&s1->mybest, &s2->mybest, sizeof(STATUS));
-	memcpy(&s1->myIRbest, &s2->myIRbest, sizeof(STATUS));
 	memcpy(&s1->rivalRecord, &s2->rivalRecord, sizeof(STATUS));
 	return s1;
 }
@@ -494,14 +496,12 @@ int InitSongData(SONGDATA *song){
 	song->courseStageCount = 0;
 	song->coursePlayable = 0;
 	song->mybest = {};
-	song->myIRbest = {};
+	song->myIRbest.reset();
 	song->rivalRecord = {};
 	(song->mybest).minbp = -1;
-	(song->myIRbest).minbp = -1;
 	song->courseType = -1;
 	song->courseIR = 0;
 	song->courseReadOnly = 0;
-	song->hasIRDerivedRecord = false;
 	if (song->grHandle != -1) {
 		DeleteGraph(song->grHandle);
 	}
@@ -1024,12 +1024,13 @@ int LoadFolderDataFromDB(CSTR query, SONGDATA *song, sqlite3 *sql, int difficult
 			song->mybest.playcount += slist[i].mybest.playcount;
 			song->mybest.clearcount += slist[i].mybest.clearcount;
 			song->mybest.failcount += slist[i].mybest.failcount;
-			if (slist[i].hasIRDerivedRecord)
+			if (slist[i].myIRbest.has_value())
 			{
-				if (slist[i].myIRbest.clear != song->mybest.clear && slist[i].myIRbest.clear <= song->mybest.clear)
-					song->mybest.clear = slist[i].myIRbest.clear;
-				if (slist[i].myIRbest.clear_db != song->mybest.clear_db && slist[i].myIRbest.clear_db <= song->mybest.clear_db)
-					song->mybest.clear_db = slist[i].myIRbest.clear_db;
+				const STATUS& myIRbest = slist[i].myIRbest.value();
+				if (myIRbest.clear != song->mybest.clear && myIRbest.clear <= song->mybest.clear)
+					song->mybest.clear = myIRbest.clear;
+				if (myIRbest.clear_db != song->mybest.clear_db && myIRbest.clear_db <= song->mybest.clear_db)
+					song->mybest.clear_db = myIRbest.clear_db;
 			}
 			else
 			{

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -940,7 +940,7 @@ int LoadFolderDataFromDB(CSTR query, SONGDATA *song, sqlite3 *sql, int difficult
 			sd.mybest.clearcount = sqlite3_column_int(stmt, 40);
 			sd.mybest.failcount = sqlite3_column_int(stmt, 41);
 			sd.mybest.rank = sqlite3_column_int(stmt, 42);
-			sd.mybest.rate = sqlite3_column_int(stmt, 43);	
+			sd.mybest.rate = sqlite3_column_int(stmt, 43);
 			sd.mybest.clear_db = sqlite3_column_int(stmt, 44);
 			sd.mybest.op_history = sqlite3_column_int(stmt, 45);
 			sd.mybest.clear_sd = sqlite3_column_int(stmt, 48);
@@ -2421,7 +2421,6 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 								}
 							}
 						}
-
 						CSTR bestHash;
 						bestHash = SQL_GetColumn(46, pStmt);
 						if (isSameScoreHash(&song.mybest, &ss->playerPassMD5, &song.hash, &bestHash)) {

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -18,7 +18,7 @@
 #endif // _WIN32
 
 int EnabledInsane;
-constexpr auto&& IR_DERIVED_RECORD_HASH = "IR_DERIVED_RECORD";
+static constexpr auto&& IR_DERIVED_RECORD_HASH = "IR_DERIVED_RECORD";
 
 namespace {
 

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -1179,7 +1179,7 @@ int GetSongData(CSTR songMD5, SONGDATA *song, sqlite3 *sql, SONGSELECT *ss) {
 			LoadIRDerivedRecord(sql, *song);
 
 			besthash = SQL_GetColumn(46, stmt);
-			if (isSameScoreHash(&song->mybest, &ss->playerPassMD5, &song->hash, &besthash) || song->hasIRDerivedRecord) {
+			if (isSameScoreHash(&song->mybest, &ss->playerPassMD5, &song->hash, &besthash)) {
 				song->mybest.stat_exscore = song->mybest.stat_great + song->mybest.stat_pgreat * 2;
 				if (song->mybest.total_notes < 1) 
 					song->mybest.total_notes = sqlite3_column_int(stmt, 26);
@@ -1821,7 +1821,7 @@ int SearchCourseFromDB(sqlite3 *sql, SONGSELECT *ss, int keys, int multistagemod
 		LoadIRDerivedRecord(sql, song);
 
 		str = SQL_GetColumn(22, pStmt);
-		if (isSameScoreHash(&song.mybest, &ss->playerPassMD5, &song.hash, &str) || song.hasIRDerivedRecord) {
+		if (isSameScoreHash(&song.mybest, &ss->playerPassMD5, &song.hash, &str)) {
 			song.mybest.stat_exscore = song.mybest.stat_great + song.mybest.stat_pgreat * 2;
 			if (song.mybest.stat_score > 0) {
 				song.mybest.stat_score = (song.mybest.stat_good + song.mybest.stat_exscore) * 2 * 50000 / song.mybest.total_notes;
@@ -2424,7 +2424,7 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 
 						CSTR bestHash;
 						bestHash = SQL_GetColumn(46, pStmt);
-						if (isSameScoreHash(&song.mybest, &ss->playerPassMD5, &song.hash, &bestHash) || song.hasIRDerivedRecord) {
+						if (isSameScoreHash(&song.mybest, &ss->playerPassMD5, &song.hash, &bestHash)) {
 							song.mybest.stat_exscore = song.mybest.stat_great + song.mybest.stat_pgreat * 2;
 							if (song.mybest.total_notes > 0) {
 								song.mybest.stat_score = ((song.mybest.stat_good + song.mybest.stat_exscore * 2) * 50000) /	song.mybest.total_notes;

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -296,9 +296,10 @@ void LoadIRDerivedRecord(sqlite3* sql, SONGDATA& sd) {
 			
 			// total_notes can be zero
 			myIRbest.total_notes = std::max(mybest.total_notes, totalnotes);
+
 			// STATUS.clear == 5 means full combo
 			myIRbest.minbp = mybest.clear == 5 ? std::min(mybest.minbp, minbp) : minbp;
-			myIRbest.stat_maxcombo = std::max(mybest.stat_maxcombo, maxcombo);
+			myIRbest.stat_maxcombo = mybest.clear == 5 ? totalnotes : std::max(mybest.stat_maxcombo, maxcombo);
 
 			// ignore playcounts
 			myIRbest.playcount = mybest.playcount;

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -992,6 +992,7 @@ int GetSongData(CSTR songMD5, SONGDATA *song, sqlite3 *sql, SONGSELECT *ss) {
 	char buf[1024];
 	sqlite3_stmt *stmt;
 	int ret = 0;
+	CSTR IR_DERIVED_RECORD_HASH = "IR_DERIVED_RECORD";
 
 	InitSongData(song);
 	query = sqlite3_snprintf(1024, buf, "SELECT * FROM song LEFT JOIN score ON song.hash = score.hash WHERE song.hash = \'%s\'", songMD5.body);
@@ -1066,7 +1067,9 @@ int GetSongData(CSTR songMD5, SONGDATA *song, sqlite3 *sql, SONGSELECT *ss) {
 			song->mybest.complete = sqlite3_column_int(stmt, 52);
 
 			besthash = SQL_GetColumn(46, stmt);
-			if (isSameScoreHash(&song->mybest, &ss->playerPassMD5, &song->hash, &besthash)) {
+			bool isIRDerivedRecord = besthash.isSame(IR_DERIVED_RECORD_HASH);
+
+			if (isSameScoreHash(&song->mybest, &ss->playerPassMD5, &song->hash, &besthash) || isIRDerivedRecord) {
 				song->mybest.stat_exscore = song->mybest.stat_great + song->mybest.stat_pgreat * 2;
 				if (song->mybest.total_notes < 1) 
 					song->mybest.total_notes = sqlite3_column_int(stmt, 26);
@@ -1075,7 +1078,14 @@ int GetSongData(CSTR songMD5, SONGDATA *song, sqlite3 *sql, SONGSELECT *ss) {
 					song->mybest.stat_score = (song->mybest.stat_good + song->mybest.stat_great * 2 + song->mybest.stat_pgreat * 4) * 50000 / song->mybest.total_notes;
 
 				if (song->mybest.minbp == 0 && song->mybest.clear != 5)
-					song->mybest.minbp = -1; 
+					song->mybest.minbp = -1;
+
+				if (isIRDerivedRecord) {
+					song->mybest.isIRDerivedRecord = 1;
+				}
+				else {
+					song->mybest.isIRDerivedRecord = 0;
+				}
 			}
 			else {
 				song->mybest = {};

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -1655,7 +1655,7 @@ int CMP_SongDataByDifficulty(const void *p1, const void *p2) {
 	return 0;
 }
 
-int CMP_SongDataByClear(const void *p1, const void *p2) {
+int CMP_SongDataByClear(const void* p1, const void* p2) {
 	SONGDATA* s1 = (SONGDATA*)p1;
 	SONGDATA* s2 = (SONGDATA*)p2;
 
@@ -1663,7 +1663,9 @@ int CMP_SongDataByClear(const void *p1, const void *p2) {
 		return s1->folderType - s2->folderType;
 	}
 
-	if (s1->mybest.clear != s2->mybest.clear) return s1->mybest.clear - s2->mybest.clear;
+	STATUS s1best = s1->myIRbest.has_value() ? s1->myIRbest.value() : s1->mybest;
+	STATUS s2best = s2->myIRbest.has_value() ? s2->myIRbest.value() : s2->mybest;
+	if (s1best.clear != s2best.clear) return s1best.clear - s2best.clear;
 
 	return CMP_SongDataByDifficulty(p1, p2);
 }

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -224,6 +224,98 @@ bool ParseTextCommand(BMSMETA& meta, CSTR& line) {
 	return false;
 }
 
+// IR Records are locally compared and updated to the original record in lr2.
+void LoadIRDerivedRecord(sqlite3* sql, SONGDATA& sd) {
+	const char* sqlQuery = "SELECT * FROM imported_score WHERE hash = ?;";
+	sqlite3_stmt* stmt;
+	if (sqlite3_prepare_v2(sql, sqlQuery, -1, &stmt, nullptr) == SQLITE_OK) {
+		sqlite3_bind_text(stmt, 1, sd.hash.body, -1, SQLITE_STATIC);
+		int stepResult = sqlite3_step(stmt);
+
+		if (stepResult == SQLITE_ROW) {
+
+			STATUS& myIRbest = sd.myIRbest;
+			const STATUS& mybest = sd.mybest;
+
+			int clear = sqlite3_column_int(stmt, 1);
+			int pgreat = sqlite3_column_int(stmt, 2);
+			int great = sqlite3_column_int(stmt, 3);
+			int good = sqlite3_column_int(stmt, 4);
+			int bad = sqlite3_column_int(stmt, 5);
+			int poor = sqlite3_column_int(stmt, 6);
+			int total_notes = sqlite3_column_int(stmt, 7);
+			int maxcombo = sqlite3_column_int(stmt, 8);
+			int minbp = sqlite3_column_int(stmt, 9);
+			int rank = sqlite3_column_int(stmt, 13);
+			int rate = sqlite3_column_int(stmt, 14);
+			int clear_db = sqlite3_column_int(stmt, 15);
+			int clear_sd = sqlite3_column_int(stmt, 19);
+			int clear_ex = sqlite3_column_int(stmt, 20);
+			int op_best = sqlite3_column_int(stmt, 21);
+			int rseed = sqlite3_column_int(stmt, 22);
+			int complete = sqlite3_column_int(stmt, 23);
+
+			int stat_score = (good + great * 2 + pgreat * 4) * 50000 / total_notes;
+			int stat_exscore = pgreat * 2 + great;
+			if (!minbp) {
+				minbp = bad + poor;
+			}
+
+			if (stat_exscore > mybest.stat_exscore)
+			{
+				myIRbest.stat_pgreat = pgreat;
+				myIRbest.stat_great = great;
+				myIRbest.stat_good = good;
+				myIRbest.stat_bad = bad;
+				myIRbest.stat_poor = poor;
+
+				myIRbest.rank = rank;
+				myIRbest.rate = rate;
+				myIRbest.rseed = rseed;
+				myIRbest.op_best = op_best;
+				myIRbest.stat_exscore = stat_exscore;
+				myIRbest.stat_score = stat_score;
+			}
+			else
+			{
+				myIRbest.stat_pgreat = mybest.stat_pgreat;
+				myIRbest.stat_great = mybest.stat_great;
+				myIRbest.stat_good = mybest.stat_good;
+				myIRbest.stat_bad = mybest.stat_bad;
+				myIRbest.stat_poor = mybest.stat_poor;
+
+				myIRbest.rank = mybest.rank;
+				myIRbest.rate = mybest.rate;
+				myIRbest.rseed = mybest.rseed;
+				myIRbest.op_best = mybest.op_best;
+				myIRbest.stat_exscore = mybest.stat_exscore;
+				myIRbest.stat_score = mybest.stat_score;
+			}
+			
+			// total_notes can be zero
+			myIRbest.total_notes = std::max(mybest.total_notes, total_notes);
+			// STATUS.clear == 5 means full combo
+			myIRbest.minbp = mybest.clear == 5 ? std::min(mybest.minbp, minbp) : minbp;
+			myIRbest.stat_maxcombo = std::max(mybest.stat_maxcombo, maxcombo);
+
+			// ignore playcounts
+			myIRbest.playcount = mybest.playcount;
+			myIRbest.clearcount = mybest.clearcount;
+			myIRbest.failcount = mybest.failcount;
+
+			myIRbest.clear = std::max(mybest.clear, clear);
+			myIRbest.clear_db = std::max(mybest.clear_db, clear_db);
+			myIRbest.clear_sd = std::max(mybest.clear_sd, clear_sd);
+			myIRbest.clear_ex = std::max(mybest.clear_ex, clear_ex);
+			myIRbest.complete = std::max(mybest.complete, complete);
+
+			myIRbest.op_history = mybest.op_history;
+			sd.hasIRDerivedRecord = true;
+		}
+
+		sqlite3_finalize(stmt);
+	}
+}
 } // namespace
 
 // thiscall in original code
@@ -333,8 +425,10 @@ SONGDATA * COPY_SONGDATA(SONGDATA *s1, SONGDATA *s2){
 	s1->courseType = s2->courseType;
 	s1->courseIR = s2->courseIR;
 	s1->grHandle = s2->grHandle;
+	s1->hasIRDerivedRecord = s2->hasIRDerivedRecord;
 	
 	memcpy(&s1->mybest, &s2->mybest, sizeof(STATUS));
+	memcpy(&s1->myIRbest, &s2->myIRbest, sizeof(STATUS));
 	memcpy(&s1->rivalRecord, &s2->rivalRecord, sizeof(STATUS));
 	return s1;
 }
@@ -400,11 +494,14 @@ int InitSongData(SONGDATA *song){
 	song->courseStageCount = 0;
 	song->coursePlayable = 0;
 	song->mybest = {};
+	song->myIRbest = {};
 	song->rivalRecord = {};
 	(song->mybest).minbp = -1;
+	(song->myIRbest).minbp = -1;
 	song->courseType = -1;
 	song->courseIR = 0;
 	song->courseReadOnly = 0;
+	song->hasIRDerivedRecord = false;
 	if (song->grHandle != -1) {
 		DeleteGraph(song->grHandle);
 	}
@@ -843,7 +940,7 @@ int LoadFolderDataFromDB(CSTR query, SONGDATA *song, sqlite3 *sql, int difficult
 			sd.mybest.clearcount = sqlite3_column_int(stmt, 40);
 			sd.mybest.failcount = sqlite3_column_int(stmt, 41);
 			sd.mybest.rank = sqlite3_column_int(stmt, 42);
-			sd.mybest.rate = sqlite3_column_int(stmt, 43);
+			sd.mybest.rate = sqlite3_column_int(stmt, 43);	
 			sd.mybest.clear_db = sqlite3_column_int(stmt, 44);
 			sd.mybest.op_history = sqlite3_column_int(stmt, 45);
 			sd.mybest.clear_sd = sqlite3_column_int(stmt, 48);
@@ -851,6 +948,10 @@ int LoadFolderDataFromDB(CSTR query, SONGDATA *song, sqlite3 *sql, int difficult
 			sd.mybest.op_best = sqlite3_column_int(stmt, 50);
 			sd.mybest.rseed = sqlite3_column_int(stmt, 51);
 			sd.mybest.complete = sqlite3_column_int(stmt, 52);
+
+			// SONGDATA's hash was not assigned. (Tracking folder stats now)
+			sd.hash = SQL_GetColumn(0, stmt);
+			LoadIRDerivedRecord(sql, sd);
 		}
 		if (mode == 0) {
 			workingFolder = newFolder;
@@ -916,17 +1017,27 @@ int LoadFolderDataFromDB(CSTR query, SONGDATA *song, sqlite3 *sql, int difficult
 		InitSongData(&sd);
 	}
 	sqlite3_finalize(stmt);
-	if (slistCount) { 
+	if (slistCount) {
 		song->mybest.clear = 5;
 		song->mybest.clear_db = 5;
-		for (int i = 0; i < slistCount; i++) { 
+		for (int i = 0; i < slistCount; i++) {
 			song->mybest.playcount += slist[i].mybest.playcount;
 			song->mybest.clearcount += slist[i].mybest.clearcount;
 			song->mybest.failcount += slist[i].mybest.failcount;
-			if (slist[i].mybest.clear != song->mybest.clear && slist[i].mybest.clear <= song->mybest.clear)
-				song->mybest.clear = slist[i].mybest.clear;
-			if (slist[i].mybest.clear_db != song->mybest.clear_db && slist[i].mybest.clear_db <= song->mybest.clear_db)
-				song->mybest.clear_db = slist[i].mybest.clear_db;
+			if (slist[i].hasIRDerivedRecord)
+			{
+				if (slist[i].myIRbest.clear != song->mybest.clear && slist[i].myIRbest.clear <= song->mybest.clear)
+					song->mybest.clear = slist[i].myIRbest.clear;
+				if (slist[i].myIRbest.clear_db != song->mybest.clear_db && slist[i].myIRbest.clear_db <= song->mybest.clear_db)
+					song->mybest.clear_db = slist[i].myIRbest.clear_db;
+			}
+			else
+			{
+				if (slist[i].mybest.clear != song->mybest.clear && slist[i].mybest.clear <= song->mybest.clear)
+					song->mybest.clear = slist[i].mybest.clear;
+				if (slist[i].mybest.clear_db != song->mybest.clear_db && slist[i].mybest.clear_db <= song->mybest.clear_db)
+					song->mybest.clear_db = slist[i].mybest.clear_db;
+			}
 		}
 	}
 	free(slist);
@@ -1065,11 +1176,10 @@ int GetSongData(CSTR songMD5, SONGDATA *song, sqlite3 *sql, SONGSELECT *ss) {
 			song->mybest.op_best = sqlite3_column_int(stmt, 50);
 			song->mybest.rseed = sqlite3_column_int(stmt, 51);
 			song->mybest.complete = sqlite3_column_int(stmt, 52);
+			LoadIRDerivedRecord(sql, *song);
 
 			besthash = SQL_GetColumn(46, stmt);
-			bool isIRDerivedRecord = besthash.isSame(IR_DERIVED_RECORD_HASH);
-
-			if (isSameScoreHash(&song->mybest, &ss->playerPassMD5, &song->hash, &besthash) || isIRDerivedRecord) {
+			if (isSameScoreHash(&song->mybest, &ss->playerPassMD5, &song->hash, &besthash) || song->hasIRDerivedRecord) {
 				song->mybest.stat_exscore = song->mybest.stat_great + song->mybest.stat_pgreat * 2;
 				if (song->mybest.total_notes < 1) 
 					song->mybest.total_notes = sqlite3_column_int(stmt, 26);
@@ -1079,8 +1189,6 @@ int GetSongData(CSTR songMD5, SONGDATA *song, sqlite3 *sql, SONGSELECT *ss) {
 
 				if (song->mybest.minbp == 0 && song->mybest.clear != 5)
 					song->mybest.minbp = -1;
-
-				song->mybest.isIRDerivedRecord = isIRDerivedRecord;
 			}
 			else {
 				song->mybest = {};
@@ -1710,18 +1818,15 @@ int SearchCourseFromDB(sqlite3 *sql, SONGSELECT *ss, int keys, int multistagemod
 		song.mybest.op_best = sqlite3_column_int(pStmt, 26);
 		song.mybest.rseed = sqlite3_column_int(pStmt, 27);
 		song.mybest.complete = sqlite3_column_int(pStmt, 28);
+		LoadIRDerivedRecord(sql, song);
+
 		str = SQL_GetColumn(22, pStmt);
-
-		bool isIRDerivedRecord = str.isSame(IR_DERIVED_RECORD_HASH);
-
-		if (isSameScoreHash(&song.mybest, &ss->playerPassMD5, &song.hash, &str) || isIRDerivedRecord) {
+		if (isSameScoreHash(&song.mybest, &ss->playerPassMD5, &song.hash, &str) || song.hasIRDerivedRecord) {
 			song.mybest.stat_exscore = song.mybest.stat_great + song.mybest.stat_pgreat * 2;
 			if (song.mybest.stat_score > 0) {
 				song.mybest.stat_score = (song.mybest.stat_good + song.mybest.stat_exscore) * 2 * 50000 / song.mybest.total_notes;
 			}
 			if (song.mybest.minbp == 0 && song.mybest.clear != 5) song.mybest.minbp = -1;
-
-			song.mybest.isIRDerivedRecord = isIRDerivedRecord;
 		}
 		else {
 			song.mybest = {};
@@ -1813,14 +1918,24 @@ int LoadBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *difficulty,
 			for (int i = 0; i < ss->prevListCount; i++) {
 				CSTR query(1024);
 				if (ss->prevList[i].tag.isDiff("(null)") && ss->prevList[i].tag.length() >= 5) {
-					query = sqlite3_snprintf(1024, buf, "SELECT * FROM song LEFT JOIN score ON song.hash = score.hash WHERE %s", ss->prevList[i].tag.body);
+					// Add IR scores in folder stats.
+					query = sqlite3_snprintf(1024, buf,
+						"SELECT * FROM song "
+						"LEFT JOIN score ON song.hash = score.hash "
+						"LEFT JOIN imported_score ON song.hash = imported_score.hash AND score.hash IS NULL "
+						"WHERE %s", ss->prevList[i].tag.body);
 					if (query.findStrPos("__NEWSONG__") > -1) {
 						query = sqlite3_snprintf(1024, buf, "SELECT * FROM song LEFT JOIN score ON song.hash = score.hash WHERE adddate > %d", GetNowUnixtime() - ss->titleflash * 3600);
 					}
 					LoadFolderDataFromDB(query, &ss->prevList[i], sql, *difficulty, *key, sort, ss->prevList[i].level, &ss->filter, 1);
 				}
 				else {
-					query = sqlite3_snprintf(1024, buf, "SELECT * FROM song LEFT JOIN score ON song.hash = score.hash WHERE parent = \'%s\'", AssignCRC32(ss->prevList[i].filepath).body);
+					// Add IR scores in folder stats.
+					query = sqlite3_snprintf(1024, buf,
+						"SELECT * FROM song "
+						"LEFT JOIN score ON song.hash = score.hash "
+						"LEFT JOIN imported_score ON song.hash = imported_score.hash AND score.hash IS NULL "
+						"WHERE parent = \'%s\'", AssignCRC32(ss->prevList[i].filepath).body);
 					LoadFolderDataFromDB(query, &ss->prevList[i], sql, *difficulty, *key, sort, 0, &ss->filter, 0);
 				}
 			}
@@ -2277,6 +2392,8 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 						song.mybest.op_best = sqlite3_column_int(pStmt, 50);
 						song.mybest.rseed = sqlite3_column_int(pStmt, 51);
 						song.mybest.complete = sqlite3_column_int(pStmt, 52);
+						LoadIRDerivedRecord(sql, song);
+
 						if (isRival) {
 							song.folderType = 5;
 							song.rivalRecord.clear = sqlite3_column_int(pStmt, 54);
@@ -2307,9 +2424,7 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 
 						CSTR bestHash;
 						bestHash = SQL_GetColumn(46, pStmt);
-
-						bool isIRDerivedRecord = bestHash.isSame(IR_DERIVED_RECORD_HASH);
-						if (isSameScoreHash(&song.mybest, &ss->playerPassMD5, &song.hash, &bestHash) || isIRDerivedRecord) {
+						if (isSameScoreHash(&song.mybest, &ss->playerPassMD5, &song.hash, &bestHash) || song.hasIRDerivedRecord) {
 							song.mybest.stat_exscore = song.mybest.stat_great + song.mybest.stat_pgreat * 2;
 							if (song.mybest.total_notes > 0) {
 								song.mybest.stat_score = ((song.mybest.stat_good + song.mybest.stat_exscore * 2) * 50000) /	song.mybest.total_notes;
@@ -2317,8 +2432,6 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 							if ((song.mybest.minbp == 0) && (song.mybest.clear != 5)) {
 								song.mybest.minbp = -1;
 							}
-
-							song.mybest.isIRDerivedRecord = isIRDerivedRecord;
 						}
 						else {
 							song.mybest = {};

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -19,9 +19,6 @@
 
 int EnabledInsane;
 static constexpr auto&& IR_DERIVED_RECORD_HASH = "IR_DERIVED_RECORD";
-static constexpr auto&& IR_RECORD_COLUMNS =
-"clear, perfect, great, good, bad, poor, totalnotes, maxcombo, minbp, "
-"rank, rate, clear_db, clear_sd, clear_ex, op_best, rseed, complete";
 
 namespace {
 
@@ -229,9 +226,11 @@ bool ParseTextCommand(BMSMETA& meta, CSTR& line) {
 
 // IR Records are locally compared and updated to the original record in lr2.
 void LoadIRDerivedRecord(sqlite3* sql, SONGDATA& sd) {
-	const std::string sqlQuery = std::format("SELECT {} FROM imported_score WHERE hash = ?;", IR_RECORD_COLUMNS);
+	const char* sqlQuery = "SELECT clear, perfect, great, good, bad, poor, totalnotes, maxcombo, minbp, "
+		"rank, rate, clear_db, clear_sd, clear_ex, op_best, rseed, complete "
+		"FROM imported_score WHERE hash = ?";
 	sqlite3_stmt* stmt;
-	if (sqlite3_prepare_v2(sql, sqlQuery.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+	if (sqlite3_prepare_v2(sql, sqlQuery, -1, &stmt, nullptr) == SQLITE_OK) {
 		sqlite3_bind_text(stmt, 1, sd.hash.body, -1, SQLITE_STATIC);
 		int stepResult = sqlite3_step(stmt);
 

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -1026,7 +1026,7 @@ int LoadFolderDataFromDB(CSTR query, SONGDATA *song, sqlite3 *sql, int difficult
 			song->mybest.failcount += slist[i].mybest.failcount;
 			if (slist[i].myIRbest.has_value())
 			{
-				const STATUS& myIRbest = slist[i].myIRbest.value();
+				const STATUS& myIRbest = *(slist[i].myIRbest);
 				if (myIRbest.clear != song->mybest.clear && myIRbest.clear <= song->mybest.clear)
 					song->mybest.clear = myIRbest.clear;
 				if (myIRbest.clear_db != song->mybest.clear_db && myIRbest.clear_db <= song->mybest.clear_db)
@@ -1663,8 +1663,8 @@ int CMP_SongDataByClear(const void* p1, const void* p2) {
 		return s1->folderType - s2->folderType;
 	}
 
-	STATUS s1best = s1->myIRbest.has_value() ? s1->myIRbest.value() : s1->mybest;
-	STATUS s2best = s2->myIRbest.has_value() ? s2->myIRbest.value() : s2->mybest;
+	STATUS s1best = s1->myIRbest.has_value() ? *(s1->myIRbest) : s1->mybest;
+	STATUS s2best = s2->myIRbest.has_value() ? *(s2->myIRbest) : s2->mybest;
 	if (s1best.clear != s2best.clear) return s1best.clear - s2best.clear;
 
 	return CMP_SongDataByDifficulty(p1, p2);

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -18,6 +18,7 @@
 #endif // _WIN32
 
 int EnabledInsane;
+constexpr auto&& IR_DERIVED_RECORD_HASH = "IR_DERIVED_RECORD";
 
 namespace {
 
@@ -992,7 +993,6 @@ int GetSongData(CSTR songMD5, SONGDATA *song, sqlite3 *sql, SONGSELECT *ss) {
 	char buf[1024];
 	sqlite3_stmt *stmt;
 	int ret = 0;
-	CSTR IR_DERIVED_RECORD_HASH = "IR_DERIVED_RECORD";
 
 	InitSongData(song);
 	query = sqlite3_snprintf(1024, buf, "SELECT * FROM song LEFT JOIN score ON song.hash = score.hash WHERE song.hash = \'%s\'", songMD5.body);
@@ -1080,12 +1080,7 @@ int GetSongData(CSTR songMD5, SONGDATA *song, sqlite3 *sql, SONGSELECT *ss) {
 				if (song->mybest.minbp == 0 && song->mybest.clear != 5)
 					song->mybest.minbp = -1;
 
-				if (isIRDerivedRecord) {
-					song->mybest.isIRDerivedRecord = 1;
-				}
-				else {
-					song->mybest.isIRDerivedRecord = 0;
-				}
+				song->mybest.isIRDerivedRecord = isIRDerivedRecord;
 			}
 			else {
 				song->mybest = {};
@@ -1717,7 +1712,6 @@ int SearchCourseFromDB(sqlite3 *sql, SONGSELECT *ss, int keys, int multistagemod
 		song.mybest.complete = sqlite3_column_int(pStmt, 28);
 		str = SQL_GetColumn(22, pStmt);
 
-		CSTR IR_DERIVED_RECORD_HASH = "IR_DERIVED_RECORD";
 		bool isIRDerivedRecord = str.isSame(IR_DERIVED_RECORD_HASH);
 
 		if (isSameScoreHash(&song.mybest, &ss->playerPassMD5, &song.hash, &str) || isIRDerivedRecord) {
@@ -1727,12 +1721,7 @@ int SearchCourseFromDB(sqlite3 *sql, SONGSELECT *ss, int keys, int multistagemod
 			}
 			if (song.mybest.minbp == 0 && song.mybest.clear != 5) song.mybest.minbp = -1;
 
-			if (isIRDerivedRecord) {
-				song.mybest.isIRDerivedRecord = 1;
-			}
-			else {
-				song.mybest.isIRDerivedRecord = 0;
-			}
+			song.mybest.isIRDerivedRecord = isIRDerivedRecord;
 		}
 		else {
 			song.mybest = {};
@@ -2316,12 +2305,11 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 							}
 						}
 
-						CSTR IR_DERIVED_RECORD_HASH = "IR_DERIVED_RECORD";
 						CSTR bestHash;
 						bestHash = SQL_GetColumn(46, pStmt);
 
-						bool isIRDerived = bestHash.isSame(IR_DERIVED_RECORD_HASH);
-						if (isSameScoreHash(&song.mybest, &ss->playerPassMD5, &song.hash, &bestHash) || isIRDerived) {
+						bool isIRDerivedRecord = bestHash.isSame(IR_DERIVED_RECORD_HASH);
+						if (isSameScoreHash(&song.mybest, &ss->playerPassMD5, &song.hash, &bestHash) || isIRDerivedRecord) {
 							song.mybest.stat_exscore = song.mybest.stat_great + song.mybest.stat_pgreat * 2;
 							if (song.mybest.total_notes > 0) {
 								song.mybest.stat_score = ((song.mybest.stat_good + song.mybest.stat_exscore * 2) * 50000) /	song.mybest.total_notes;
@@ -2330,12 +2318,7 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 								song.mybest.minbp = -1;
 							}
 
-							if (isIRDerived) {
-								song.mybest.isIRDerivedRecord = 1;
-							}
-							else {
-								song.mybest.isIRDerivedRecord = 0;
-							}
+							song.mybest.isIRDerivedRecord = isIRDerivedRecord;
 						}
 						else {
 							song.mybest = {};

--- a/LR2/LR2_statlong.cpp
+++ b/LR2/LR2_statlong.cpp
@@ -51,6 +51,40 @@ int ReadPlayerScore(CSTR id, CSTR pass, PLAYERSTATISTIC *pstat) {
 		return 0;
 	}
 
+	constexpr const char* createTableQuery =
+		"CREATE TABLE IF NOT EXISTS imported_score ("
+		"hash TEXT PRIMARY KEY, "
+		"clear INTEGER, "
+		"perfect INTEGER, "
+		"great INTEGER, "
+		"good INTEGER, "
+		"bad INTEGER, "
+		"poor INTEGER, "
+		"totalnotes INTEGER, "
+		"maxcombo INTEGER, "
+		"minbp INTEGER, "
+		"playcount INTEGER, "
+		"clearcount INTEGER, "
+		"failcount INTEGER, "
+		"rank INTEGER, "
+		"rate INTEGER, "
+		"clear_db INTEGER, "
+		"op_history INTEGER, "
+		"scorehash TEXT, "
+		"ghost TEXT, "
+		"clear_sd INTEGER, "
+		"clear_ex INTEGER, "
+		"op_best INTEGER, "
+		"rseed INTEGER, "
+		"complete INTEGER"
+		");";
+
+	if (sqlite3_exec(scoreDB, createTableQuery, nullptr, nullptr, nullptr) != SQLITE_OK) {
+		MessageBoxA(NULL, "Error creating IR Derived Score Table", "Error", 0);
+		sqlite3_close(scoreDB);
+		return 0;
+	}
+
 	MD5inDB = SQL_GetColumn(1, stmt);
 	if (passMD5.isSame(&MD5inDB) == 0) {
 		MessageBoxA(NULL, "パスワードが違います。", "エラー", 0);
@@ -208,6 +242,11 @@ int UpdateScoreDB(CSTR hash, STATUS *stat, sqlite3 *sql, CSTR *passMD5) {
 			, stat->clear, stat->stat_pgreat, stat->stat_great, stat->stat_good, stat->stat_bad, stat->stat_poor, stat->total_notes, stat->stat_maxcombo, stat->minbp, stat->playcount, stat->clearcount, stat->failcount, stat->op_history, scoreMD5.body, stat->rank, stat->rate, stat->clear_db, stat->clear_sd, stat->clear_ex, stat->op_best, stat->rseed, stat->complete, hash.body);
 		SQL_Run(query, sql);
 	}
+
+	// delete imported score from IR
+	CSTR delQuery;
+	cstrSprintf(&delQuery, "DELETE FROM imported_score WHERE hash = \'%s\'", hash.body);
+	SQL_Run(delQuery, sql);
 	sqlite3_exec(sql, "COMMIT", 0, 0, 0);
 	return 1;
 }

--- a/LR2/LR2_statplay.cpp
+++ b/LR2/LR2_statplay.cpp
@@ -714,7 +714,7 @@ int SaveResult(game *g, sqlite3* sql) {
 		UpdatePlayerStat(&g->gameplay.playerstat, sql);
 		g->sSelect.oldIRrank = bms.mybest.IRranking;
 
-		if (g->net.isOnline && g->is_starter == 0) {
+		if (!bms.mybest.isIRDerivedRecord && g->net.isOnline && g->is_starter == 0) {
 			ErrorLogAdd("IRに登録しますか？\n");
 			g->net.myRanking.InitRanking();
 			if (g->gameplay.flag_longsound || g->gameplay.flag_0note) {

--- a/LR2/LR2_statplay.cpp
+++ b/LR2/LR2_statplay.cpp
@@ -684,6 +684,7 @@ int SaveResult(game *g, sqlite3* sql) {
 				bms.mybest.op_best = g->gameplay.player[0].gaugeType + g->config.play.random[0] * 10 + g->config.play.random[1] * 100 + g->config.play.dpflip * 1000;
 			}
 
+			bms.mybest.isIRDerivedRecord = false;
 			isNewRecord = true;
 		}
 

--- a/LR2/LR2_statplay.cpp
+++ b/LR2/LR2_statplay.cpp
@@ -684,7 +684,6 @@ int SaveResult(game *g, sqlite3* sql) {
 				bms.mybest.op_best = g->gameplay.player[0].gaugeType + g->config.play.random[0] * 10 + g->config.play.random[1] * 100 + g->config.play.dpflip * 1000;
 			}
 
-			bms.mybest.isIRDerivedRecord = false;
 			isNewRecord = true;
 		}
 
@@ -705,7 +704,6 @@ int SaveResult(game *g, sqlite3* sql) {
 		bms.mybest.op_history |= ConvertOptionHistory(g);
 
 		CheckMission(g);
-
 		UpdateScoreDB(bms.hash, &bms.mybest, sql, &g->sSelect.playerPassMD5);
 
 		if (isNewRecord) {
@@ -715,7 +713,7 @@ int SaveResult(game *g, sqlite3* sql) {
 		UpdatePlayerStat(&g->gameplay.playerstat, sql);
 		g->sSelect.oldIRrank = bms.mybest.IRranking;
 
-		if (!bms.mybest.isIRDerivedRecord && g->net.isOnline && g->is_starter == 0) {
+		if (g->net.isOnline && g->is_starter == 0) {
 			ErrorLogAdd("IRに登録しますか？\n");
 			g->net.myRanking.InitRanking();
 			if (g->gameplay.flag_longsound || g->gameplay.flag_0note) {

--- a/LR2/LR2_statplay.cpp
+++ b/LR2/LR2_statplay.cpp
@@ -684,7 +684,7 @@ int SaveResult(game *g, sqlite3* sql) {
 				bms.mybest.op_best = g->gameplay.player[0].gaugeType + g->config.play.random[0] * 10 + g->config.play.random[1] * 100 + g->config.play.dpflip * 1000;
 			}
 
-			bms.mybest.isIRDerivedRecord = 0;
+			bms.mybest.isIRDerivedRecord = false;
 			isNewRecord = true;
 		}
 

--- a/LR2/LR2_statplay.cpp
+++ b/LR2/LR2_statplay.cpp
@@ -684,7 +684,7 @@ int SaveResult(game *g, sqlite3* sql) {
 				bms.mybest.op_best = g->gameplay.player[0].gaugeType + g->config.play.random[0] * 10 + g->config.play.random[1] * 100 + g->config.play.dpflip * 1000;
 			}
 
-			bms.mybest.isIRDerivedRecord = false;
+			bms.mybest.isIRDerivedRecord = 0;
 			isNewRecord = true;
 		}
 

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -2621,7 +2621,8 @@ int ProcI_Select(game *g, sqlite3 *sql) {
 					}
 				}
 
-				bool hasIRDerivedRecord = g->sSelect.bmsList[bar].myIRbest.has_value();
+				const STATUS& mybest = g->sSelect.bmsList[bar].myIRbest.has_value() ?
+					*g->sSelect.bmsList[bar].myIRbest : g->sSelect.bmsList[bar].mybest;
 				if (g->sSelect.bmsList[bar].rivalRecord.stat_exscore < 1 || g->net.rankingData.showRanking != 0) {
 					if (g->net.rankingData.showRanking == 1) {
 						AddDrawingBuffer_Object(&g->skstruct.drBuf, &g->skstruct.src_BAR_LAMP[g->sSelect.bmsList[bar].rivalRecord.clear], &g->skstruct.dst_BAR_LAMP[g->sSelect.bmsList[bar].rivalRecord.clear], &g->timer1, dstd3.x, dstd3.y);
@@ -2629,24 +2630,16 @@ int ProcI_Select(game *g, sqlite3 *sql) {
 					else {
 						int t = g->config.play.battle;
 						if (g->config.play.battle == 3) {
-							t = hasIRDerivedRecord ?
-								g->sSelect.bmsList[bar].myIRbest.value().clear_sd :
-								g->sSelect.bmsList[bar].mybest.clear_sd;
+							t = mybest.clear_sd;
 						}
 						else if (g->config.play.battle == 2) {
-							t = hasIRDerivedRecord ?
-								g->sSelect.bmsList[bar].myIRbest.value().clear_db :
-								g->sSelect.bmsList[bar].mybest.clear_db;
+							t = mybest.clear_db;
 						}
 						else if (g->config.play.is_extra == 1) {
-							t = hasIRDerivedRecord ?
-								g->sSelect.bmsList[bar].myIRbest.value().clear_ex :
-								g->sSelect.bmsList[bar].mybest.clear_ex;
+							t = mybest.clear_ex;
 						}
 						else {
-							t = hasIRDerivedRecord ?
-								g->sSelect.bmsList[bar].myIRbest.value().clear :
-								g->sSelect.bmsList[bar].mybest.clear;
+							t = mybest.clear;
 						}
 						AddDrawingBuffer_Object(&g->skstruct.drBuf, &g->skstruct.src_BAR_LAMP[t], &g->skstruct.dst_BAR_LAMP[t], &g->timer1, dstd3.x, dstd3.y);
 					}
@@ -2655,24 +2648,16 @@ int ProcI_Select(game *g, sqlite3 *sql) {
 					int t = g->config.play.battle;
 					int r = 0;
 					if (g->config.play.battle == 3) {
-						t = hasIRDerivedRecord ?
-							g->sSelect.bmsList[bar].myIRbest.value().clear_sd :
-							g->sSelect.bmsList[bar].mybest.clear_sd;
+						t = mybest.clear_sd;
 					}
 					else if (g->config.play.battle == 2) {
-						t = hasIRDerivedRecord ?
-							g->sSelect.bmsList[bar].myIRbest.value().clear_db :
-							g->sSelect.bmsList[bar].mybest.clear_db;
+						t = mybest.clear_db;
 					}
 					else if (g->config.play.is_extra == 1) {
-						t = hasIRDerivedRecord ?
-							g->sSelect.bmsList[bar].myIRbest.value().clear_ex :
-							g->sSelect.bmsList[bar].mybest.clear_ex;
+						t = mybest.clear_ex;
 					}
 					else {
-						t = hasIRDerivedRecord ?
-							g->sSelect.bmsList[bar].myIRbest.value().clear :
-							g->sSelect.bmsList[bar].mybest.clear;
+						t = mybest.clear;
 						r = g->sSelect.bmsList[bar].rivalRecord.clear;
 					}
 					AddDrawingBuffer_Object(&g->skstruct.drBuf, &g->skstruct.src_BAR_MY_LAMP[t], &g->skstruct.dst_BAR_MY_LAMP[t], &g->timer1, dstd3.x, dstd3.y);

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -2621,6 +2621,7 @@ int ProcI_Select(game *g, sqlite3 *sql) {
 					}
 				}
 
+				bool hasIRDerivedRecord = g->sSelect.bmsList[bar].hasIRDerivedRecord;
 				if (g->sSelect.bmsList[bar].rivalRecord.stat_exscore < 1 || g->net.rankingData.showRanking != 0) {
 					if (g->net.rankingData.showRanking == 1) {
 						AddDrawingBuffer_Object(&g->skstruct.drBuf, &g->skstruct.src_BAR_LAMP[g->sSelect.bmsList[bar].rivalRecord.clear], &g->skstruct.dst_BAR_LAMP[g->sSelect.bmsList[bar].rivalRecord.clear], &g->timer1, dstd3.x, dstd3.y);
@@ -2628,16 +2629,24 @@ int ProcI_Select(game *g, sqlite3 *sql) {
 					else {
 						int t = g->config.play.battle;
 						if (g->config.play.battle == 3) {
-							t = g->sSelect.bmsList[bar].mybest.clear_sd;
+							t = hasIRDerivedRecord ?
+								g->sSelect.bmsList[bar].myIRbest.clear_sd :
+								g->sSelect.bmsList[bar].mybest.clear_sd;
 						}
 						else if (g->config.play.battle == 2) {
-							t = g->sSelect.bmsList[bar].mybest.clear_db;
+							t = hasIRDerivedRecord ?
+								g->sSelect.bmsList[bar].myIRbest.clear_db :
+								g->sSelect.bmsList[bar].mybest.clear_db;
 						}
 						else if (g->config.play.is_extra == 1) {
-							t = g->sSelect.bmsList[bar].mybest.clear_ex;
+							t = hasIRDerivedRecord ?
+								g->sSelect.bmsList[bar].myIRbest.clear_ex :
+								g->sSelect.bmsList[bar].mybest.clear_ex;
 						}
 						else {
-							t = g->sSelect.bmsList[bar].mybest.clear;
+							t = hasIRDerivedRecord ?
+								g->sSelect.bmsList[bar].myIRbest.clear :
+								g->sSelect.bmsList[bar].mybest.clear;
 						}
 						AddDrawingBuffer_Object(&g->skstruct.drBuf, &g->skstruct.src_BAR_LAMP[t], &g->skstruct.dst_BAR_LAMP[t], &g->timer1, dstd3.x, dstd3.y);
 					}
@@ -2646,16 +2655,24 @@ int ProcI_Select(game *g, sqlite3 *sql) {
 					int t = g->config.play.battle;
 					int r = 0;
 					if (g->config.play.battle == 3) {
-						t = g->sSelect.bmsList[bar].mybest.clear_sd;
+						t = hasIRDerivedRecord ?
+							g->sSelect.bmsList[bar].myIRbest.clear_sd :
+							g->sSelect.bmsList[bar].mybest.clear_sd;
 					}
 					else if (g->config.play.battle == 2) {
-						t = g->sSelect.bmsList[bar].mybest.clear_db;
+						t = hasIRDerivedRecord ?
+							g->sSelect.bmsList[bar].myIRbest.clear_db :
+							g->sSelect.bmsList[bar].mybest.clear_db;
 					}
 					else if (g->config.play.is_extra == 1) {
-						t = g->sSelect.bmsList[bar].mybest.clear_ex;
+						t = hasIRDerivedRecord ?
+							g->sSelect.bmsList[bar].myIRbest.clear_ex :
+							g->sSelect.bmsList[bar].mybest.clear_ex;
 					}
 					else {
-						t = g->sSelect.bmsList[bar].mybest.clear;
+						t = hasIRDerivedRecord ?
+							g->sSelect.bmsList[bar].myIRbest.clear :
+							g->sSelect.bmsList[bar].mybest.clear;
 						r = g->sSelect.bmsList[bar].rivalRecord.clear;
 					}
 					AddDrawingBuffer_Object(&g->skstruct.drBuf, &g->skstruct.src_BAR_MY_LAMP[t], &g->skstruct.dst_BAR_MY_LAMP[t], &g->timer1, dstd3.x, dstd3.y);

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -2621,7 +2621,7 @@ int ProcI_Select(game *g, sqlite3 *sql) {
 					}
 				}
 
-				bool hasIRDerivedRecord = g->sSelect.bmsList[bar].hasIRDerivedRecord;
+				bool hasIRDerivedRecord = g->sSelect.bmsList[bar].myIRbest.has_value();
 				if (g->sSelect.bmsList[bar].rivalRecord.stat_exscore < 1 || g->net.rankingData.showRanking != 0) {
 					if (g->net.rankingData.showRanking == 1) {
 						AddDrawingBuffer_Object(&g->skstruct.drBuf, &g->skstruct.src_BAR_LAMP[g->sSelect.bmsList[bar].rivalRecord.clear], &g->skstruct.dst_BAR_LAMP[g->sSelect.bmsList[bar].rivalRecord.clear], &g->timer1, dstd3.x, dstd3.y);
@@ -2630,22 +2630,22 @@ int ProcI_Select(game *g, sqlite3 *sql) {
 						int t = g->config.play.battle;
 						if (g->config.play.battle == 3) {
 							t = hasIRDerivedRecord ?
-								g->sSelect.bmsList[bar].myIRbest.clear_sd :
+								g->sSelect.bmsList[bar].myIRbest.value().clear_sd :
 								g->sSelect.bmsList[bar].mybest.clear_sd;
 						}
 						else if (g->config.play.battle == 2) {
 							t = hasIRDerivedRecord ?
-								g->sSelect.bmsList[bar].myIRbest.clear_db :
+								g->sSelect.bmsList[bar].myIRbest.value().clear_db :
 								g->sSelect.bmsList[bar].mybest.clear_db;
 						}
 						else if (g->config.play.is_extra == 1) {
 							t = hasIRDerivedRecord ?
-								g->sSelect.bmsList[bar].myIRbest.clear_ex :
+								g->sSelect.bmsList[bar].myIRbest.value().clear_ex :
 								g->sSelect.bmsList[bar].mybest.clear_ex;
 						}
 						else {
 							t = hasIRDerivedRecord ?
-								g->sSelect.bmsList[bar].myIRbest.clear :
+								g->sSelect.bmsList[bar].myIRbest.value().clear :
 								g->sSelect.bmsList[bar].mybest.clear;
 						}
 						AddDrawingBuffer_Object(&g->skstruct.drBuf, &g->skstruct.src_BAR_LAMP[t], &g->skstruct.dst_BAR_LAMP[t], &g->timer1, dstd3.x, dstd3.y);
@@ -2656,22 +2656,22 @@ int ProcI_Select(game *g, sqlite3 *sql) {
 					int r = 0;
 					if (g->config.play.battle == 3) {
 						t = hasIRDerivedRecord ?
-							g->sSelect.bmsList[bar].myIRbest.clear_sd :
+							g->sSelect.bmsList[bar].myIRbest.value().clear_sd :
 							g->sSelect.bmsList[bar].mybest.clear_sd;
 					}
 					else if (g->config.play.battle == 2) {
 						t = hasIRDerivedRecord ?
-							g->sSelect.bmsList[bar].myIRbest.clear_db :
+							g->sSelect.bmsList[bar].myIRbest.value().clear_db :
 							g->sSelect.bmsList[bar].mybest.clear_db;
 					}
 					else if (g->config.play.is_extra == 1) {
 						t = hasIRDerivedRecord ?
-							g->sSelect.bmsList[bar].myIRbest.clear_ex :
+							g->sSelect.bmsList[bar].myIRbest.value().clear_ex :
 							g->sSelect.bmsList[bar].mybest.clear_ex;
 					}
 					else {
 						t = hasIRDerivedRecord ?
-							g->sSelect.bmsList[bar].myIRbest.clear :
+							g->sSelect.bmsList[bar].myIRbest.value().clear :
 							g->sSelect.bmsList[bar].mybest.clear;
 						r = g->sSelect.bmsList[bar].rivalRecord.clear;
 					}

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1904,7 +1904,6 @@ int ProcS_Play(game *g, sqlite3* sql) {
 	}
 
 	g->gameplay.highScore.InitJudgeQueue();
-
 	if (g->gameplay.isGhostDisabled == 0) {
 		const SONGDATA& songData = g->sSelect.bmsList[g->sSelect.cur_song];
 

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1904,8 +1904,18 @@ int ProcS_Play(game *g, sqlite3* sql) {
 	}
 
 	g->gameplay.highScore.InitJudgeQueue();
+
 	if (g->gameplay.isGhostDisabled == 0) {
-		ReadGhostToScore(sql,md5,&g->gameplay.highScore);
+		const SONGDATA& songData = g->sSelect.bmsList[g->sSelect.cur_song];
+
+		// Use IR Ghost only if its exscore is higher.
+		if (songData.hasIRDerivedRecord &&
+			songData.myIRbest.stat_exscore > songData.mybest.stat_exscore) {
+			ReadIRGhostToScore(sql, md5, &g->gameplay.highScore);
+		}
+		else {
+			ReadGhostToScore(sql, md5, &g->gameplay.highScore);
+		}
 	}
 
 	if (g->net.rankingData.target_ID > 0 && g->net.isOnline) {

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1908,13 +1908,8 @@ int ProcS_Play(game *g, sqlite3* sql) {
 		const SONGDATA& songData = g->sSelect.bmsList[g->sSelect.cur_song];
 
 		// Use IR Ghost only if its exscore is higher.
-		if (songData.hasIRDerivedRecord &&
-			songData.myIRbest.stat_exscore > songData.mybest.stat_exscore) {
-			ReadIRGhostToScore(sql, md5, &g->gameplay.highScore);
-		}
-		else {
-			ReadGhostToScore(sql, md5, &g->gameplay.highScore);
-		}
+		bool useIRGhost = songData.hasIRDerivedRecord && songData.myIRbest.stat_exscore > songData.mybest.stat_exscore;
+		ReadGhostToScore(sql, md5, &g->gameplay.highScore, useIRGhost);
 	}
 
 	if (g->net.rankingData.target_ID > 0 && g->net.isOnline) {

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1907,8 +1907,7 @@ int ProcS_Play(game *g, sqlite3* sql) {
 	if (g->gameplay.isGhostDisabled == 0) {
 		const SONGDATA& songData = g->sSelect.bmsList[g->sSelect.cur_song];
 
-		// Use IR Ghost only if its exscore is higher.
-		bool useIRGhost = songData.hasIRDerivedRecord && songData.myIRbest.stat_exscore > songData.mybest.stat_exscore;
+		bool useIRGhost = songData.myIRbest.has_value() && songData.myIRbest.value().stat_exscore > songData.mybest.stat_exscore;
 		ReadGhostToScore(sql, md5, &g->gameplay.highScore, useIRGhost);
 	}
 

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -3,10 +3,10 @@
 #include <array>
 #include <future>
 #include <mutex>
+#include <optional>
 #include <thread>
 #include <unordered_map>
 #include <vector>
-#include <optional>
 
 #include "strclass.h"
 #include "LR2_customir.h"

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -461,10 +461,11 @@ struct SONGDATA { /* 712bytes */
 	int courseType{}; /* 0:expert 1:nonstop 2:class */
 	int courseIR{}; /* IR flag */
 	int grHandle{};
+
+	// If present, this will contain score for the song imported from the IR with best properties mixed in with 'mybest'.
+	std::optional<STATUS> myIRbest;
 	struct STATUS mybest;
-	struct STATUS myIRbest;
 	struct STATUS rivalRecord;
-	bool hasIRDerivedRecord{};
 };
 
 struct COURSESELECT {

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -6,6 +6,7 @@
 #include <thread>
 #include <unordered_map>
 #include <vector>
+#include <optional>
 
 #include "strclass.h"
 #include "LR2_customir.h"

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -409,6 +409,7 @@ struct STATUS {
 	char IRthreadEnd{};
 	int complete{};
 	int rseed{};
+	int isIRDerivedRecord{};
 };
 
 struct SONGDATA { /* 712bytes */

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -409,7 +409,6 @@ struct STATUS {
 	char IRthreadEnd{};
 	int complete{};
 	int rseed{};
-	bool isIRDerivedRecord{};
 };
 
 struct SONGDATA { /* 712bytes */
@@ -463,7 +462,9 @@ struct SONGDATA { /* 712bytes */
 	int courseIR{}; /* IR flag */
 	int grHandle{};
 	struct STATUS mybest;
+	struct STATUS myIRbest;
 	struct STATUS rivalRecord;
+	bool hasIRDerivedRecord{};
 };
 
 struct COURSESELECT {

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -409,7 +409,7 @@ struct STATUS {
 	char IRthreadEnd{};
 	int complete{};
 	int rseed{};
-	int isIRDerivedRecord{};
+	bool isIRDerivedRecord{};
 };
 
 struct SONGDATA { /* 712bytes */


### PR DESCRIPTION
## Changes
- LR2_songmanage separately loads IR records by using an `imported_score` table.
- `imported_score` and `score` tables share the same schema.
- `std::optional<STATUS> myIRbest` field added to `SONGDATA` structure.
- `myIRbest` is used exclusively for skin features; it does not impact the original score. (not sent to IR)
- `LR2_skinobject` displays the better stats of the two (mybest and myIRbest).

You can test the changes with this importer.
https://github.com/Unengine/BokutachiToOpenLR2ScoreImporter

[Here is my plan documentation](https://app.notion.com/p/IR-Record-to-LR2-player-db-38452d65f39a801fbf78e059a816f9df?source=copy_link)