### PR TITLE
[Bugfix] Add EXTENDEDPLAYERSTATS.cb by 1 on BAD

### DIFF
--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -845,6 +845,7 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			auto increment_extended = [](EXTENDEDPLAYERSTATS& stats, bool isFast, int offset) {
 				isFast ? stats.ebd++ : stats.lbd++;
 				isFast ? stats.fast++ : stats.slow++;
+				stats.cb++;
 				stats.lastFastSlow = isFast ? 1 : 2;
 				stats.noteCount++;
 				stats.lastHitOffset = offset;


### PR DESCRIPTION
<img width="1280" height="720" alt="LR2 2026-06-23 00-12-46" src="https://github.com/user-attachments/assets/cb234ce5-d29e-47e3-94d4-6540cc42b9f6" />

`SetObjectValue_Num` in skinobject returns combo break stat (`EXTENDEDPLAYERSTATS.cb`) when case number is 216,
but I found `EXTENDEDPLAYERSTATS.cb` is only added by 1 on lpr(Late-poor, missing notes).
So I also made it add `EXTENDEDPLAYERSTATS.cb` by 1 also on BAD.
