### PR TITLE
feat: send ghost + play w/ ghost in battle

### DIFF
--- a/ExampleIR/ExternalIR.cpp
+++ b/ExampleIR/ExternalIR.cpp
@@ -87,6 +87,23 @@ static openlr2::GetStatus GetResultRank(const char* songHash, int /*reserved*/, 
     return openlr2::GetStatus::Ok;
 }
 
+static openlr2::GetStatus GetGhost(const IRScoreV1& score, int mode, int /*targetPlayerId*/, IRGhostResult& out) {
+    std::println(std::cout, "GetGhost({{.song.hash={}}}, mode={})", score.song.hash, mode);
+    out = {};
+    if (mode == 8) {
+        out.averageExscore = 800;
+        return openlr2::GetStatus::Ok;
+    }
+    out.displayName = "EXAMPLE";
+    out.ghostData = "#EXAMPLE,1,0,LXZ,"; // this ghost will do almost perfect play.
+    out.optionDigit1 = 1;
+    out.optionDigit2 = 0;
+    out.optionDigit3 = 0;
+    out.optionDigit4 = 0;
+    out.randomSeed = 0;
+    return openlr2::GetStatus::Ok;
+}
+
 extern "C" OLR2_IR_EXPORT void GetMethodTable(MethodTable& table) {
     // Fill out the pointers to methods you want to use. Leave them at nullptr if you don't want to use them.
     // As API gets updated, new methods may appear available at MethodTable, but old ones will never be removed or their
@@ -96,6 +113,7 @@ extern "C" OLR2_IR_EXPORT void GetMethodTable(MethodTable& table) {
     table.SendScoreV1 = &SendScore;
     table.GetResultRank = &GetResultRank;
     table.RestoreCachedRank = &RestoreCachedRank;
+    table.GetGhost = &GetGhost;
 }
 
 #ifdef _WIN32

--- a/ExampleIR/ExternalIR.cpp
+++ b/ExampleIR/ExternalIR.cpp
@@ -97,7 +97,7 @@ static openlr2::GetStatus GetGhost(const char* songHash, openlr2::GhostMode mode
         return openlr2::GetStatus::Ok;
     }
     out.displayName = "EXAMPLE";
-    out.ghostData = "#EXAMPLE,21,2179,LXZ,"; // this ghost will do almost perfect play.
+    out.ghostData = "LXZ"; // this ghost will do almost perfect play.
     out.gauge = openlr2::Gauge::Survival;
     out.randomOption = { openlr2::Random::Random, openlr2::Random::No };
     out.dpflip = false;

--- a/ExampleIR/ExternalIR.cpp
+++ b/ExampleIR/ExternalIR.cpp
@@ -98,11 +98,10 @@ static openlr2::GetStatus GetGhost(const char* songHash, openlr2::GhostMode mode
     }
     out.displayName = "EXAMPLE";
     out.ghostData = "#EXAMPLE,1,0,LXZ,"; // this ghost will do almost perfect play.
-    out.gaugeOption = 1;
-    out.p1randomOption = 0;
-    out.p2randomOption = 0;
-    out.dpFlipOption = 0;
-    out.randomSeed = 0;
+    out.gauge = openlr2::Gauge::Survival;
+    out.randomOption = { openlr2::Random::No, openlr2::Random::No };
+    out.dpflip = false;
+    out.rseed = 0;
     return openlr2::GetStatus::Ok;
 }
 

--- a/ExampleIR/ExternalIR.cpp
+++ b/ExampleIR/ExternalIR.cpp
@@ -101,7 +101,7 @@ static openlr2::GetStatus GetGhost(const char* songHash, openlr2::GhostMode mode
     out.gauge = openlr2::Gauge::Survival;
     out.randomOption = { openlr2::Random::No, openlr2::Random::No };
     out.dpflip = false;
-    out.rseed = 0;
+    out.rseed = 2179; // 1357246
     return openlr2::GetStatus::Ok;
 }
 

--- a/ExampleIR/ExternalIR.cpp
+++ b/ExampleIR/ExternalIR.cpp
@@ -89,7 +89,7 @@ static openlr2::GetStatus GetResultRank(const char* songHash, int /*reserved*/, 
     return openlr2::GetStatus::Ok;
 }
 
