### PR TITLE
fix: update op 218 to return the current note on the result screen

### DIFF
--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -2117,7 +2117,7 @@ uint SetObjectValue_Num(game *g, int op) {
 			}
 			break;
 		case 218:
-			if (g->procSelecter == 4) {
+			if (g->procSelecter == 4 || g->procSelecter == 5) {
 				return g->gameplay.player[0].note_current;
 			}
 			return g->net.rankingData.clearPlayers[5];


### PR DESCRIPTION

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/bf60fa0c-659c-423d-ae8d-2e5dc503eac2" />

Seems like there are some skins that use op 218 on the result screen to display dead notes.