### PR TITLE
feat: user-configurable resolution via openlr2-config.xml

### DIFF
--- a/LR2/En_graphic.cpp
+++ b/LR2/En_graphic.cpp
@@ -14,6 +14,16 @@ int SetBackground(int hImage) {
 
 int screenSizeX, screenSizeY;
 int skinSizeX, skinSizeY;
+
+// Maps the global resolution counter (config.system.resolution) to pixels.
+void GetConfigResolution(int counter, int* outX, int* outY) {
+	switch (counter) {
+		case 1:  *outX = 1280; *outY = 720;  break;  // HD
+		case 2:  *outX = 1920; *outY = 1080; break;  // UHD (experimental)
+		default: *outX = 640;  *outY = 480;  break;  // SD
+	}
+}
+
 int Resize(game* g, double skinX, double skinY, bool bit16) {
 	int oldXpos = 320, oldYpos = 240;
 

--- a/LR2/En_graphic.h
+++ b/LR2/En_graphic.h
@@ -7,5 +7,6 @@ extern int hBackImage;
 int SetBackground(int hImage);
 
 int Resize(game* g, double skinX, double skinY, bool bit16);
+void GetConfigResolution(int counter, int* outX, int* outY);
 extern int skinSizeX, skinSizeY;
 extern int screenSizeX, screenSizeY;

--- a/LR2/LR2_configsave.cpp
+++ b/LR2/LR2_configsave.cpp
@@ -574,6 +574,10 @@ int WriteOpenLr2ConfigXml(game *g, const char *filename){
 	fputs("<?xml version=\"1.0\" encoding=\"shift_jis\"?>\n", pFile);
 	fputs("<config>\n", pFile);
 
+	fputs("\t<system>\n", pFile);
+	WriteXML_Tab2Int(pFile, "resolution", (g->config).system.resolution);
+	fputs("\t</system>\n", pFile);
+
 	fputs("\t<play>\n", pFile);
 	sprintf(buf, "\t\t<%s>%d</%s>\n", "gaugeautoshift", (g->config).play.m_gas, "gaugeautoshift");
 	fputs(buf, pFile);
@@ -1176,6 +1180,7 @@ int ReadOpenLr2Config(game* g, const char* filepath) {
 		delete(hXml);
 		hXml = nullptr;
 	}
+	ReadXml_Int("config", "system", "resolution", 0, &g->config.system.resolution, hXml);
 	ReadXml_PositiveIntAsBool("config", "play", "gaugeautoshift", false, &g->config.play.m_gas, hXml);
 	ReadXml_Str("config", "skin", "courseresult", "", &g->config.skin.skinFilePath[15], hXml);
 	ReadXml_Str("config", "network", "display_ir", "", &g->config.network.displayIr, hXml);

--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -370,7 +370,7 @@ int InitSkin(skstruct *sk, int /*unused*/, char font) {
 	sk->customfile_count = 0;
 	
 	DeleteGraph(sk->GrHandle[GrH_Preview]);
-	sk->GrHandle[GrH_Preview] = MakeGraph(skinSizeX, skinSizeY); //TODO_RESOULUTION	
+	sk->GrHandle[GrH_Preview] = MakeGraph(skinSizeX, skinSizeY); //TODO_RESOULUTION
 	DeleteGraph(sk->GrHandle[104]);
 	sk->GrHandle[104] = MakeGraph(256, 256);
 	if (sk->GrHandle[GrH_Stage] == -1) sk->GrHandle[GrH_Stage] = MakeGraph(640, 480);
@@ -1741,8 +1741,16 @@ int LoadScene(skstruct* sk, CSTR skinfile, int p5, char font) {
 int LoadSceneG(game* g, skstruct* sk, int skinNum, int font) {
 	CSTR skinfile(g->config.skin.skinFilePath[skinNum]);
 
-	Resize(g, g->skinData.Data[g->skinData.skinID[skinNum]].targetX, g->skinData.Data[g->skinData.skinID[skinNum]].targetY, 0);
-	
+	const SkinHeader& skin = g->skinData.Data[g->skinData.skinID[skinNum]];
+	if (skin.hasResolutionTag) {
+		Resize(g, skin.targetX, skin.targetY, 0);   // per-skin #RESOLUTION wins
+	}
+	else {
+		int resX, resY;
+		GetConfigResolution(g->config.system.resolution, &resX, &resY);
+		Resize(g, resX, resY, 0);                    // fallback to config global
+	}
+
 	LoadScene(sk, skinfile, g->skinData.Data[g->skinData.skinID[skinNum]].informationP5, font);
 	return 0;
 }

--- a/LR2/LR2_skinmanage.cpp
+++ b/LR2/LR2_skinmanage.cpp
@@ -275,6 +275,7 @@ int ParseLR2SkinCustom(SkinManage *skm, CSTR filepath) {
 				skm->Data[skm->Count - 1].targetY = (csvBuf.val[2] < 480) ? 480 : csvBuf.val[2];
 				break;
 			}
+			skm->Data[skm->Count - 1].hasResolutionTag = true;
 		}
 		else if (buffer.left(13).isSame("#CUSTOMOPTION")) {
 			SplitCSV(buffer, &csvBuf, ",");

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -292,7 +292,9 @@ int main(int argc, char** argv) {
 	gs.timer1.movieFramerate = (double)gs.config.tools.movie_framerate;
 	gs.timer1.movieTimer = 0.0;
 
-	SetGraphMode(640, 480, (gs.config.system.highcolor == 0) ? 32 : 16, 60);
+	int resX, resY;
+	GetConfigResolution(gs.config.system.resolution, &resX, &resY);
+	SetGraphMode(resX, resY, (gs.config.system.highcolor == 0) ? 32 : 16, 60);
 	if (gs.rec.recMode == 3) {
 		SetGraphMode(256, 256, 32, 60);
 	}
@@ -314,7 +316,7 @@ int main(int argc, char** argv) {
 	}
 	else {
 		if ((gs.is_recordmode == '\0') && (gs.rec.recMode == 0)) {
-			SetWindowSizeExtendRate((double)gs.config.system.windowsize_x / 640.0, (double)gs.config.system.windowsize_y / 480.0); //TODO_RESOULUTION
+			SetWindowSizeExtendRate((double)gs.config.system.windowsize_x / resX, (double)gs.config.system.windowsize_y / resY);
 			if (gs.is_starter) { //unreachable duplicated code
 				if (MessageBoxA(NULL, "フルスクリーンモードで起動しますか？", "確認", 4) == 6) {
 					gs.config.system.screenmode = 0;
@@ -1933,7 +1935,7 @@ int main(int argc, char** argv) {
 					for (int i = 0; i < 10; i++) {
 						gs.skstruct.ImageFonts[i].filepath[0] = 0;
 					}
-					SetGraphMode(640, 480, (gs.config.system.highcolor == 0 ? 32 : 16), 60); //TODO_RESOULUTION
+					SetGraphMode(resX, resY, (gs.config.system.highcolor == 0 ? 32 : 16), 60); //redundant?
 					SetWaitVSyncFlag(0); //VSYNC
 #ifdef _WIN32
 					ChangeWindowMode(gs.config.system.screenmode);
@@ -1977,7 +1979,7 @@ int main(int argc, char** argv) {
 					for (int i = 0; i < 10; i++) {
 						gs.skstruct.ImageFonts[i].filepath[0] = 0;
 					}
-					SetGraphMode(640, 480, (gs.config.system.highcolor == 0 ? 32 : 16), 60); //TODO_RESOULUTION
+					SetGraphMode(resX, resY, (gs.config.system.highcolor == 0 ? 32 : 16), 60); //redundant?
 					SetWaitVSyncFlag(0); //VSYNC
 #ifdef _WIN32
 					ChangeWindowMode(gs.config.system.screenmode);
@@ -2218,7 +2220,7 @@ int main(int argc, char** argv) {
 			for (int i = 0; i < 10; i++) {
 				gs.skstruct.ImageFonts[i].filepath[0] = 0;
 			}
-			SetGraphMode(640, 480, (gs.config.system.highcolor == 0 ? 32 : 16), 60); //TODO_RESOULUTION
+			SetGraphMode(resX, resY, (gs.config.system.highcolor == 0 ? 32 : 16), 60); //redundant?
 			SetWaitVSyncFlag(0); //VSYNC
 #ifdef _WIN32
 			ChangeWindowMode(gs.config.system.screenmode);
@@ -2247,7 +2249,7 @@ int main(int argc, char** argv) {
 			for (int i = 0; i < 10; i++) {
 				gs.skstruct.ImageFonts[i].filepath[0] = 0;
 			}
-			SetGraphMode(640, 480, (gs.config.system.highcolor == 0 ? 32 : 16), 60); //TODO_RESOULUTION
+			SetGraphMode(resX, resY, (gs.config.system.highcolor == 0 ? 32 : 16), 60); //redundant?
 			SetDrawScreen(DX_SCREEN_BACK);
 			LoadSceneG(&gs, &gs.skstruct, SKINTYPE_SELECT);
 			SetWaitVSyncFlag(0); //VSYNC

--- a/LR2/Scene07_Skinselect.cpp
+++ b/LR2/Scene07_Skinselect.cpp
@@ -257,9 +257,17 @@ int ProcI_SkinSelect(game *g) {
 
 
 
-	int& tx = g->skinData.Data[g->skinData.previewID].targetX;
-	int& ty = g->skinData.Data[g->skinData.previewID].targetY;
-	if (!(tx == 640 && ty == 480)) {
+	// effective resolution of the previewed skin: per-skin #RESOLUTION wins, else config global
+	const SkinHeader& pskin = g->skinData.Data[g->skinData.previewID];
+	int tx, ty;
+	if (pskin.hasResolutionTag) {
+		tx = pskin.targetX;
+		ty = pskin.targetY;
+	}
+	else {
+		GetConfigResolution(g->config.system.resolution, &tx, &ty);
+	}
+	if (!(tx == skinSizeX && ty == skinSizeY)) {
 		g->skstruct.GrHandle[106] = MakeScreen(tx, ty);
 		SetDrawScreen(g->skstruct.GrHandle[106]);
 	}
@@ -269,11 +277,11 @@ int ProcI_SkinSelect(game *g) {
 	}
 
 	SetDrawScreen(DX_SCREEN_BACK); //there is a flickering in not SD skins preview
-	if (!(tx == 640 && ty == 480)) {
-		DrawExtendGraph(0, 0, 640, 480, g->skstruct.GrHandle[106], 1);
+	if (!(tx == skinSizeX && ty == skinSizeY)) {
+		DrawExtendGraph(0, 0, skinSizeX, skinSizeY, g->skstruct.GrHandle[106], 1);
 		DeleteGraph(g->skstruct.GrHandle[106]);
 	}
-	ScreenCapture(g->skstruct.GrHandle[GrH_Preview], 640, 480); //thumbnail size is fixed as SRC 105(GrH_Preview], in skin file
+	ScreenCapture(g->skstruct.GrHandle[GrH_Preview], skinSizeX, skinSizeY); //thumbnail size is fixed as SRC 105(GrH_Preview], in skin file
 	
 	clsDx();
 	InitDrawingBuffer(&g->skstruct2.drBuf);
@@ -285,15 +293,15 @@ int MakeSkinPreview(game* g, skstruct* sk, SkinManage* sm) {
 	if (g->config.system.disableskinpreview == 1 || sm->Data[sm->previewID].type == SKINTYPE_SOUNDSET) {
 		int grh = LoadGraph(sm->Data[sm->previewID].thumbnail, 0);
 		if (grh != -1) {
-			DrawExtendGraph(0, 0, 640, 480, grh, 0);
-			ScreenCapture(g->skstruct.GrHandle[GrH_Preview], 640, 480);
+			DrawExtendGraph(0, 0, skinSizeX, skinSizeY, grh, 0);
+			ScreenCapture(g->skstruct.GrHandle[GrH_Preview], skinSizeX, skinSizeY);
 			DeleteGraph(grh);
 		}
 		//TOFIX : when no thumbnail, previsous selected thumbnail remains, I don't know how to draw that "thumbnail" image)
 		//thumbnail size is fixed, in skin file. it is SRC 105
 		else {
-			DrawBox(0, 0, 640, 480, 0x00000000, 1, 1);
-			ScreenCapture(g->skstruct.GrHandle[GrH_Preview], 640, 480);
+			DrawBox(0, 0, skinSizeX, skinSizeY, 0x00000000, 1, 1);
+			ScreenCapture(g->skstruct.GrHandle[GrH_Preview], skinSizeX, skinSizeY);
 		}
 		return 0;
 	}

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -348,6 +348,7 @@ struct CONFIG_SYSTEM {
 	int windowsize_y{};
 	int maindisplay{};
 	int softwarerendering{};
+	int resolution{};   // 0=SD 640x480, 1=HD 1280x720, 2=UHD 1920x1080
 	unsigned int coreCount = 0;
 };
 
@@ -1484,6 +1485,7 @@ struct SkinHeader { /* SkinInfo */
 	int custom_count;
 
 	//RESOLUTION
+	bool hasResolutionTag = false; // true if the skin declared #RESOLUTION; else fall back to config global
 	int targetX = 640;
 	int targetY = 480;
 };

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ https://web.archive.org/web/20190802100906/http://www.dream-pro.info/~lavalse/LR
 
 - Add the corresponding #RESOLUTION under #INFORMATION in your .lr2skin files for each of the game scenes (music select, decide, play, result, course result...) Refer to the image above as an example.
 
+- You can also set default resolution in "LR2files/Config/openlr2-config.xml" (0:SD 1:HD 2:FHD)
+
 ## Known issues
 
 - score save issue on NONSTOP MIX


### PR DESCRIPTION
## Summary

Adds user-configurable resolution with a hybrid model: if a skin declares `#RESOLUTION` in its `.lr2skin` file, that resolution is used. If it doesn't, the game falls back to a global resolution set by the user in `openlr2-config.xml` (0=640x480, 1=1280x720, 2=1920x1080).

Previously, skins without `#RESOLUTION` were locked to 640x480 with no way to change it. Now the user can set their preferred default resolution and skins that declare their own still work as before.

## What changed

LR2/structure.h`**: Added `resolution{}` field to `CONFIG_SYSTEM` and `hasResolutionTag` flag to `SkinHeader` to track whether a skin explicitly declared `#RESOLUTION`.

- **`LR2/LR2_skinmanage.cpp`**: During skin parsing, `hasResolutionTag` is set to `false` by default and `true` when `#RESOLUTION` is found.

- **`LR2/En_graphic.cpp` + `En_graphic.h`**: Added `GetConfigResolution(int counter, int* outX, int* outY)` helper that maps the config counter to pixel dimensions.

- **`LR2/LR2_skinload.cpp`**: `LoadSceneG()` now checks `hasResolutionTag` — if true, uses the skin's resolution; if false, uses the global config fallback via `GetConfigResolution`.

- **`LR2/LR2_configsave.cpp`**: Resolution is read/written from `openlr2-config.xml` under `<system>`. This is for future implementation on new clients (i hope).

- **`LR2/Main.cpp`**: Startup `SetGraphMode` and `SetWindowSizeExtendRate` now use the global resolution instead of hardcoded 640x480.

- **`LR2/Scene07_Skinselect.cpp`**: Skin preview now respects the hybrid model and uses `skinSizeX`/`skinSizeY` instead of hardcoded 640x480.

## Why it's safe

- Default value is `0` (640x480), so existing users without the config field get the same behavior as before.
- Skins that declare `#RESOLUTION` are unaffected — their resolution takes priority.
- The config lives in `openlr2-config.xml` which the external configurator does not touch.

## Testing

- Once you close the game, the label <system><resolution>0</resolution></system> is going to be created on openLR2/config.xml, 0 being the default behaviour.
- Edit <resolution>0</resolution> to 1 or 2 for change the desired resolution (1=1280x720 or 2=1920x1080)
- Check gameplay and skin preview.

## W h y...

At this point, a lot of people has #RESOLUTION implemented on their skins so, for those who has HD skins-only or wanted to try an UHD approach (using the skin converter) without the need of modifying the .lr2skin on _every single folder_, this could be a good approach for manual resolution handling.