-static openlr2::GetStatus GetGhost(const char* songHash, openlr2::GhostMode mode, int /*targetPlayerId*/, IRGhostResult& out) {
+static openlr2::GetStatus GetGhost(const char* songHash, openlr2::GhostMode mode, int /*targetPlayerId*/, openlr2::IRGhostResult& out) {
     std::println(std::cout, "GetGhost({})", songHash);
     out = {};
     if (mode == openlr2::GhostMode::Average) {

--- a/ExampleIR/ExternalIR.cpp
+++ b/ExampleIR/ExternalIR.cpp
@@ -26,7 +26,7 @@ static bool Login() {
 }
 
 static SendScoreStatus SendScore(const IRScoreV1& score) {
-    std::println(std::cout, "SendScore({{.song.hash={}}})", score.song.hash);
+    std::println(std::cout, "SendScore({{.song.hash={}}}, ghostData={})", score.song.hash, score.ghostData);
     constexpr const char* lamps[6] = { "NO PLAY", "FAIL", "EASY", "NORMAL", "HARD", "FULL COMBO" };
     if (score.settings.assist[score.state.player]) return SendScoreStatus::Fail;
     std::string filename = std::format("score{}.txt", State::scoresSaved);
@@ -43,7 +43,8 @@ static SendScoreStatus SendScore(const IRScoreV1& score) {
         "fast: {}\n"
         "slow: {}\n"
         "cb: {}\n"
-        "lamp: {}\n",
+        "lamp: {}\n"
+        "ghostData: {}\n",
         score.song.hash, score.state.keymode, score.exscore,
         score.judgements_total.epg + score.judgements_total.lpg,
         score.judgements_total.egr + score.judgements_total.lgr,
@@ -51,7 +52,8 @@ static SendScoreStatus SendScore(const IRScoreV1& score) {
         score.judgements_total.ebd + score.judgements_total.lbd,
         score.judgements_total.epr + score.judgements_total.lpr,
         score.judgements_total.fast, score.judgements_total.slow, score.judgements_total.cb,
-        lamps[score.clearType]
+        lamps[score.clearType],
+        score.ghostData
     );
     std::ofstream dump(State::path / filename);
     dump << processedScore;

--- a/ExampleIR/ExternalIR.cpp
+++ b/ExampleIR/ExternalIR.cpp
@@ -96,10 +96,10 @@ static openlr2::GetStatus GetGhost(const IRScoreV1& score, int mode, int /*targe
     }
     out.displayName = "EXAMPLE";
     out.ghostData = "#EXAMPLE,1,0,LXZ,"; // this ghost will do almost perfect play.
-    out.optionDigit1 = 1;
-    out.optionDigit2 = 0;
-    out.optionDigit3 = 0;
-    out.optionDigit4 = 0;
+    out.gaugeOption = 1;
+    out.p1randomOption = 0;
+    out.p2randomOption = 0;
+    out.dpFlipOption = 0;
     out.randomSeed = 0;
     return openlr2::GetStatus::Ok;
 }

--- a/ExampleIR/ExternalIR.cpp
+++ b/ExampleIR/ExternalIR.cpp
@@ -26,7 +26,7 @@ static bool Login() {
 }
 
 static SendScoreStatus SendScore(const IRScoreV1& score) {
-    std::println(std::cout, "SendScore({{.song.hash={}}}, ghostData={})", score.song.hash, score.ghostData);
+    std::println(std::cout, "SendScore({{.song.hash={}}})", score.song.hash);
     constexpr const char* lamps[6] = { "NO PLAY", "FAIL", "EASY", "NORMAL", "HARD", "FULL COMBO" };
     if (score.settings.assist[score.state.player]) return SendScoreStatus::Fail;
     std::string filename = std::format("score{}.txt", State::scoresSaved);

--- a/ExampleIR/ExternalIR.cpp
+++ b/ExampleIR/ExternalIR.cpp
@@ -97,9 +97,9 @@ static openlr2::GetStatus GetGhost(const char* songHash, openlr2::GhostMode mode
         return openlr2::GetStatus::Ok;
     }
     out.displayName = "EXAMPLE";
-    out.ghostData = "#EXAMPLE,1,0,LXZ,"; // this ghost will do almost perfect play.
+    out.ghostData = "#EXAMPLE,21,2179,LXZ,"; // this ghost will do almost perfect play.
     out.gauge = openlr2::Gauge::Survival;
-    out.randomOption = { openlr2::Random::No, openlr2::Random::No };
+    out.randomOption = { openlr2::Random::Random, openlr2::Random::No };
     out.dpflip = false;
     out.rseed = 2179; // 1357246
     return openlr2::GetStatus::Ok;

--- a/ExampleIR/ExternalIR.cpp
+++ b/ExampleIR/ExternalIR.cpp
@@ -89,8 +89,8 @@ static openlr2::GetStatus GetResultRank(const char* songHash, int /*reserved*/, 
     return openlr2::GetStatus::Ok;
 }
 
-static openlr2::GetStatus GetGhost(const IRScoreV1& score, int mode, int /*targetPlayerId*/, IRGhostResult& out) {
-    std::println(std::cout, "GetGhost({{.song.hash={}}}, mode={})", score.song.hash, mode);
+static openlr2::GetStatus GetGhost(const char* songHash, int mode, int /*targetPlayerId*/, IRGhostResult& out) {
+    std::println(std::cout, "GetGhost({{}}, mode={})", songHash != nullptr ? songHash : "", mode);
     out = {};
     if (mode == 8) {
         out.averageExscore = 800;

--- a/ExampleIR/ExternalIR.cpp
+++ b/ExampleIR/ExternalIR.cpp
@@ -89,10 +89,10 @@ static openlr2::GetStatus GetResultRank(const char* songHash, int /*reserved*/, 
     return openlr2::GetStatus::Ok;
 }
 
-static openlr2::GetStatus GetGhost(const char* songHash, int mode, int /*targetPlayerId*/, IRGhostResult& out) {
-    std::println(std::cout, "GetGhost({{}}, mode={})", songHash != nullptr ? songHash : "", mode);
+static openlr2::GetStatus GetGhost(const char* songHash, openlr2::GhostMode mode, int /*targetPlayerId*/, IRGhostResult& out) {
+    std::println(std::cout, "GetGhost({})", songHash);
     out = {};
-    if (mode == 8) {
+    if (mode == openlr2::GhostMode::Average) {
         out.averageExscore = 800;
         return openlr2::GetStatus::Ok;
     }

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -722,6 +722,7 @@ int InitGameplay_retry(gameplay *gp, AUDIO *snd, game *g) {
 	gp->lastMissTime = 0;
 	gp->misslayerTime[0] = 0;
 	gp->misslayerTime[1] = 0;
+	gp->resultGhostForIr.clear();
 	gp->p1Score.InitJudgeQueue();
 	gp->p1Score.ResetJudgeQueue(gp->player[0].totalnotes * 2);
 	gp->fxChangeInRecording = false;
@@ -4127,6 +4128,7 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 		}
 	}
 
+	gp->resultGhostForIr.clear();
 	gp->p1Score.InitJudgeQueue();
 	gp->p1Score.ResetJudgeQueue(gp->player[0].totalnotes * 2);
 	gp->BPM = gp->BPM_fix;

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -269,9 +269,11 @@ bool CUSTOMIR_MANAGER::TryGetTargetInfo(game& g, CSTR songmd5, int mode, CSTR* o
 	case openlr2::GetStatus::Ok:
 		break;
 	case openlr2::GetStatus::Retry:
+		OverlayNotification("'%s' failed to get ghost data - ignoring retry\n", ir->Name().c_str());
 		return false;
 	case openlr2::GetStatus::Fail:
-		return false;
+		OverlayNotification("'%s' failed to get ghost data\n", ir->Name().c_str());
+	return false;
 	}
 
 	if (mode == 8) {

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -284,10 +284,10 @@ bool CUSTOMIR_MANAGER::TryGetTargetInfo(game& g, CSTR songmd5, int mode, CSTR* o
 	*oName = result.displayName.c_str();
 	oData->fillzero();
 	if (!result.ghostData.empty()) oData->add(result.ghostData.c_str());
-	*oDigit1 = result.optionDigit1;
-	*oDigit2 = result.optionDigit2;
-	*oDigit3 = result.optionDigit3;
-	*oDigit4 = result.optionDigit4;
+	*oDigit1 = result.gaugeOption;
+	*oDigit2 = result.p1randomOption;
+	*oDigit3 = result.p2randomOption;
+	*oDigit4 = result.dpFlipOption;
 	*oSeed = result.randomSeed;
 	return true;
 }

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -5,12 +5,14 @@
 #include "structure.h"
 
 #include <algorithm>
+#include <atomic>
 #include <array>
 #include <chrono>
 #include <cmath>
 #include <cstring>
 #include <filesystem>
 #include <future>
+#include <memory>
 #include <optional>
 #include <ranges>
 #include <string>
@@ -168,25 +170,36 @@ CUSTOMIR_MANAGER::~CUSTOMIR_MANAGER() {
 	}
 }
 
-static void SendScoreWithBlockingRetry(CustomIR& ir, const IRScoreV1& scoreV1) {
+static void SendScoreWithBlockingRetry(CustomIR& ir, const IRScoreV1& scoreV1, game* gamePtr, std::shared_ptr<std::atomic<int>> sendScorePending) {
 	constexpr int tryMax = 6;
 	int tryCount = 1;
-	while (tryCount <= tryMax) {
+	bool finished = false;
+	while (!finished && tryCount <= tryMax) {
 		switch (ir.SendScore(scoreV1)) {
 		case SendScoreStatus::Fail:
 			OverlayNotification("'%s' failed to submit score\n", ir.Name().c_str());
-			return;
+			finished = true;
+			break;
 		case SendScoreStatus::Ok:
-			return;
+			finished = true;
+			break;
 		case SendScoreStatus::Retry:
 			std::this_thread::sleep_for(std::chrono::seconds(static_cast<int>(std::pow(4, tryCount))));
 			tryCount++;
 			break;
 		}
 	}
-	OverlayNotification("'%s' failed to submit score after %d attempts\n", ir.Name().c_str(), tryCount);
+	if (!finished) {
+		OverlayNotification("'%s' failed to submit score after %d attempts\n", ir.Name().c_str(), tryCount);
+	}
+	if (gamePtr == nullptr || sendScorePending == nullptr) {
+		return;
+	}
+	if (sendScorePending->fetch_sub(1) == 1) {
+		gamePtr->gameplay.p1Score.InitJudgeQueue();
+	}
 }
-static void SendScoreMultiplexed(std::vector<std::future<void>>& mSendThreads, const IRScoreV1& scoreV1, std::vector<std::shared_ptr<CustomIR>> irs) {
+static void SendScoreMultiplexed(std::vector<std::future<void>>& mSendThreads, const IRScoreV1& scoreV1, std::vector<std::shared_ptr<CustomIR>> irs, game* gamePtr, std::shared_ptr<std::atomic<int>> sendScorePending) {
 	std::vector<int> finishedThreads;
 	for (const auto& [i, it] : std::views::enumerate(mSendThreads)) {
 		if (it.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready) {
@@ -203,9 +216,13 @@ static void SendScoreMultiplexed(std::vector<std::future<void>>& mSendThreads, c
 	for (const auto& ir : irs) {
 		mSendThreads.push_back(std::async(
 					std::launch::async,
-					[](std::shared_ptr<CustomIR> ir, IRScoreV1 score){ SendScoreWithBlockingRetry(*ir, score); },
+					[](std::shared_ptr<CustomIR> ir, IRScoreV1 score, game* gamePtr, std::shared_ptr<std::atomic<int>> sendScorePending) {
+						SendScoreWithBlockingRetry(*ir, score, gamePtr, sendScorePending);
+					},
 					ir,
-					scoreV1));
+					scoreV1,
+					gamePtr,
+					sendScorePending));
 	}
 }
 
@@ -646,8 +663,8 @@ std::optional<openlr2::IRRankResult> CUSTOMIR_MANAGER::RestoreCachedRank(const c
 	abort(); // unreachable
 }
 
-static std::optional<openlr2::IRRankResult> ResultIrAsync(std::shared_ptr<CustomIR> ir, IRScoreV1 score) {
-	SendScoreWithBlockingRetry(*ir, score);
+static std::optional<openlr2::IRRankResult> ResultIrAsync(std::shared_ptr<CustomIR> ir, IRScoreV1 score, game* gamePtr, std::shared_ptr<std::atomic<int>> sendScorePending) {
+	SendScoreWithBlockingRetry(*ir, score, gamePtr, sendScorePending);
 
 	std::optional<openlr2::IRRankResult> out{ openlr2::IRRankResult{} };
 	switch (ir->GetResultRank(score.song.hash.c_str(), *out)) {
@@ -666,6 +683,8 @@ void CUSTOMIR_MANAGER::BeginResultIr(game& game, sqlite3* sql, int player) {
 		return;
 	}
 
+	const auto irIt = std::ranges::find(mModules, mDisplayIr, &CustomIR::Name);
+	auto sendScorePending = std::make_shared<std::atomic<int>>(static_cast<int>(mModules.size()));
 	IRScoreInternal internal{ game, sql, player };
 	IRScoreV1 scoreV1;
 	internal.MakeScoreV1(scoreV1);
@@ -674,9 +693,10 @@ void CUSTOMIR_MANAGER::BeginResultIr(game& game, sqlite3* sql, int player) {
 			mSendThreads, scoreV1,
 			mModules | std::views::filter([&](const std::shared_ptr<CustomIR> &module) {
 				return module->Name() != mDisplayIr;
-				}) | std::ranges::to<std::vector>());
+				}) | std::ranges::to<std::vector>(),
+			&game,
+			sendScorePending);
 
-	const auto irIt = std::ranges::find(mModules, mDisplayIr, &CustomIR::Name);
 	if (irIt == mModules.end()) {
 		return;
 	}
@@ -684,7 +704,7 @@ void CUSTOMIR_MANAGER::BeginResultIr(game& game, sqlite3* sql, int player) {
 		ErrorLogAdd("BUG: we have an unexpected mResultIrFuture");
 		mResultIrFuture.get();
 	}
-	mResultIrFuture = std::async(std::launch::async, &ResultIrAsync, *irIt, scoreV1);
+	mResultIrFuture = std::async(std::launch::async, &ResultIrAsync, *irIt, scoreV1, &game, sendScorePending);
 }
 
 static void fill_ranking_player_from_customir(RANKINGPLAYER& dest, const openlr2::IRRankPlayer& src, int ranking) {

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -5,7 +5,6 @@
 #include "structure.h"
 
 #include <algorithm>
-#include <atomic>
 #include <array>
 #include <chrono>
 #include <cmath>
@@ -170,7 +169,7 @@ CUSTOMIR_MANAGER::~CUSTOMIR_MANAGER() {
 	}
 }
 
-static void SendScoreWithBlockingRetry(CustomIR& ir, const IRScoreV1& scoreV1, game* gamePtr, std::shared_ptr<std::atomic<int>> sendScorePending) {
+static void SendScoreWithBlockingRetry(CustomIR& ir, const IRScoreV1& scoreV1) {
 	constexpr int tryMax = 6;
 	int tryCount = 1;
 	bool finished = false;
@@ -192,14 +191,8 @@ static void SendScoreWithBlockingRetry(CustomIR& ir, const IRScoreV1& scoreV1, g
 	if (!finished) {
 		OverlayNotification("'%s' failed to submit score after %d attempts\n", ir.Name().c_str(), tryCount);
 	}
-	if (gamePtr == nullptr || sendScorePending == nullptr) {
-		return;
-	}
-	if (sendScorePending->fetch_sub(1) == 1) {
-		gamePtr->gameplay.p1Score.InitJudgeQueue();
-	}
 }
-static void SendScoreMultiplexed(std::vector<std::future<void>>& mSendThreads, const IRScoreV1& scoreV1, std::vector<std::shared_ptr<CustomIR>> irs, game* gamePtr, std::shared_ptr<std::atomic<int>> sendScorePending) {
+static void SendScoreMultiplexed(std::vector<std::future<void>>& mSendThreads, const IRScoreV1& scoreV1, std::vector<std::shared_ptr<CustomIR>> irs) {
 	std::vector<int> finishedThreads;
 	for (const auto& [i, it] : std::views::enumerate(mSendThreads)) {
 		if (it.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready) {
@@ -216,13 +209,11 @@ static void SendScoreMultiplexed(std::vector<std::future<void>>& mSendThreads, c
 	for (const auto& ir : irs) {
 		mSendThreads.push_back(std::async(
 					std::launch::async,
-					[](std::shared_ptr<CustomIR> ir, IRScoreV1 score, game* gamePtr, std::shared_ptr<std::atomic<int>> sendScorePending) {
-						SendScoreWithBlockingRetry(*ir, score, gamePtr, sendScorePending);
+					[](std::shared_ptr<CustomIR> ir, IRScoreV1 score) {
+						SendScoreWithBlockingRetry(*ir, score);
 					},
 					ir,
-					scoreV1,
-					gamePtr,
-					sendScorePending));
+					scoreV1));
 	}
 }
 
@@ -663,8 +654,8 @@ std::optional<openlr2::IRRankResult> CUSTOMIR_MANAGER::RestoreCachedRank(const c
 	abort(); // unreachable
 }
 
-static std::optional<openlr2::IRRankResult> ResultIrAsync(std::shared_ptr<CustomIR> ir, IRScoreV1 score, game* gamePtr, std::shared_ptr<std::atomic<int>> sendScorePending) {
-	SendScoreWithBlockingRetry(*ir, score, gamePtr, sendScorePending);
+static std::optional<openlr2::IRRankResult> ResultIrAsync(std::shared_ptr<CustomIR> ir, IRScoreV1 score) {
+	SendScoreWithBlockingRetry(*ir, score);
 
 	std::optional<openlr2::IRRankResult> out{ openlr2::IRRankResult{} };
 	switch (ir->GetResultRank(score.song.hash.c_str(), *out)) {
@@ -684,18 +675,18 @@ void CUSTOMIR_MANAGER::BeginResultIr(game& game, sqlite3* sql, int player) {
 	}
 
 	const auto irIt = std::ranges::find(mModules, mDisplayIr, &CustomIR::Name);
-	auto sendScorePending = std::make_shared<std::atomic<int>>(static_cast<int>(mModules.size()));
 	IRScoreInternal internal{ game, sql, player };
 	IRScoreV1 scoreV1;
 	internal.MakeScoreV1(scoreV1);
+	if (player == 0) {
+		game.gameplay.p1Score.InitJudgeQueue();
+	}
 
 	SendScoreMultiplexed(
 			mSendThreads, scoreV1,
 			mModules | std::views::filter([&](const std::shared_ptr<CustomIR> &module) {
 				return module->Name() != mDisplayIr;
-				}) | std::ranges::to<std::vector>(),
-			&game,
-			sendScorePending);
+				}) | std::ranges::to<std::vector>());
 
 	if (irIt == mModules.end()) {
 		return;
@@ -704,7 +695,7 @@ void CUSTOMIR_MANAGER::BeginResultIr(game& game, sqlite3* sql, int player) {
 		ErrorLogAdd("BUG: we have an unexpected mResultIrFuture");
 		mResultIrFuture.get();
 	}
-	mResultIrFuture = std::async(std::launch::async, &ResultIrAsync, *irIt, scoreV1, &game, sendScorePending);
+	mResultIrFuture = std::async(std::launch::async, &ResultIrAsync, *irIt, scoreV1);
 }
 
 static void fill_ranking_player_from_customir(RANKINGPLAYER& dest, const openlr2::IRRankPlayer& src, int ranking) {

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -269,11 +269,11 @@ bool CUSTOMIR_MANAGER::TryGetTargetInfo(game& g, CSTR songmd5, int mode, CSTR* o
 	case openlr2::GetStatus::Ok:
 		break;
 	case openlr2::GetStatus::Retry:
-		OverlayNotification("'%s' failed to get ghost data - ignoring retry\n", irIt->Name().c_str());
+		OverlayNotification("'%s' failed to get ghost data - ignoring retry\n", (*irIt)->Name().c_str());
 		return false;
 	case openlr2::GetStatus::Fail:
-		OverlayNotification("'%s' failed to get ghost data\n", irIt->Name().c_str());
-	return false;
+		OverlayNotification("'%s' failed to get ghost data\n", (*irIt)->Name().c_str());
+		return false;
 	}
 
 	if (mode == 8) {

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -80,7 +80,7 @@ public:
 	SendScoreStatus SendScore(const IRScoreV1& score);
 	openlr2::GetStatus GetResultRank(const char* songHash, openlr2::IRRankResult& out);
 	openlr2::GetStatus RestoreCachedRank(const char* songHash, openlr2::IRRankResult& out);
-	openlr2::GetStatus GetGhost(const char* songHash, int mode, int targetPlayerId, IRGhostResult& out);
+	openlr2::GetStatus GetGhost(const char* songHash, openlr2::GhostMode mode, int targetPlayerId, IRGhostResult& out);
 
 	[[nodiscard]] const std::string& Name() const { return mName; };
 private:
@@ -153,7 +153,7 @@ openlr2::GetStatus CustomIR::RestoreCachedRank(const char* songHash, openlr2::IR
 	return mMethods.RestoreCachedRank(songHash, -1, out);
 }
 
-openlr2::GetStatus CustomIR::GetGhost(const char* songHash, int mode, int targetPlayerId, IRGhostResult& out) {
+openlr2::GetStatus CustomIR::GetGhost(const char* songHash, openlr2::GhostMode mode, int targetPlayerId, IRGhostResult& out) {
 	if (mMethods.GetGhost == nullptr) return openlr2::GetStatus::Fail;
 	return mMethods.GetGhost(songHash, mode, targetPlayerId, out);
 }
@@ -261,10 +261,18 @@ bool CUSTOMIR_MANAGER::TryGetTargetInfo(game& g, CSTR songmd5, int mode, CSTR* o
 	const auto irIt = std::ranges::find(mModules, mDisplayIr, &CustomIR::Name);
 	if (irIt == mModules.end()) { return false; }
 
+	openlr2::GhostMode ghostMode = openlr2::GhostMode::Top; // default is "top"; as dream-pro default
+	switch (mode) {
+	case 0: ghostMode = openlr2::GhostMode::Target; break;
+	case 6: ghostMode = openlr2::GhostMode::Top; break;
+	case 7: ghostMode = openlr2::GhostMode::Next; break;
+	case 8: ghostMode = openlr2::GhostMode::Average; break;
+	}
+
 	const char* songHash = songmd5.body;
 
 	IRGhostResult result{};
-	switch ((*irIt)->GetGhost(songHash, mode, g.net.rankingData.target_ID, result)) {
+	switch ((*irIt)->GetGhost(songHash, ghostMode, g.net.rankingData.target_ID, result)) {
 	case openlr2::GetStatus::Ok:
 		break;
 	case openlr2::GetStatus::Retry:
@@ -275,7 +283,7 @@ bool CUSTOMIR_MANAGER::TryGetTargetInfo(game& g, CSTR songmd5, int mode, CSTR* o
 		return false;
 	}
 
-	if (mode == 8) {
+	if (ghostMode == openlr2::GhostMode::Average) {
 		*oName = "AVERAGE";
 		*oExscore = result.averageExscore;
 		return result.averageExscore > 0;

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -80,7 +80,7 @@ public:
 	SendScoreStatus SendScore(const IRScoreV1& score) const;
 	openlr2::GetStatus GetResultRank(const char* songHash, openlr2::IRRankResult& out);
 	openlr2::GetStatus RestoreCachedRank(const char* songHash, openlr2::IRRankResult& out);
-	openlr2::GetStatus FetchIrGhost(const IRScoreV1& score, int mode, int targetPlayerId, IRGhostResult& out) const;
+	openlr2::GetStatus GetGhost(const IRScoreV1& score, int mode, int targetPlayerId, IRGhostResult& out) const;
 
 	[[nodiscard]] const std::string& Name() const { return mName; };
 private:
@@ -153,7 +153,7 @@ openlr2::GetStatus CustomIR::RestoreCachedRank(const char* songHash, openlr2::IR
 	return mMethods.RestoreCachedRank(songHash, -1, out);
 }
 
-openlr2::GetStatus CustomIR::FetchIrGhost(const IRScoreV1& score, int mode, int targetPlayerId, IRGhostResult& out) const {
+openlr2::GetStatus CustomIR::GetGhost(const IRScoreV1& score, int mode, int targetPlayerId, IRGhostResult& out) const {
 	if (mMethods.GetGhost == nullptr) return openlr2::GetStatus::Fail;
 	return mMethods.GetGhost(score, mode, targetPlayerId, out);
 }
@@ -265,7 +265,7 @@ bool CUSTOMIR_MANAGER::TryGetTargetInfo(game& g, CSTR songmd5, int mode, CSTR* o
 	score.song.hash = songmd5.body != nullptr ? songmd5.body : "";
 
 	IRGhostResult result{};
-	switch ((*irIt)->FetchIrGhost(score, mode, g.net.rankingData.target_ID, result)) {
+	switch ((*irIt)->GetGhost(score, mode, g.net.rankingData.target_ID, result)) {
 	case openlr2::GetStatus::Ok:
 		break;
 	case openlr2::GetStatus::Retry:

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -80,6 +80,7 @@ public:
 	SendScoreStatus SendScore(const IRScoreV1& score);
 	openlr2::GetStatus GetResultRank(const char* songHash, openlr2::IRRankResult& out);
 	openlr2::GetStatus RestoreCachedRank(const char* songHash, openlr2::IRRankResult& out);
+	openlr2::GetStatus FetchIrGhost(const IRScoreV1& score, int mode, int targetPlayerId, IRGhostResult& out) const;
 
 	[[nodiscard]] const std::string& Name() const { return mName; };
 private:
@@ -150,6 +151,11 @@ openlr2::GetStatus CustomIR::GetResultRank(const char* songHash, openlr2::IRRank
 openlr2::GetStatus CustomIR::RestoreCachedRank(const char* songHash, openlr2::IRRankResult& out) {
 	if (mMethods.RestoreCachedRank == nullptr) return openlr2::GetStatus::Fail;
 	return mMethods.RestoreCachedRank(songHash, -1, out);
+}
+
+openlr2::GetStatus CustomIR::FetchIrGhost(const IRScoreV1& score, int mode, int targetPlayerId, IRGhostResult& out) const {
+	if (mMethods.GetGhost == nullptr) return openlr2::GetStatus::Fail;
+	return mMethods.GetGhost(score, mode, targetPlayerId, out);
 }
 
 CUSTOMIR_MANAGER::~CUSTOMIR_MANAGER() {
@@ -249,6 +255,39 @@ void CUSTOMIR_MANAGER::Login() {
 			OverlayNotification("[%s] Failed to log in\n", ir->Name().c_str());
 		}
 	}
+}
+
+bool CUSTOMIR_MANAGER::TryGetTargetInfo(game& g, CSTR songmd5, int mode, CSTR* oData, CSTR* oName, int* oDigit1, int* oDigit2, int* oDigit3, int* oDigit4, int* oSeed, int* oExscore) const {
+	const auto irIt = std::ranges::find(mModules, mDisplayIr, &CustomIR::Name);
+	if (irIt == mModules.end()) { return false; }
+
+	IRScoreV1 score{};
+	score.song.hash = songmd5.body != nullptr ? songmd5.body : "";
+
+	IRGhostResult result{};
+	switch ((*irIt)->FetchIrGhost(score, mode, g.net.rankingData.target_ID, result)) {
+	case openlr2::GetStatus::Ok:
+		break;
+	case openlr2::GetStatus::Retry:
+		return false;
+	case openlr2::GetStatus::Fail:
+		return false;
+	}
+
+	if (mode == 8) {
+		*oName = "AVERAGE";
+		*oExscore = result.averageExscore;
+		return result.averageExscore > 0;
+	}
+	*oName = result.displayName.c_str();
+	oData->fillzero();
+	if (!result.ghostData.empty()) oData->add(result.ghostData.c_str());
+	*oDigit1 = result.optionDigit1;
+	*oDigit2 = result.optionDigit2;
+	*oDigit3 = result.optionDigit3;
+	*oDigit4 = result.optionDigit4;
+	*oSeed = result.randomSeed;
+	return true;
 }
 
 struct IRScoreInternal {

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -11,7 +11,6 @@
 #include <cstring>
 #include <filesystem>
 #include <future>
-#include <memory>
 #include <optional>
 #include <ranges>
 #include <string>

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -172,25 +172,20 @@ CUSTOMIR_MANAGER::~CUSTOMIR_MANAGER() {
 static void SendScoreWithBlockingRetry(CustomIR& ir, const IRScoreV1& scoreV1) {
 	constexpr int tryMax = 6;
 	int tryCount = 1;
-	bool finished = false;
-	while (!finished && tryCount <= tryMax) {
+	while (tryCount <= tryMax) {
 		switch (ir.SendScore(scoreV1)) {
 		case SendScoreStatus::Fail:
 			OverlayNotification("'%s' failed to submit score\n", ir.Name().c_str());
-			finished = true;
-			break;
+			return;
 		case SendScoreStatus::Ok:
-			finished = true;
-			break;
+			return;
 		case SendScoreStatus::Retry:
 			std::this_thread::sleep_for(std::chrono::seconds(static_cast<int>(std::pow(4, tryCount))));
 			tryCount++;
 			break;
 		}
 	}
-	if (!finished) {
-		OverlayNotification("'%s' failed to submit score after %d attempts\n", ir.Name().c_str(), tryCount);
-	}
+	OverlayNotification("'%s' failed to submit score after %d attempts\n", ir.Name().c_str(), tryCount);
 }
 static void SendScoreMultiplexed(std::vector<std::future<void>>& mSendThreads, const IRScoreV1& scoreV1, std::vector<std::shared_ptr<CustomIR>> irs) {
 	std::vector<int> finishedThreads;

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -269,10 +269,10 @@ bool CUSTOMIR_MANAGER::TryGetTargetInfo(game& g, CSTR songmd5, int mode, CSTR* o
 	case openlr2::GetStatus::Ok:
 		break;
 	case openlr2::GetStatus::Retry:
-		OverlayNotification("'%s' failed to get ghost data - ignoring retry\n", ir->Name().c_str());
+		OverlayNotification("'%s' failed to get ghost data - ignoring retry\n", irIt->Name().c_str());
 		return false;
 	case openlr2::GetStatus::Fail:
-		OverlayNotification("'%s' failed to get ghost data\n", ir->Name().c_str());
+		OverlayNotification("'%s' failed to get ghost data\n", irIt->Name().c_str());
 	return false;
 	}
 

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -1,7 +1,6 @@
 #include "LR2_customir.h"
 
 #include "LR2_customir_api.h"
-#include "LR2_ghost.h"
 #include "LR2_songmanage.h"
 #include "structure.h"
 
@@ -623,12 +622,6 @@ IRScoreInternal::IRScoreInternal(game& game, sqlite3* sql, int _player) {
 		CSTR ghostCstr = gameplay.p1Score.EncodeGhostData();
 		if (ghostCstr.length() > 0 && ghostCstr.isDiff("GHOST_ERROR") != 0) {
 			ghostData = ghostCstr.body;
-		}
-		else if (sql != nullptr) {
-			CSTR dbGhost = ReadGhost(sql, curSong.hash);
-			if (dbGhost.length() > 0) {
-				ghostData = dbGhost.body;
-			}
 		}
 	}
 }

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -1,6 +1,7 @@
 #include "LR2_customir.h"
 
 #include "LR2_customir_api.h"
+#include "LR2_ghost.h"
 #include "LR2_songmanage.h"
 #include "structure.h"
 
@@ -77,7 +78,7 @@ public:
 	CustomIR(const std::filesystem::path& directory);
 	bool Initialize();
 	bool Login();
-	SendScoreStatus SendScore(const IRScoreV1& score);
+	SendScoreStatus SendScore(const IRScoreV1& score) const;
 	openlr2::GetStatus GetResultRank(const char* songHash, openlr2::IRRankResult& out);
 	openlr2::GetStatus RestoreCachedRank(const char* songHash, openlr2::IRRankResult& out);
 	openlr2::GetStatus FetchIrGhost(const IRScoreV1& score, int mode, int targetPlayerId, IRGhostResult& out) const;
@@ -138,7 +139,7 @@ bool CustomIR::Login() {
 	return mMethods.LoginV1();
 }
 
-SendScoreStatus CustomIR::SendScore(const IRScoreV1& score) {
+SendScoreStatus CustomIR::SendScore(const IRScoreV1& score) const {
 	if (mMethods.SendScoreV1 == nullptr) return SendScoreStatus::Fail;
 	return mMethods.SendScoreV1(score);
 }
@@ -378,6 +379,7 @@ struct IRScoreInternal {
 	double rate{};
 	int clearType{};
 	int inputType{};
+	std::string ghostData{};
 	struct GRAPHDATA {
 		std::array<std::array<int, 1000>, 6> hp{};
 		std::array<int, 1000> combo{};
@@ -481,6 +483,7 @@ void IRScoreInternal::MakeScoreV1(IRScoreV1& scoreOut) const {
 	scoreOut.graphs.combo = graphs.combo;
 	scoreOut.graphs.exscore = graphs.exscore;
 	scoreOut.graphs.rate = graphs.rate;
+	scoreOut.ghostData = ghostData;
 }
 
 IRScoreInternal::IRScoreInternal(game& game, sqlite3* sql, int _player) {
@@ -614,6 +617,19 @@ IRScoreInternal::IRScoreInternal(game& game, sqlite3* sql, int _player) {
 		memcpy(graphs.combo.data(), statgraph.combo, graphs.combo.size());
 		memcpy(graphs.exscore.data(), statgraph.exscore, graphs.exscore.size());
 		memcpy(graphs.rate.data(), gameplay.rategraph[_player].val, graphs.rate.size());
+	}
+
+	if (!courseScore && _player == 0) {
+		CSTR ghostCstr = gameplay.p1Score.EncodeGhostData();
+		if (ghostCstr.length() > 0 && ghostCstr.isDiff("GHOST_ERROR") != 0) {
+			ghostData = ghostCstr.body;
+		}
+		else if (sql != nullptr) {
+			CSTR dbGhost = ReadGhost(sql, curSong.hash);
+			if (dbGhost.length() > 0) {
+				ghostData = dbGhost.body;
+			}
+		}
 	}
 }
 

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -257,7 +257,7 @@ void CUSTOMIR_MANAGER::Login() {
 	}
 }
 
-std::optional<openlr2::IRGhostResult> CUSTOMIR_MANAGER::TryGetTargetInfo(CSTR songmd5, int mode, int targetPlayerId) const {
+std::optional<openlr2::IRGhostResult> CUSTOMIR_MANAGER::TryGetTargetInfo(const char* songmd5, int mode, int targetPlayerId) const {
 	const auto irIt = std::ranges::find(mModules, mDisplayIr, &CustomIR::Name);
 	if (irIt == mModules.end()) { return std::nullopt; }
 
@@ -272,10 +272,8 @@ std::optional<openlr2::IRGhostResult> CUSTOMIR_MANAGER::TryGetTargetInfo(CSTR so
 		return std::nullopt;
 	}
 
-	const char* songHash = songmd5.body;
-
 	openlr2::IRGhostResult result{};
-	switch ((*irIt)->GetGhost(songHash, ghostMode, targetPlayerId, result)) {
+	switch ((*irIt)->GetGhost(songmd5, ghostMode, targetPlayerId, result)) {
 	case openlr2::GetStatus::Ok:
 		break;
 	case openlr2::GetStatus::Retry:

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -261,6 +261,7 @@ std::optional<IRGhostResult> CUSTOMIR_MANAGER::TryGetTargetInfo(CSTR songmd5, in
 	const auto irIt = std::ranges::find(mModules, mDisplayIr, &CustomIR::Name);
 	if (irIt == mModules.end()) { return std::nullopt; }
 
+	openlr2::GhostMode ghostMode{};
 	switch (mode) {
 	case 0: ghostMode = openlr2::GhostMode::Target; break;
 	case 6: ghostMode = openlr2::GhostMode::Top; break;
@@ -268,7 +269,7 @@ std::optional<IRGhostResult> CUSTOMIR_MANAGER::TryGetTargetInfo(CSTR songmd5, in
 	case 8: ghostMode = openlr2::GhostMode::Average; break;
 	default:
 		ErrorLogFmtAdd("Invalid ghost mode: %d\n", mode);
-		return false;
+		return std::nullopt;
 	}
 
 	const char* songHash = songmd5.body;

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -204,9 +204,7 @@ static void SendScoreMultiplexed(std::vector<std::future<void>>& mSendThreads, c
 	for (const auto& ir : irs) {
 		mSendThreads.push_back(std::async(
 					std::launch::async,
-					[](std::shared_ptr<CustomIR> ir, IRScoreV1 score) {
-						SendScoreWithBlockingRetry(*ir, score);
-					},
+					[](std::shared_ptr<CustomIR> ir, IRScoreV1 score){ SendScoreWithBlockingRetry(*ir, score); },
 					ir,
 					scoreV1));
 	}
@@ -669,7 +667,6 @@ void CUSTOMIR_MANAGER::BeginResultIr(game& game, sqlite3* sql, int player) {
 		return;
 	}
 
-	const auto irIt = std::ranges::find(mModules, mDisplayIr, &CustomIR::Name);
 	IRScoreInternal internal{ game, sql, player };
 	IRScoreV1 scoreV1;
 	internal.MakeScoreV1(scoreV1);
@@ -683,6 +680,7 @@ void CUSTOMIR_MANAGER::BeginResultIr(game& game, sqlite3* sql, int player) {
 				return module->Name() != mDisplayIr;
 				}) | std::ranges::to<std::vector>());
 
+	const auto irIt = std::ranges::find(mModules, mDisplayIr, &CustomIR::Name);
 	if (irIt == mModules.end()) {
 		return;
 	}

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -272,12 +272,14 @@ std::optional<openlr2::IRGhostResult> CUSTOMIR_MANAGER::TryGetTargetInfo(CSTR so
 		return std::nullopt;
 	}
 
-	const char* songHash = songmd5.body;
-
 	openlr2::IRGhostResult result{};
-	switch ((*irIt)->GetGhost(songHash, ghostMode, targetPlayerId, result)) {
+	switch ((*irIt)->GetGhost(songmd5.body, ghostMode, targetPlayerId, result)) {
 	case openlr2::GetStatus::Ok:
-		break;
+		if (ghostMode == openlr2::GhostMode::Average && result.averageExscore <= 0) {
+			ErrorLogAdd("CustomIR BUG: invalid averageExscore\n");
+			return std::nullopt;
+		}
+		return result;
 	case openlr2::GetStatus::Retry:
 		OverlayNotification("'%s' failed to get ghost data - ignoring retry\n", (*irIt)->Name().c_str());
 		return std::nullopt;
@@ -285,11 +287,9 @@ std::optional<openlr2::IRGhostResult> CUSTOMIR_MANAGER::TryGetTargetInfo(CSTR so
 		OverlayNotification("'%s' failed to get ghost data\n", (*irIt)->Name().c_str());
 		return std::nullopt;
 	}
-
-	if (ghostMode == openlr2::GhostMode::Average && result.averageExscore <= 0) {
-		return std::nullopt;
-	}
-	return result;
+	// TODO: remove 'abort()' from other handlers, logging an error and returning nothing instead. 
+	ErrorLogAdd("CustomIR BUG: invalid GetGhost return value\n");
+	return std::nullopt;
 }
 
 struct IRScoreInternal {

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -621,10 +621,7 @@ IRScoreInternal::IRScoreInternal(game& game, sqlite3* sql, int _player) {
 	}
 
 	if (!courseScore && _player == 0) {
-		CSTR ghostCstr = gameplay.p1Score.EncodeGhostData();
-		if (ghostCstr.length() > 0 && ghostCstr.isDiff("GHOST_ERROR") != 0) {
-			ghostData = ghostCstr.body;
-		}
+		ghostData = gameplay.resultGhostForIr;
 	}
 }
 
@@ -669,9 +666,6 @@ void CUSTOMIR_MANAGER::BeginResultIr(game& game, sqlite3* sql, int player) {
 	IRScoreInternal internal{ game, sql, player };
 	IRScoreV1 scoreV1;
 	internal.MakeScoreV1(scoreV1);
-	if (player == 0) {
-		game.gameplay.p1Score.InitJudgeQueue();
-	}
 
 	SendScoreMultiplexed(
 			mSendThreads, scoreV1,

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -257,9 +257,9 @@ void CUSTOMIR_MANAGER::Login() {
 	}
 }
 
-bool CUSTOMIR_MANAGER::TryGetTargetInfo(game& g, CSTR songmd5, int mode, CSTR* oData, CSTR* oName, int* oGaugeOption, int* oP1randomOption, int* oP2randomOption, int* oDpFlipOption, int* oRandomSeed, int* oExscore) const {
+std::optional<IRGhostResult> CUSTOMIR_MANAGER::TryGetTargetInfo(CSTR songmd5, int mode, int targetPlayerId) const {
 	const auto irIt = std::ranges::find(mModules, mDisplayIr, &CustomIR::Name);
-	if (irIt == mModules.end()) { return false; }
+	if (irIt == mModules.end()) { return std::nullopt; }
 
 	openlr2::GhostMode ghostMode = openlr2::GhostMode::Top; // default is "top"; as dream-pro default
 	switch (mode) {
@@ -272,31 +272,21 @@ bool CUSTOMIR_MANAGER::TryGetTargetInfo(game& g, CSTR songmd5, int mode, CSTR* o
 	const char* songHash = songmd5.body;
 
 	IRGhostResult result{};
-	switch ((*irIt)->GetGhost(songHash, ghostMode, g.net.rankingData.target_ID, result)) {
+	switch ((*irIt)->GetGhost(songHash, ghostMode, targetPlayerId, result)) {
 	case openlr2::GetStatus::Ok:
 		break;
 	case openlr2::GetStatus::Retry:
 		OverlayNotification("'%s' failed to get ghost data - ignoring retry\n", (*irIt)->Name().c_str());
-		return false;
+		return std::nullopt;
 	case openlr2::GetStatus::Fail:
 		OverlayNotification("'%s' failed to get ghost data\n", (*irIt)->Name().c_str());
-		return false;
+		return std::nullopt;
 	}
 
-	if (ghostMode == openlr2::GhostMode::Average) {
-		*oName = "AVERAGE";
-		*oExscore = result.averageExscore;
-		return result.averageExscore > 0;
+	if (ghostMode == openlr2::GhostMode::Average && result.averageExscore <= 0) {
+		return std::nullopt;
 	}
-	*oName = result.displayName.c_str();
-	oData->fillzero();
-	if (!result.ghostData.empty()) oData->add(result.ghostData.c_str());
-	*oGaugeOption = result.gaugeOption;
-	*oP1randomOption = result.p1randomOption;
-	*oP2randomOption = result.p2randomOption;
-	*oDpFlipOption = result.dpFlipOption;
-	*oRandomSeed = result.randomSeed;
-	return true;
+	return result;
 }
 
 struct IRScoreInternal {

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -261,12 +261,14 @@ std::optional<IRGhostResult> CUSTOMIR_MANAGER::TryGetTargetInfo(CSTR songmd5, in
 	const auto irIt = std::ranges::find(mModules, mDisplayIr, &CustomIR::Name);
 	if (irIt == mModules.end()) { return std::nullopt; }
 
-	openlr2::GhostMode ghostMode = openlr2::GhostMode::Top; // default is "top"; as dream-pro default
 	switch (mode) {
 	case 0: ghostMode = openlr2::GhostMode::Target; break;
 	case 6: ghostMode = openlr2::GhostMode::Top; break;
 	case 7: ghostMode = openlr2::GhostMode::Next; break;
 	case 8: ghostMode = openlr2::GhostMode::Average; break;
+	default:
+		ErrorLogFmtAdd("Invalid ghost mode: %d\n", mode);
+		return false;
 	}
 
 	const char* songHash = songmd5.body;

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -80,7 +80,7 @@ public:
 	SendScoreStatus SendScore(const IRScoreV1& score);
 	openlr2::GetStatus GetResultRank(const char* songHash, openlr2::IRRankResult& out);
 	openlr2::GetStatus RestoreCachedRank(const char* songHash, openlr2::IRRankResult& out);
-	openlr2::GetStatus GetGhost(const char* songHash, openlr2::GhostMode mode, int targetPlayerId, IRGhostResult& out);
+	openlr2::GetStatus GetGhost(const char* songHash, openlr2::GhostMode mode, int targetPlayerId, openlr2::IRGhostResult& out);
 
 	[[nodiscard]] const std::string& Name() const { return mName; };
 private:
@@ -153,7 +153,7 @@ openlr2::GetStatus CustomIR::RestoreCachedRank(const char* songHash, openlr2::IR
 	return mMethods.RestoreCachedRank(songHash, -1, out);
 }
 
-openlr2::GetStatus CustomIR::GetGhost(const char* songHash, openlr2::GhostMode mode, int targetPlayerId, IRGhostResult& out) {
+openlr2::GetStatus CustomIR::GetGhost(const char* songHash, openlr2::GhostMode mode, int targetPlayerId, openlr2::IRGhostResult& out) {
 	if (mMethods.GetGhost == nullptr) return openlr2::GetStatus::Fail;
 	return mMethods.GetGhost(songHash, mode, targetPlayerId, out);
 }
@@ -257,7 +257,7 @@ void CUSTOMIR_MANAGER::Login() {
 	}
 }
 
-std::optional<IRGhostResult> CUSTOMIR_MANAGER::TryGetTargetInfo(CSTR songmd5, int mode, int targetPlayerId) const {
+std::optional<openlr2::IRGhostResult> CUSTOMIR_MANAGER::TryGetTargetInfo(CSTR songmd5, int mode, int targetPlayerId) const {
 	const auto irIt = std::ranges::find(mModules, mDisplayIr, &CustomIR::Name);
 	if (irIt == mModules.end()) { return std::nullopt; }
 
@@ -274,7 +274,7 @@ std::optional<IRGhostResult> CUSTOMIR_MANAGER::TryGetTargetInfo(CSTR songmd5, in
 
 	const char* songHash = songmd5.body;
 
-	IRGhostResult result{};
+	openlr2::IRGhostResult result{};
 	switch ((*irIt)->GetGhost(songHash, ghostMode, targetPlayerId, result)) {
 	case openlr2::GetStatus::Ok:
 		break;

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -274,7 +274,7 @@ void CUSTOMIR_MANAGER::Login() {
 	}
 }
 
-bool CUSTOMIR_MANAGER::TryGetTargetInfo(game& g, CSTR songmd5, int mode, CSTR* oData, CSTR* oName, int* oDigit1, int* oDigit2, int* oDigit3, int* oDigit4, int* oSeed, int* oExscore) const {
+bool CUSTOMIR_MANAGER::TryGetTargetInfo(game& g, CSTR songmd5, int mode, CSTR* oData, CSTR* oName, int* oGaugeOption, int* oP1randomOption, int* oP2randomOption, int* oDpFlipOption, int* oRandomSeed, int* oExscore) const {
 	const auto irIt = std::ranges::find(mModules, mDisplayIr, &CustomIR::Name);
 	if (irIt == mModules.end()) { return false; }
 
@@ -301,11 +301,11 @@ bool CUSTOMIR_MANAGER::TryGetTargetInfo(game& g, CSTR songmd5, int mode, CSTR* o
 	*oName = result.displayName.c_str();
 	oData->fillzero();
 	if (!result.ghostData.empty()) oData->add(result.ghostData.c_str());
-	*oDigit1 = result.gaugeOption;
-	*oDigit2 = result.p1randomOption;
-	*oDigit3 = result.p2randomOption;
-	*oDigit4 = result.dpFlipOption;
-	*oSeed = result.randomSeed;
+	*oGaugeOption = result.gaugeOption;
+	*oP1randomOption = result.p1randomOption;
+	*oP2randomOption = result.p2randomOption;
+	*oDpFlipOption = result.dpFlipOption;
+	*oRandomSeed = result.randomSeed;
 	return true;
 }
 

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -77,10 +77,10 @@ public:
 	CustomIR(const std::filesystem::path& directory);
 	bool Initialize();
 	bool Login();
-	SendScoreStatus SendScore(const IRScoreV1& score) const;
+	SendScoreStatus SendScore(const IRScoreV1& score);
 	openlr2::GetStatus GetResultRank(const char* songHash, openlr2::IRRankResult& out);
 	openlr2::GetStatus RestoreCachedRank(const char* songHash, openlr2::IRRankResult& out);
-	openlr2::GetStatus GetGhost(const char* songHash, int mode, int targetPlayerId, IRGhostResult& out) const;
+	openlr2::GetStatus GetGhost(const char* songHash, int mode, int targetPlayerId, IRGhostResult& out);
 
 	[[nodiscard]] const std::string& Name() const { return mName; };
 private:
@@ -138,7 +138,7 @@ bool CustomIR::Login() {
 	return mMethods.LoginV1();
 }
 
-SendScoreStatus CustomIR::SendScore(const IRScoreV1& score) const {
+SendScoreStatus CustomIR::SendScore(const IRScoreV1& score) {
 	if (mMethods.SendScoreV1 == nullptr) return SendScoreStatus::Fail;
 	return mMethods.SendScoreV1(score);
 }
@@ -153,7 +153,7 @@ openlr2::GetStatus CustomIR::RestoreCachedRank(const char* songHash, openlr2::IR
 	return mMethods.RestoreCachedRank(songHash, -1, out);
 }
 
-openlr2::GetStatus CustomIR::GetGhost(const char* songHash, int mode, int targetPlayerId, IRGhostResult& out) const {
+openlr2::GetStatus CustomIR::GetGhost(const char* songHash, int mode, int targetPlayerId, IRGhostResult& out) {
 	if (mMethods.GetGhost == nullptr) return openlr2::GetStatus::Fail;
 	return mMethods.GetGhost(songHash, mode, targetPlayerId, out);
 }

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -80,7 +80,7 @@ public:
 	SendScoreStatus SendScore(const IRScoreV1& score) const;
 	openlr2::GetStatus GetResultRank(const char* songHash, openlr2::IRRankResult& out);
 	openlr2::GetStatus RestoreCachedRank(const char* songHash, openlr2::IRRankResult& out);
-	openlr2::GetStatus GetGhost(const IRScoreV1& score, int mode, int targetPlayerId, IRGhostResult& out) const;
+	openlr2::GetStatus GetGhost(const char* songHash, int mode, int targetPlayerId, IRGhostResult& out) const;
 
 	[[nodiscard]] const std::string& Name() const { return mName; };
 private:
@@ -153,9 +153,9 @@ openlr2::GetStatus CustomIR::RestoreCachedRank(const char* songHash, openlr2::IR
 	return mMethods.RestoreCachedRank(songHash, -1, out);
 }
 
-openlr2::GetStatus CustomIR::GetGhost(const IRScoreV1& score, int mode, int targetPlayerId, IRGhostResult& out) const {
+openlr2::GetStatus CustomIR::GetGhost(const char* songHash, int mode, int targetPlayerId, IRGhostResult& out) const {
 	if (mMethods.GetGhost == nullptr) return openlr2::GetStatus::Fail;
-	return mMethods.GetGhost(score, mode, targetPlayerId, out);
+	return mMethods.GetGhost(songHash, mode, targetPlayerId, out);
 }
 
 CUSTOMIR_MANAGER::~CUSTOMIR_MANAGER() {
@@ -261,11 +261,10 @@ bool CUSTOMIR_MANAGER::TryGetTargetInfo(game& g, CSTR songmd5, int mode, CSTR* o
 	const auto irIt = std::ranges::find(mModules, mDisplayIr, &CustomIR::Name);
 	if (irIt == mModules.end()) { return false; }
 
-	IRScoreV1 score{};
-	score.song.hash = songmd5.body != nullptr ? songmd5.body : "";
+	const char* songHash = songmd5.body;
 
 	IRGhostResult result{};
-	switch ((*irIt)->GetGhost(score, mode, g.net.rankingData.target_ID, result)) {
+	switch ((*irIt)->GetGhost(songHash, mode, g.net.rankingData.target_ID, result)) {
 	case openlr2::GetStatus::Ok:
 		break;
 	case openlr2::GetStatus::Retry:

--- a/LR2/LR2_customir.h
+++ b/LR2/LR2_customir.h
@@ -35,7 +35,9 @@ public:
 	void BeginResultIr(game& game, sqlite3* sql, int player);
 	void Initialize(const std::filesystem::path& directory, std::string activeProvider);
 	void Login();
-	std::optional<openlr2::IRGhostResult> TryGetTargetInfo(CSTR songmd5, int mode, int targetPlayerId) const;
+	// \note Delegates to the display IR
+	// \retval nullopt - Fail
+	std::optional<openlr2::IRGhostResult> TryGetTargetInfo(const char* songmd5, int mode, int targetPlayerId) const;
 private:
 	std::vector<std::shared_ptr<CustomIR>> mModules;
 	std::vector<std::future<void>> mSendThreads;

--- a/LR2/LR2_customir.h
+++ b/LR2/LR2_customir.h
@@ -35,7 +35,7 @@ public:
 	void BeginResultIr(game& game, sqlite3* sql, int player);
 	void Initialize(const std::filesystem::path& directory, std::string activeProvider);
 	void Login();
-	bool TryGetTargetInfo(game& g, CSTR songmd5, int mode, CSTR* oData, CSTR* oName, int* oDigit1, int* oDigit2, int* oDigit3, int* oDigit4, int* oSeed, int* oExscore) const;
+	bool TryGetTargetInfo(game& g, CSTR songmd5, int mode, CSTR* oData, CSTR* oName, int* oGaugeOption, int* oP1randomOption, int* oP2randomOption, int* oDpFlipOption, int* oRandomSeed, int* oExscore) const;
 private:
 	std::vector<std::shared_ptr<CustomIR>> mModules;
 	std::vector<std::future<void>> mSendThreads;

--- a/LR2/LR2_customir.h
+++ b/LR2/LR2_customir.h
@@ -35,7 +35,7 @@ public:
 	void BeginResultIr(game& game, sqlite3* sql, int player);
 	void Initialize(const std::filesystem::path& directory, std::string activeProvider);
 	void Login();
-	bool TryGetTargetInfo(game& g, CSTR songmd5, int mode, CSTR* oData, CSTR* oName, int* oGaugeOption, int* oP1randomOption, int* oP2randomOption, int* oDpFlipOption, int* oRandomSeed, int* oExscore) const;
+	std::optional<IRGhostResult> TryGetTargetInfo(CSTR songmd5, int mode, int targetPlayerId) const;
 private:
 	std::vector<std::shared_ptr<CustomIR>> mModules;
 	std::vector<std::future<void>> mSendThreads;

--- a/LR2/LR2_customir.h
+++ b/LR2/LR2_customir.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "LR2_customir_api.h"
+#include "strclass.h"
 
 #include <filesystem>
 #include <future>
@@ -34,6 +35,7 @@ public:
 	void BeginResultIr(game& game, sqlite3* sql, int player);
 	void Initialize(const std::filesystem::path& directory, std::string activeProvider);
 	void Login();
+	bool TryGetTargetInfo(game& g, CSTR songmd5, int mode, CSTR* oData, CSTR* oName, int* oDigit1, int* oDigit2, int* oDigit3, int* oDigit4, int* oSeed, int* oExscore) const;
 private:
 	std::vector<std::shared_ptr<CustomIR>> mModules;
 	std::vector<std::future<void>> mSendThreads;

--- a/LR2/LR2_customir.h
+++ b/LR2/LR2_customir.h
@@ -35,7 +35,7 @@ public:
 	void BeginResultIr(game& game, sqlite3* sql, int player);
 	void Initialize(const std::filesystem::path& directory, std::string activeProvider);
 	void Login();
-	std::optional<IRGhostResult> TryGetTargetInfo(CSTR songmd5, int mode, int targetPlayerId) const;
+	std::optional<openlr2::IRGhostResult> TryGetTargetInfo(CSTR songmd5, int mode, int targetPlayerId) const;
 private:
 	std::vector<std::shared_ptr<CustomIR>> mModules;
 	std::vector<std::future<void>> mSendThreads;

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -148,9 +148,9 @@ enum class InputType : int {
 
 enum class GhostMode : int {
 	Target = 0,
-	Top = 6,
-	Next = 7,
-	Average = 8,
+	Top,
+	Next,
+	Average,
 };
 
 enum class Lamp : int {

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -240,8 +240,6 @@ enum class GetStatus: int {
 
 } // namespace openlr2
 
-using IRGhostResult = openlr2::IRGhostResult;
-
 struct MethodTable {
 	// Mandatory method. Module name must be unique among loaded modules.
 	const char*(OLR2_IR_API* GetName)() = nullptr;
@@ -276,5 +274,5 @@ struct MethodTable {
 	void* reserved5 = nullptr;
 	void* reserved6 = nullptr;
 	// This is called synchronously when play is entered to retrieve the ghost data for the play.
-	openlr2::GetStatus(OLR2_IR_API* GetGhost)(const char* songHash, openlr2::GhostMode mode, int targetPlayerId, IRGhostResult& out) = nullptr;
+	openlr2::GetStatus(OLR2_IR_API* GetGhost)(const char* songHash, openlr2::GhostMode mode, int targetPlayerId, openlr2::IRGhostResult& out) = nullptr;
 };

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -176,7 +176,7 @@ struct IRGhostResult {
 	bool reserved1{};
 	bool reserved2{};
 	bool reserved3{};
-	int averageExscore{};
+	int averageExscore{}; // Only used if \ref GhostMode == \ref GhostMode::Average.
 };
 
 // \warning Experimental API, may be changed.

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -250,7 +250,6 @@ struct MethodTable {
 	// Ran on its own thread at score result, both for normal plays and courses.
 	// This is called even with scores that wouldn't be sent to LR2IR or saved to the score.db, it's up to the module to
 	// filter them.
-	// score.ghostData is populated when live ghost capture succeeded; upload or ignore per IR policy.
 	// For soft errors, SendScore should return SendScoreStatus::Retry. The game will retry calling a sensible amount
 	// times with a backoff then.
 	SendScoreStatus(OLR2_IR_API* SendScoreV1)(const IRScoreV1& score) = nullptr;

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -107,6 +107,7 @@ struct IRScoreV1 {
 		std::array<int, 1000> exscore{};
 		std::array<int, 1000> rate{};
 	} graphs{};
+	std::string ghostData{};
 };
 
 enum class SendScoreStatus: int {
@@ -235,6 +236,7 @@ struct MethodTable {
 	// Ran on its own thread at score result, both for normal plays and courses.
 	// This is called even with scores that wouldn't be sent to LR2IR or saved to the score.db, it's up to the module to
 	// filter them.
+	// score.ghostData is populated when live ghost capture succeeded; upload or ignore per IR policy.
 	// For soft errors, SendScore should return SendScoreStatus::Retry. The game will retry calling a sensible amount
 	// times with a backoff then.
 	SendScoreStatus(OLR2_IR_API* SendScoreV1)(const IRScoreV1& score) = nullptr;

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -162,7 +162,7 @@ enum class Random : int {
 
 struct IRGhostResult {
 	std::string displayName;
-	std::string ghostData;
+	std::string ghostData; // Example: E@3ZZ
 	// P1 and P2 random layouts.
 	// Should be 0 if the layout is not known, or the corresponding \ref randomOption is not noran, mirror, or random.
 	// Examples: 1234567 54321 135792468.

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -107,7 +107,7 @@ struct IRScoreV1 {
 		std::array<int, 1000> exscore{};
 		std::array<int, 1000> rate{};
 	} graphs{};
-	std::string ghostData{};
+	std::string ghostData{}; // In LR2 ghost format. May not be present in some cases, e.g. course scores.
 };
 
 enum class SendScoreStatus: int {

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -125,7 +125,6 @@ struct IRGhostResult {
 	int dpFlipOption{};
 	int randomSeed{};
 	int averageExscore{};
-	bool hasPlay{};
 };
 
 namespace openlr2 {

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -179,7 +179,6 @@ struct IRGhostResult {
 	int averageExscore{}; // Only used if \ref GhostMode == \ref GhostMode::Average.
 };
 
-// \warning Experimental API, may be changed.
 struct IRRankPlayer {
 	std::string name; // Display name of the user
 	std::string comment; // User-defined comment of the score
@@ -215,7 +214,6 @@ struct IRRankPlayer {
 	uint64_t reserved7{};
 };
 
-// \warning Experimental API, may be changed.
 struct IRRankResult {
 	// The leaderboard. Top X players, usually 999.
 	std::vector<IRRankPlayer> ranking;
@@ -231,7 +229,6 @@ struct IRRankResult {
 	int totalPlaycount{};
 };
 
-// \warning Experimental API, may be changed.
 enum class GetStatus: int {
 	Ok = 0,
 	Retry,
@@ -257,21 +254,21 @@ struct MethodTable {
 	// The game awaits on this to complete before it lets the user out of result.
 	// Make sure to save the fetched result somewhere, so that RestoreCachedRank can then load it.
 	// Replace with HTTP + mandatory cache write.
-	// \warning Experimental API, may be changed.
 	openlr2::GetStatus(OLR2_IR_API* GetResultRank)(const char* songHash, int reserved, openlr2::IRRankResult& out) = nullptr;
 	// Called from song select when scrolling past 'songHash' song.
 	// Loads the leaderboard from where GetResultRank saved it.
 	// Do not perform HTTP here.
 	// Replace with cache read.
-	// \warning Experimental API, may be changed.
 	openlr2::GetStatus(OLR2_IR_API* RestoreCachedRank)(const char* songHash, int reserved, openlr2::IRRankResult& out) = nullptr;
-	// Forward compatibility, so you can try running IR modules designed for newer OpenLR2 versions.
+	// This is called synchronously when play is entered to retrieve the ghost data for the play.
+	openlr2::GetStatus(OLR2_IR_API* GetGhost)(const char* songHash, openlr2::GhostMode mode, int targetPlayerId, openlr2::IRGhostResult& out) = nullptr;
+	// Forward compatibility.
+	// These fields will always be moved to the end of the struct when new fields are added.
+	// Thanks to this CustomIR module designed for newer game version won't write out-of-bounds memory when assigning fields of older MethodTable.
 	void* reserved1 = nullptr;
 	void* reserved2 = nullptr;
 	void* reserved3 = nullptr;
 	void* reserved4 = nullptr;
 	void* reserved5 = nullptr;
 	void* reserved6 = nullptr;
-	// This is called synchronously when play is entered to retrieve the ghost data for the play.
-	openlr2::GetStatus(OLR2_IR_API* GetGhost)(const char* songHash, openlr2::GhostMode mode, int targetPlayerId, openlr2::IRGhostResult& out) = nullptr;
 };

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -258,6 +258,6 @@ struct MethodTable {
 	void* reserved4 = nullptr;
 	void* reserved5 = nullptr;
 	void* reserved6 = nullptr;
-	// dream-pro getghost.cgi parity: mode 0=target, 6=top, 7=next, 8=average. Chart key: songHash only.
+	// This is called synchronously when play is entered to retrieve the ghost data for the play.
 	openlr2::GetStatus(OLR2_IR_API* GetGhost)(const char* songHash, int mode, int targetPlayerId, IRGhostResult& out) = nullptr;
 };

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -146,6 +146,13 @@ enum class InputType : int {
 	Midi,
 };
 
+enum class GhostMode : int {
+	Target = 0,
+	Top = 6,
+	Next = 7,
+	Average = 8,
+};
+
 enum class Lamp : int {
 	NoPlay = 0,
 	Fail,
@@ -259,5 +266,5 @@ struct MethodTable {
 	void* reserved5 = nullptr;
 	void* reserved6 = nullptr;
 	// This is called synchronously when play is entered to retrieve the ghost data for the play.
-	openlr2::GetStatus(OLR2_IR_API* GetGhost)(const char* songHash, int mode, int targetPlayerId, IRGhostResult& out) = nullptr;
+	openlr2::GetStatus(OLR2_IR_API* GetGhost)(const char* songHash, openlr2::GhostMode mode, int targetPlayerId, IRGhostResult& out) = nullptr;
 };

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -119,10 +119,10 @@ enum class SendScoreStatus: int {
 struct IRGhostResult {
 	std::string displayName;
 	std::string ghostData;
-	int optionDigit1{};
-	int optionDigit2{};
-	int optionDigit3{};
-	int optionDigit4{};
+	int gaugeOption{};
+	int p1randomOption{};
+	int p2randomOption{};
+	int dpFlipOption{};
 	int randomSeed{};
 	int averageExscore{};
 	bool hasPlay{};

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -116,17 +116,6 @@ enum class SendScoreStatus: int {
 	Fail,
 };
 
-struct IRGhostResult {
-	std::string displayName;
-	std::string ghostData;
-	int gaugeOption{};
-	int p1randomOption{};
-	int p2randomOption{};
-	int dpFlipOption{};
-	int randomSeed{};
-	int averageExscore{};
-};
-
 namespace openlr2 {
 
 enum class Gauge : int {
@@ -169,6 +158,25 @@ enum class Random : int {
 	SRandom,
 	Scatter, // AKA H-Random
 	Converge, // AKA All-Scratch
+};
+
+struct IRGhostResult {
+	std::string displayName;
+	std::string ghostData;
+	// P1 and P2 random layouts.
+	// Should be 0 if the layout is not known, or the corresponding \ref randomOption is not noran, mirror, or random.
+	// Examples: 1234567 54321 135792468.
+	std::array<int, 2> randomLayout{};
+	std::array<Random, 2> randomOption{};
+	Gauge gauge{Gauge::Unknown};
+	// LR2 rseed. If not known, the layout from \ref randomLayout can be used instead.
+	// -1 if unknown, 0-0x7ffe otherwise.
+	int rseed{-1};
+	bool dpflip{};
+	bool reserved1{};
+	bool reserved2{};
+	bool reserved3{};
+	int averageExscore{};
 };
 
 // \warning Experimental API, may be changed.
@@ -231,6 +239,8 @@ enum class GetStatus: int {
 };
 
 } // namespace openlr2
+
+using IRGhostResult = openlr2::IRGhostResult;
 
 struct MethodTable {
 	// Mandatory method. Module name must be unique among loaded modules.

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -259,6 +259,6 @@ struct MethodTable {
 	void* reserved4 = nullptr;
 	void* reserved5 = nullptr;
 	void* reserved6 = nullptr;
-	// dream-pro getghost.cgi parity: mode 0=target, 6=top, 7=next, 8=average.
-	openlr2::GetStatus(OLR2_IR_API* GetGhost)(const IRScoreV1& score, int mode, int targetPlayerId, IRGhostResult& out) = nullptr;
+	// dream-pro getghost.cgi parity: mode 0=target, 6=top, 7=next, 8=average. Chart key: songHash only.
+	openlr2::GetStatus(OLR2_IR_API* GetGhost)(const char* songHash, int mode, int targetPlayerId, IRGhostResult& out) = nullptr;
 };

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -115,6 +115,18 @@ enum class SendScoreStatus: int {
 	Fail,
 };
 
+struct IRGhostResult {
+	std::string displayName;
+	std::string ghostData;
+	int optionDigit1{};
+	int optionDigit2{};
+	int optionDigit3{};
+	int optionDigit4{};
+	int randomSeed{};
+	int averageExscore{};
+	bool hasPlay{};
+};
+
 namespace openlr2 {
 
 enum class Gauge : int {
@@ -245,4 +257,6 @@ struct MethodTable {
 	void* reserved4 = nullptr;
 	void* reserved5 = nullptr;
 	void* reserved6 = nullptr;
+	// dream-pro getghost.cgi parity: mode 0=target, 6=top, 7=next, 8=average.
+	openlr2::GetStatus(OLR2_IR_API* GetGhost)(const IRScoreV1& score, int mode, int targetPlayerId, IRGhostResult& out) = nullptr;
 };

--- a/LR2/LR2_ghost.cpp
+++ b/LR2/LR2_ghost.cpp
@@ -167,7 +167,7 @@ int PLAYSCORE::SetGhost(int exscore, int notes, CSTR name){
 	return 1;
 }
 
-CSTR PLAYSCORE::EncodeGhostData(void) {
+CSTR PLAYSCORE::EncodeGhostData(void) const {
 	if (this->judge_queue_len == 0) return "GHOST_ERROR";
 
 	int rep = 0;
@@ -440,30 +440,6 @@ CSTR PLAYSCORE::EncodeGhostData(void) {
 
 		o++;
 	}
-
-	this->name.fillzero();
-	this->totalnotes = 0;
-	this->nownote = 0;
-	this->exscore = 0;
-	this->rate = 0;
-	this->judge_queue_len = 0;
-	this->judgeExpect[0] = 0;
-	this->judge[0] = 0;
-	this->judgeExpect[1] = 0;
-	this->judge[1] = 0;
-	this->judgeExpect[2] = 0;
-	this->judge[2] = 0;
-	this->judgeExpect[3] = 0;
-	this->judge[3] = 0;
-	this->judgeExpect[4] = 0;
-	this->judge[4] = 0;
-	this->judgeExpect[5] = 0;
-	this->judge[5] = 0;
-	this->ghostReadCount = 0;
-	this->judge_queue_capacity = 0;
-	free(this->judge_queue);
-	this->judge_queue = NULL;
-	this->judge_queue_capacity = 0;
 
 	return str;
 }

--- a/LR2/LR2_ghost.cpp
+++ b/LR2/LR2_ghost.cpp
@@ -712,6 +712,7 @@ int WriteGhostInDatabase(sqlite3 *sql, CSTR songMD5, PLAYSCORE *score) {
 		ErrorLogAdd("sqlite3_finalize error\n");
 	}
 
+	score->InitJudgeQueue();
 	ErrorLogAdd("ゴーストの書き込みが終了しました\n");
 	return 0;
 }

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -719,7 +719,7 @@ bool NETWORK::GetTargetInfo(game& g, int mode, CSTR songmd5, CSTR *oData, CSTR *
 	return false;
 }
 
-static void ThreadProc_IRsendScore(NETWORK *ir) {
+static void ThreadProc_IRsendScore(NETWORK *ir, CSTR ghostString) {
 	ErrorLogAdd("LR2IRにスコアを送信します。\n");
 	CSTR scorehash;
 	cstrSprintf(&scorehash, "%s%s%d%d", ir->IR_passMD5.body, ir->myRanking.songMD5.body,ir->myRanking.exscore, ir->myRanking.clear);
@@ -744,7 +744,7 @@ static void ThreadProc_IRsendScore(NETWORK *ir) {
 			ir->myRanking.clearcount, ir->myRanking.rate, ir->myRanking.minbp,
 			ir->myRanking.totalnotes, ir->myRanking.opt_history,
 			ir->myRanking.opt_this, ir->myRanking.line, ir->myRanking.judge,
-			ir->myRanking.inputtype, ir->myRanking.ghost.body,
+			ir->myRanking.inputtype, ghostString.body,
 			ir->myRanking.rseed, ir->myRanking.clear_db, ir->myRanking.clear_ex,
 			ir->myRanking.clear_sd, scorehash.body);
 	ir->target_URL = "http://www.dream-pro.info/~lavalse/LR2IR/2/score.cgi";
@@ -947,7 +947,7 @@ int NETWORK::Login(int isDirectPlay) {
 	return -3;
 }
 
-int NETWORK::MakeIRsendScoreThread() {
+int NETWORK::MakeIRsendScoreThread(CSTR ghostString) {
 	GetTimeWrap();
 	this->waitForHandle = true;
 	if (hHandle.joinable()) {
@@ -956,7 +956,7 @@ int NETWORK::MakeIRsendScoreThread() {
 	this->waitForHandle = false;
 	this->rankingData.Init();
 	this->IRstatus = 1;
-	this->hHandle = std::jthread(ThreadProc_IRsendScore, this);
+	this->hHandle = std::jthread(ThreadProc_IRsendScore, this, ghostString);
 	return 0;
 }
 

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -6,6 +6,7 @@
 #include "En_timer.h"
 #include "En_xml.h"
 #include "LR2_ir.h"
+#include "LR2_customir.h"
 #include "LR2_version.h"
 #include "filesystem.h"
 #include "tinyxml/tinyxml.h"
@@ -629,13 +630,17 @@ int NETWORK::HTTPrequest() {
 #endif // _WIN32
 }
 
-void NETWORK::WaitAndInitRanking() {
+void NETWORK::WaitForRankingHandle() {
 	GetTimeWrap();
 	this->waitForHandle = true;
 	if (hHandle.joinable()) {
 		hHandle.join();
 	}
 	this->waitForHandle = false;
+}
+
+void NETWORK::WaitAndInitRanking() {
+	WaitForRankingHandle();
 	this->rankingData.Init();
 }
 
@@ -700,6 +705,18 @@ int OpenWebRanking(CSTR songmd5){
 	cstrSprintf(&url, "xdg-open \"http://www.dream-pro.info/~lavalse/LR2IR/search.cgi?mode=ranking&bmsmd5=%s#status&\" &", songmd5.body);
 	return system(url.body) == 0;
 #endif
+}
+
+bool NETWORK::GetTargetInfo(game& g, int mode, CSTR songmd5, CSTR *oData, CSTR *oName, int *oDigit1, int *oDigit2, int *oDigit3, int *oDigit4, int *oSeed, int *oExscore) {
+	WaitForRankingHandle();
+	if (customIR.TryGetTargetInfo(g, songmd5, mode, oData, oName, oDigit1, oDigit2, oDigit3, oDigit4, oSeed, oExscore)) {
+		return true;
+	}
+	if (isOnline) {
+		WaitAndInitRanking();
+		return GetTargetInfo(mode, songmd5, oData, oName, oDigit1, oDigit2, oDigit3, oDigit4, oSeed, oExscore) != 0;
+	}
+	return false;
 }
 
 static void ThreadProc_IRsendScore(NETWORK *ir) {

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -707,9 +707,9 @@ int OpenWebRanking(CSTR songmd5){
 #endif
 }
 
-bool NETWORK::GetTargetInfo(game& g, int mode, CSTR songmd5, CSTR *oData, CSTR *oName, int *oDigit1, int *oDigit2, int *oDigit3, int *oDigit4, int *oSeed, int *oExscore) {
+bool NETWORK::GetTargetInfo(int mode, CSTR songmd5, CSTR *oData, CSTR *oName, int *oDigit1, int *oDigit2, int *oDigit3, int *oDigit4, int *oSeed, int *oExscore) {
 	WaitForRankingHandle();
-	if (auto result = customIR.TryGetTargetInfo(songmd5, mode, g.net.rankingData.target_ID)) {
+	if (auto result = customIR.TryGetTargetInfo(songmd5, mode, rankingData.target_ID)) {
 		if (mode == 8) {
 			*oName = "AVERAGE";
 			*oExscore = result->averageExscore;
@@ -751,7 +751,7 @@ bool NETWORK::GetTargetInfo(game& g, int mode, CSTR songmd5, CSTR *oData, CSTR *
 	}
 	if (isOnline) {
 		WaitAndInitRanking();
-		return GetTargetInfo(mode, songmd5, oData, oName, oDigit1, oDigit2, oDigit3, oDigit4, oSeed, oExscore) != 0;
+		return LR2IR_GetTargetInfo(mode, songmd5, oData, oName, oDigit1, oDigit2, oDigit3, oDigit4, oSeed, oExscore) != 0;
 	}
 	return false;
 }
@@ -798,7 +798,7 @@ static void ThreadProc_IRsendScore(NETWORK *ir, std::string ghostString) {
 	ir->hHandle.detach(); // Detach ourselves TODO: refactor surrounding code to avoid this
 }
 
-int NETWORK::GetTargetInfo(int mode, CSTR songmd5, CSTR *oData, CSTR *oName, int *oDigit1, int *oDigit2, int *oDigit3, int *oDigit4, int *oSeed, int *oExscore) {
+int NETWORK::LR2IR_GetTargetInfo(int mode, CSTR songmd5, CSTR *oData, CSTR *oName, int *oDigit1, int *oDigit2, int *oDigit3, int *oDigit4, int *oSeed, int *oExscore) {
 
 	CSTR search("top");
 

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -718,11 +718,11 @@ bool NETWORK::GetTargetInfo(game& g, int mode, CSTR songmd5, CSTR *oData, CSTR *
 		*oName = result->displayName.c_str();
 		oData->fillzero();
 		if (!result->ghostData.empty()) oData->add(result->ghostData.c_str());
-		*oDigit1 = result->gaugeOption;
-		*oDigit2 = result->p1randomOption;
-		*oDigit3 = result->p2randomOption;
-		*oDigit4 = result->dpFlipOption;
-		*oSeed = result->randomSeed;
+		*oDigit1 = result->gauge == openlr2::Gauge::Unknown ? 0 : static_cast<int>(result->gauge) - 1;
+		*oDigit2 = static_cast<int>(result->randomOption[0]);
+		*oDigit3 = static_cast<int>(result->randomOption[1]);
+		*oDigit4 = result->dpflip ? 1 : 0;
+		*oSeed = result->rseed >= 0 ? result->rseed : 0;
 		return true;
 	}
 	if (isOnline) {

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -26,7 +26,7 @@ void MYRANKING::InitRanking() {
 	this->title.fillzero();
 	this->genre.fillzero();
 	this->artist.fillzero();
-	this->ghost.fillzero();
+	this->_ghost.fillzero();
 	this->maxbpm = 0;
 	this->minbpm = 0;
 	this->playlevel = 0;

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -719,7 +719,7 @@ bool NETWORK::GetTargetInfo(game& g, int mode, CSTR songmd5, CSTR *oData, CSTR *
 	return false;
 }
 
-static void ThreadProc_IRsendScore(NETWORK *ir, CSTR ghostString) {
+static void ThreadProc_IRsendScore(NETWORK *ir, std::string ghostString) {
 	ErrorLogAdd("LR2IRにスコアを送信します。\n");
 	CSTR scorehash;
 	cstrSprintf(&scorehash, "%s%s%d%d", ir->IR_passMD5.body, ir->myRanking.songMD5.body,ir->myRanking.exscore, ir->myRanking.clear);
@@ -744,7 +744,7 @@ static void ThreadProc_IRsendScore(NETWORK *ir, CSTR ghostString) {
 			ir->myRanking.clearcount, ir->myRanking.rate, ir->myRanking.minbp,
 			ir->myRanking.totalnotes, ir->myRanking.opt_history,
 			ir->myRanking.opt_this, ir->myRanking.line, ir->myRanking.judge,
-			ir->myRanking.inputtype, ghostString.body,
+			ir->myRanking.inputtype, ghostString.c_str(),
 			ir->myRanking.rseed, ir->myRanking.clear_db, ir->myRanking.clear_ex,
 			ir->myRanking.clear_sd, scorehash.body);
 	ir->target_URL = "http://www.dream-pro.info/~lavalse/LR2IR/2/score.cgi";
@@ -947,7 +947,7 @@ int NETWORK::Login(int isDirectPlay) {
 	return -3;
 }
 
-int NETWORK::MakeIRsendScoreThread(CSTR ghostString) {
+int NETWORK::MakeIRsendScoreThread(std::string ghostString) {
 	GetTimeWrap();
 	this->waitForHandle = true;
 	if (hHandle.joinable()) {

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -750,7 +750,7 @@ bool NETWORK::GetTargetInfo(int mode, CSTR songmd5, CSTR *oData, CSTR *oName, in
 		return true;
 	}
 	if (isOnline) {
-		WaitAndInitRanking();
+		this->rankingData.Init();
 		return LR2IR_GetTargetInfo(mode, songmd5, oData, oName, oDigit1, oDigit2, oDigit3, oDigit4, oSeed, oExscore) != 0;
 	}
 	return false;

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -727,8 +727,24 @@ bool NETWORK::GetTargetInfo(game& g, int mode, CSTR songmd5, CSTR *oData, CSTR *
 		case openlr2::Gauge::GAttack: *oDigit1 = 5; break;
 		default: *oDigit1 = 0; break;
 		}
-		*oDigit2 = static_cast<int>(result->randomOption[0]);
-		*oDigit3 = static_cast<int>(result->randomOption[1]);
+		switch (result->randomOption[0]) {
+		case openlr2::Random::No: *oDigit2 = 0; break;
+		case openlr2::Random::Mirror: *oDigit2 = 1; break;
+		case openlr2::Random::Random: *oDigit2 = 2; break;
+		case openlr2::Random::SRandom: *oDigit2 = 3; break;
+		case openlr2::Random::Scatter: *oDigit2 = 4; break;
+		case openlr2::Random::Converge: *oDigit2 = 5; break;
+		default: *oDigit2 = 0; break;
+		}
+		switch (result->randomOption[1]) {
+		case openlr2::Random::No: *oDigit3 = 0; break;
+		case openlr2::Random::Mirror: *oDigit3 = 1; break;
+		case openlr2::Random::Random: *oDigit3 = 2; break;
+		case openlr2::Random::SRandom: *oDigit3 = 3; break;
+		case openlr2::Random::Scatter: *oDigit3 = 4; break;
+		case openlr2::Random::Converge: *oDigit3 = 5; break;
+		default: *oDigit3 = 0; break;
+		}
 		*oDigit4 = result->dpflip ? 1 : 0;
 		*oSeed = result->rseed >= 0 ? result->rseed : 0; //TOFIX: 0 is a valid seed
 		return true;

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -709,7 +709,20 @@ int OpenWebRanking(CSTR songmd5){
 
 bool NETWORK::GetTargetInfo(game& g, int mode, CSTR songmd5, CSTR *oData, CSTR *oName, int *oDigit1, int *oDigit2, int *oDigit3, int *oDigit4, int *oSeed, int *oExscore) {
 	WaitForRankingHandle();
-	if (customIR.TryGetTargetInfo(g, songmd5, mode, oData, oName, oDigit1, oDigit2, oDigit3, oDigit4, oSeed, oExscore)) {
+	if (auto result = customIR.TryGetTargetInfo(songmd5, mode, g.net.rankingData.target_ID)) {
+		if (mode == 8) {
+			*oName = "AVERAGE";
+			*oExscore = result->averageExscore;
+			return true;
+		}
+		*oName = result->displayName.c_str();
+		oData->fillzero();
+		if (!result->ghostData.empty()) oData->add(result->ghostData.c_str());
+		*oDigit1 = result->gaugeOption;
+		*oDigit2 = result->p1randomOption;
+		*oDigit3 = result->p2randomOption;
+		*oDigit4 = result->dpFlipOption;
+		*oSeed = result->randomSeed;
 		return true;
 	}
 	if (isOnline) {

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -718,7 +718,15 @@ bool NETWORK::GetTargetInfo(game& g, int mode, CSTR songmd5, CSTR *oData, CSTR *
 		*oName = result->displayName.c_str();
 		oData->fillzero();
 		if (!result->ghostData.empty()) oData->add(result->ghostData.c_str());
-		*oDigit1 = result->gauge == openlr2::Gauge::Unknown ? 0 : static_cast<int>(result->gauge) - 1;
+		switch (result->gauge) {
+		case openlr2::Gauge::Groove: *oDigit1 = 0; break;
+		case openlr2::Gauge::Survival: *oDigit1 = 1; break;
+		case openlr2::Gauge::Death: *oDigit1 = 2; break;
+		case openlr2::Gauge::Easy: *oDigit1 = 3; break;
+		case openlr2::Gauge::PAttack: *oDigit1 = 4; break;
+		case openlr2::Gauge::GAttack: *oDigit1 = 5; break;
+		default: *oDigit1 = 0; break;
+		}
 		*oDigit2 = static_cast<int>(result->randomOption[0]);
 		*oDigit3 = static_cast<int>(result->randomOption[1]);
 		*oDigit4 = result->dpflip ? 1 : 0;

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -722,7 +722,7 @@ bool NETWORK::GetTargetInfo(game& g, int mode, CSTR songmd5, CSTR *oData, CSTR *
 		*oDigit2 = static_cast<int>(result->randomOption[0]);
 		*oDigit3 = static_cast<int>(result->randomOption[1]);
 		*oDigit4 = result->dpflip ? 1 : 0;
-		*oSeed = result->rseed >= 0 ? result->rseed : 0;
+		*oSeed = result->rseed >= 0 ? result->rseed : 0; //TOFIX: 0 is a valid seed
 		return true;
 	}
 	if (isOnline) {

--- a/LR2/LR2_statplay.cpp
+++ b/LR2/LR2_statplay.cpp
@@ -768,7 +768,7 @@ int SaveResult(game *g, sqlite3* sql) {
 
 				g->net.myRanking.inputtype = DetermineResultPlayDevice(&g->KeyInput);
 				const CSTR ghostString = ReadGhost(sql, bms.hash);
-				g->net.MakeIRsendScoreThread(ghostString);
+				g->net.MakeIRsendScoreThread(ghostString.body);
 
 				if (!g->config.network.displayIr.length()) {
 					bms.mybest.IRranking = g->net.rankingData.myRanking;
@@ -1102,7 +1102,7 @@ int SaveResult(game *g, sqlite3* sql) {
 
 							g->net.myRanking.inputtype = DetermineResultPlayDevice(&g->KeyInput);
 							const CSTR ghostString = ReadGhost(sql, g->sSelect.bmsList[g->sSelect.cur_song].hash);
-							g->net.MakeIRsendScoreThread(ghostString);
+							g->net.MakeIRsendScoreThread(ghostString.body);
 
 							if (!g->config.network.displayIr.length()) {
 								g->sSelect.bmsList[g->sSelect.cur_song].mybest.IRranking = g->net.rankingData.myRanking;
@@ -1149,7 +1149,7 @@ int SaveResult(game *g, sqlite3* sql) {
 							
 							g->net.myRanking.inputtype = DetermineResultPlayDevice(&g->KeyInput);
 							const CSTR ghostString = ReadGhost(sql, g->sSelect.bmsList[g->sSelect.cur_song].hash);
-							g->net.MakeIRsendScoreThread(ghostString);
+							g->net.MakeIRsendScoreThread(ghostString.body);
 
 							if (!g->config.network.displayIr.length()) {
 								g->sSelect.bmsList[g->sSelect.cur_song].mybest.IRranking = g->net.rankingData.myRanking;

--- a/LR2/LR2_statplay.cpp
+++ b/LR2/LR2_statplay.cpp
@@ -767,8 +767,8 @@ int SaveResult(game *g, sqlite3* sql) {
 				g->net.myRanking.judge = meta.judge;
 
 				g->net.myRanking.inputtype = DetermineResultPlayDevice(&g->KeyInput);
-				g->net.myRanking.ghost = ReadGhost(sql, bms.hash);
-				g->net.MakeIRsendScoreThread();
+				const CSTR ghostString = ReadGhost(sql, bms.hash);
+				g->net.MakeIRsendScoreThread(ghostString);
 
 				if (!g->config.network.displayIr.length()) {
 					bms.mybest.IRranking = g->net.rankingData.myRanking;
@@ -1101,8 +1101,8 @@ int SaveResult(game *g, sqlite3* sql) {
 							g->net.myRanking.judge = meta.judge;
 
 							g->net.myRanking.inputtype = DetermineResultPlayDevice(&g->KeyInput);
-							g->net.myRanking.ghost = ReadGhost(sql, g->sSelect.bmsList[g->sSelect.cur_song].hash);
-							g->net.MakeIRsendScoreThread();
+							const CSTR ghostString = ReadGhost(sql, g->sSelect.bmsList[g->sSelect.cur_song].hash);
+							g->net.MakeIRsendScoreThread(ghostString);
 
 							if (!g->config.network.displayIr.length()) {
 								g->sSelect.bmsList[g->sSelect.cur_song].mybest.IRranking = g->net.rankingData.myRanking;
@@ -1148,8 +1148,8 @@ int SaveResult(game *g, sqlite3* sql) {
 							g->net.myRanking.line = g->sSelect.bmsList[g->sSelect.cur_song].keymode;
 							
 							g->net.myRanking.inputtype = DetermineResultPlayDevice(&g->KeyInput);
-							g->net.myRanking.ghost = ReadGhost(sql, g->sSelect.bmsList[g->sSelect.cur_song].hash);
-							g->net.MakeIRsendScoreThread();
+							const CSTR ghostString = ReadGhost(sql, g->sSelect.bmsList[g->sSelect.cur_song].hash);
+							g->net.MakeIRsendScoreThread(ghostString);
 
 							if (!g->config.network.displayIr.length()) {
 								g->sSelect.bmsList[g->sSelect.cur_song].mybest.IRranking = g->net.rankingData.myRanking;

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1179,7 +1179,7 @@ int CmdSearch(game *g, CSTR *cmd, sqlite3 *sql) {
 				g->net.myRanking.judge = meta.judge;
 				g->net.myRanking.inputtype = 2; //TOFIX: input device MIDI??
 
-				g->net.myRanking.ghost = ReadGhost(sql, g->sSelect.bmsList[g->sSelect.cur_song].hash);
+				const CSTR ghostString = ReadGhost(sql, g->sSelect.bmsList[g->sSelect.cur_song].hash);
 				CSTR scorehash;
 				cstrSprintf(&scorehash, "%s%s%d%d", g->net.IR_passMD5.body, g->net.myRanking.songMD5.body, g->net.myRanking.exscore, g->net.myRanking.clear);
 				scorehash = MD5str(scorehash);
@@ -1211,7 +1211,7 @@ int CmdSearch(game *g, CSTR *cmd, sqlite3 *sql) {
 						g->net.myRanking.line,
 						g->net.myRanking.judge,
 						g->net.myRanking.inputtype,
-						g->net.myRanking.ghost.body,
+						ghostString.body,
 						g->net.myRanking.rseed,
 						g->net.myRanking.clear_db,
 						g->net.myRanking.clear_ex,

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1805,15 +1805,15 @@ int ProcS_Play(game *g, sqlite3* sql) {
 	if (g->net.rankingData.target_ID > 0) { // remove check isOnline. it will be processed integrally within GetTargetInfo along with the CustomIR.
 		g->gameplay.targetScore.InitJudgeQueue();
 		if ((g->gameplay.ghostBattle == 0 && g->gameplay.isAutoplay != 1) || g->gameplay.replay.status == 2) {
-			g->net.GetTargetInfo(*g, 0, md5, &gData, &gName, &iTemp, &iTemp, &iTemp, &iTemp, &iTemp, &iTemp);
+			g->net.GetTargetInfo(0, md5, &gData, &gName, &iTemp, &iTemp, &iTemp, &iTemp, &iTemp, &iTemp);
 		}
 		else {
 			int origGauge = g->config.play.gaugeOption[0];
 			//TOFIX : seed is not putted into replaydata, when use ghostbattle. (retry puts seed) (see also ParseBmsFile())
 			if(g->sSelect.bmsList[g->sSelect.cur_song].keymode > 9)
-				g->net.GetTargetInfo(*g, 0, md5, &gData, &gName, &g->config.play.gaugeOption[0], &g->config.play.random[0], &g->config.play.random[1], &g->config.play.dpflip, &g->gameplay.randomseed, &iTemp);
+				g->net.GetTargetInfo(0, md5, &gData, &gName, &g->config.play.gaugeOption[0], &g->config.play.random[0], &g->config.play.random[1], &g->config.play.dpflip, &g->gameplay.randomseed, &iTemp);
 			else
-				g->net.GetTargetInfo(*g, 0, md5, &gData, &gName, &g->config.play.gaugeOption[0], &g->config.play.random[0], &g->config.play.random[1], &iTemp, &g->gameplay.randomseed, &iTemp);
+				g->net.GetTargetInfo(0, md5, &gData, &gName, &g->config.play.gaugeOption[0], &g->config.play.random[0], &g->config.play.random[1], &iTemp, &g->gameplay.randomseed, &iTemp);
 			
 			g->config.play.gaugeOption[1] = g->config.play.gaugeOption[0];
 			g->config.play.random[1] = g->config.play.random[0];
@@ -1971,7 +1971,7 @@ int ProcS_Play(game *g, sqlite3* sql) {
 			case 7:
 				if (g->gameplay.isGhostDisabled == 0) {
 					iTemp = 0;
-					g->net.GetTargetInfo(*g, g->config.play.p1_target, md5, &gData, &gName, &iTemp, &iTemp, &iTemp, &iTemp, &iTemp, &iTemp);
+					g->net.GetTargetInfo(g->config.play.p1_target, md5, &gData, &gName, &iTemp, &iTemp, &iTemp, &iTemp, &iTemp, &iTemp);
 					if (gData.length() > 0 && g->config.play.p1_target != 8) {
 						g->gameplay.targetScore.DecodeGhostData(gData);
 						g->gameplay.targetScore.name = gName;
@@ -1992,7 +1992,7 @@ int ProcS_Play(game *g, sqlite3* sql) {
 				if (g->gameplay.isGhostDisabled == 0) {
 					iTemp = 0;
 					int exscore = 0;
-					g->net.GetTargetInfo(*g, g->config.play.p1_target, md5, &gData, &gName, &iTemp, &iTemp, &iTemp, &iTemp, &iTemp, &exscore);
+					g->net.GetTargetInfo(g->config.play.p1_target, md5, &gData, &gName, &iTemp, &iTemp, &iTemp, &iTemp, &iTemp, &exscore);
 					
 					if (exscore == 0) {
 						g->gameplay.targetScore.SetDefaultGhost(g->config.play.target_percent, g->gameplay.player[0].totalnotes);

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1802,19 +1802,18 @@ int ProcS_Play(game *g, sqlite3* sql) {
 		md5 = g->sSelect.bmsList[g->sSelect.cur_song].hash;
 	}
 
-	if (g->net.rankingData.target_ID > 0 && g->net.isOnline) {
+	if (g->net.rankingData.target_ID > 0) { // remove check isOnline. it will be processed integrally within GetTargetInfo along with the CustomIR.
 		g->gameplay.targetScore.InitJudgeQueue();
-		g->net.WaitAndInitRanking();
 		if ((g->gameplay.ghostBattle == 0 && g->gameplay.isAutoplay != 1) || g->gameplay.replay.status == 2) {
-			g->net.GetTargetInfo(0, md5, &gData, &gName, &iTemp, &iTemp, &iTemp, &iTemp, &iTemp, &iTemp);
+			g->net.GetTargetInfo(*g, 0, md5, &gData, &gName, &iTemp, &iTemp, &iTemp, &iTemp, &iTemp, &iTemp);
 		}
 		else {
 			int origGauge = g->config.play.gaugeOption[0];
 			//TOFIX : seed is not putted into replaydata, when use ghostbattle. (retry puts seed) (see also ParseBmsFile())
 			if(g->sSelect.bmsList[g->sSelect.cur_song].keymode > 9)
-				g->net.GetTargetInfo(0, md5, &gData, &gName, &g->config.play.gaugeOption[0], &g->config.play.random[0], &g->config.play.random[1], &g->config.play.dpflip, &g->gameplay.randomseed, &iTemp);
+				g->net.GetTargetInfo(*g, 0, md5, &gData, &gName, &g->config.play.gaugeOption[0], &g->config.play.random[0], &g->config.play.random[1], &g->config.play.dpflip, &g->gameplay.randomseed, &iTemp);
 			else
-				g->net.GetTargetInfo(0, md5, &gData, &gName, &g->config.play.gaugeOption[0], &g->config.play.random[0], &g->config.play.random[1], &iTemp, &g->gameplay.randomseed, &iTemp);
+				g->net.GetTargetInfo(*g, 0, md5, &gData, &gName, &g->config.play.gaugeOption[0], &g->config.play.random[0], &g->config.play.random[1], &iTemp, &g->gameplay.randomseed, &iTemp);
 			
 			g->config.play.gaugeOption[1] = g->config.play.gaugeOption[0];
 			g->config.play.random[1] = g->config.play.random[0];
@@ -1908,7 +1907,7 @@ int ProcS_Play(game *g, sqlite3* sql) {
 		ReadGhostToScore(sql,md5,&g->gameplay.highScore);
 	}
 
-	if (g->net.rankingData.target_ID > 0 && g->net.isOnline) {
+	if (g->net.rankingData.target_ID > 0) {
 		if (gData.length() <= 0 || gData.isDiff("Z") == 0) {
 			ErrorLogFmtAdd("ゴースト無しでターゲットを設定します ターゲット番号 %d ターゲット名 %s\n", g->net.rankingData.target_number, g->net.rankingData.ranking[g->net.rankingData.target_number].name.body);
 
@@ -1968,9 +1967,8 @@ int ProcS_Play(game *g, sqlite3* sql) {
 			case 6:
 			case 7:
 				if (g->gameplay.isGhostDisabled == 0) {
-					g->net.WaitAndInitRanking();
 					iTemp = 0;
-					g->net.GetTargetInfo(g->config.play.p1_target, md5, &gData, &gName, &iTemp, &iTemp, &iTemp, &iTemp, &iTemp, &iTemp);
+					g->net.GetTargetInfo(*g, g->config.play.p1_target, md5, &gData, &gName, &iTemp, &iTemp, &iTemp, &iTemp, &iTemp, &iTemp);
 					if (gData.length() > 0 && g->config.play.p1_target != 8) {
 						g->gameplay.targetScore.DecodeGhostData(gData);
 						g->gameplay.targetScore.name = gName;
@@ -1989,10 +1987,9 @@ int ProcS_Play(game *g, sqlite3* sql) {
 				break;
 			case 8:
 				if (g->gameplay.isGhostDisabled == 0) {
-					g->net.WaitAndInitRanking();
 					iTemp = 0;
 					int exscore = 0;
-					g->net.GetTargetInfo(g->config.play.p1_target, md5, &gData, &gName, &iTemp, &iTemp, &iTemp, &iTemp, &iTemp, &exscore);
+					g->net.GetTargetInfo(*g, g->config.play.p1_target, md5, &gData, &gName, &iTemp, &iTemp, &iTemp, &iTemp, &iTemp, &exscore);
 					
 					if (exscore == 0) {
 						g->gameplay.targetScore.SetDefaultGhost(g->config.play.target_percent, g->gameplay.player[0].totalnotes);

--- a/LR2/Scene05_Result.cpp
+++ b/LR2/Scene05_Result.cpp
@@ -6,6 +6,11 @@
 
 int ProcS_Result(game *g, sqlite3 *sql) {
 
+	g->gameplay.resultGhostForIr.clear();
+	CSTR ghostCstr = g->gameplay.p1Score.EncodeGhostData();
+	if (ghostCstr.length() > 0 && ghostCstr.isDiff("GHOST_ERROR") != 0) {
+		g->gameplay.resultGhostForIr = ghostCstr.body;
+	}
 	g->net.customIR.BeginResultIr(*g, sql, 0);
 
 	LoadSceneG(g, &g->skstruct, SKINTYPE_RESULT);

--- a/LR2/Scene13_Courseresult.cpp
+++ b/LR2/Scene13_Courseresult.cpp
@@ -147,7 +147,7 @@ int ProcS_subCourseResult(game *g, sqlite3 *sql) {
 			g->net.myRanking.clear_ex = g->sSelect.bmsList[g->sSelect.cur_song].mybest.clear_ex;
 			g->net.myRanking.line = g->sSelect.bmsList[g->sSelect.cur_song].keymode;
 			g->net.myRanking.inputtype = DetermineResultPlayDevice(&g->KeyInput);
-			const CSTR ghostString = "Z";
+			std::string ghostString = "Z";
 			g->net.MakeIRsendScoreThread(ghostString);
 
 			if (!g->config.network.displayIr.length()) {

--- a/LR2/Scene13_Courseresult.cpp
+++ b/LR2/Scene13_Courseresult.cpp
@@ -147,8 +147,8 @@ int ProcS_subCourseResult(game *g, sqlite3 *sql) {
 			g->net.myRanking.clear_ex = g->sSelect.bmsList[g->sSelect.cur_song].mybest.clear_ex;
 			g->net.myRanking.line = g->sSelect.bmsList[g->sSelect.cur_song].keymode;
 			g->net.myRanking.inputtype = DetermineResultPlayDevice(&g->KeyInput);
-			g->net.myRanking.ghost = "Z";
-			g->net.MakeIRsendScoreThread();
+			const CSTR ghostString = "Z";
+			g->net.MakeIRsendScoreThread(ghostString);
 
 			if (!g->config.network.displayIr.length()) {
 				g->sSelect.bmsList[g->sSelect.cur_song].mybest.IRranking = g->net.rankingData.myRanking;

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1424,8 +1424,8 @@ struct NETWORK {
 
 	int GetRivalInfo(int ID_rival);
 
-	int GetTargetInfo(int mode, CSTR songmd5, CSTR * oStr1, CSTR * oStr2, int * oDigit1, int * oDigit2, int * oDigit3, int * oDigit4, int * oUnk, int * oExscore);
-	bool GetTargetInfo(game& g, int mode, CSTR songmd5, CSTR * oStr1, CSTR * oStr2, int * oDigit1, int * oDigit2, int * oDigit3, int * oDigit4, int * oUnk, int * oExscore);
+	int LR2IR_GetTargetInfo(int mode, CSTR songmd5, CSTR * oStr1, CSTR * oStr2, int * oDigit1, int * oDigit2, int * oDigit3, int * oDigit4, int * oUnk, int * oExscore);
+	bool GetTargetInfo(int mode, CSTR songmd5, CSTR * oStr1, CSTR * oStr2, int * oDigit1, int * oDigit2, int * oDigit3, int * oDigit4, int * oUnk, int * oExscore);
 	NETWORK();
 	int WS_clean();
 	int Login(int isDirectPlay);

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1305,7 +1305,8 @@ struct gameplay {
 	float earthquake_y;
 	int bpmChangedRealtime; /* timer142 */
 	int bpmChangedBmstime; /* bpm change timing */
-	char ghostBattle; 
+	char ghostBattle;
+	std::string resultGhostForIr;
 	struct CONFIG_PLAY targetCfg; /* //1p_speed ~ struct */
 	int delayDetectedCount;
 	int delayCheckCount;

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <future>
 #include <mutex>
+#include <string>
 #include <thread>
 #include <unordered_map>
 #include <vector>
@@ -1423,7 +1424,7 @@ struct NETWORK {
 	NETWORK();
 	int WS_clean();
 	int Login(int isDirectPlay);
-	int MakeIRsendScoreThread(CSTR ghostString);
+	int MakeIRsendScoreThread(std::string ghostString);
 };
 
 struct game {

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1179,7 +1179,7 @@ struct PLAYSCORE {
 	char GetJudgeFromQueue(void);
 	int SetDefaultGhost(int target, int notes);
 	int SetGhost(int exscore, int notes, CSTR name);
-	CSTR EncodeGhostData(void);
+	CSTR EncodeGhostData(void) const;
 	int DecodeGhostData(CSTR data);
 	int SetScore(PLAYERSTATUS *pstat, char flagExpect);
 };

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -27,6 +27,7 @@
 
 
 struct sqlite3;
+struct game;
 
 typedef unsigned char   undefined;
 typedef unsigned int    ImageBaseOffset32;
@@ -1411,12 +1412,14 @@ struct NETWORK {
 	void ParseRankingXml(const char* path);
 
 	int HTTPrequest();
+	void WaitForRankingHandle();
 	void WaitAndInitRanking();
 	int GetRanking(CSTR hash, char flagInit);
 
 	int GetRivalInfo(int ID_rival);
 
 	int GetTargetInfo(int mode, CSTR songmd5, CSTR * oStr1, CSTR * oStr2, int * oDigit1, int * oDigit2, int * oDigit3, int * oDigit4, int * oUnk, int * oExscore);
+	bool GetTargetInfo(game& g, int mode, CSTR songmd5, CSTR * oStr1, CSTR * oStr2, int * oDigit1, int * oDigit2, int * oDigit3, int * oDigit4, int * oUnk, int * oExscore);
 	NETWORK();
 	int WS_clean();
 	int Login(int isDirectPlay);

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1423,7 +1423,7 @@ struct NETWORK {
 	NETWORK();
 	int WS_clean();
 	int Login(int isDirectPlay);
-	int MakeIRsendScoreThread();
+	int MakeIRsendScoreThread(CSTR ghostString);
 };
 
 struct game {

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -879,7 +879,7 @@ struct MYRANKING {
 	int clear_sd;
 	int clear_db;
 	int rseed;
-	CSTR ghost; /* struct to? */
+	CSTR _ghost; // TODO: remove when we throw out memset usage
 
 	void InitRanking();
 };


### PR DESCRIPTION
This PR includes features to transmit Ghosts and support battles with them.

In this process, I also fixed the ghost data resetting issue that @MatVeiQaaa  pointed out previously. This task includes the refactoring of LR2IR (handling ghostString by receiving it as a parameter) and the process of saving the ghost separately in MakeScoreV1 and initializing the buffer before proceeding with the IR transmission.

The ghostData is currently an LR2-exclusive specification, and we currently support sending and receiving ghostData generated in LR2. (We might need to modify this in the future if other IRs require different Ghost specifications.)