### PR TITLE
Implement F/S rate bargraph and fix guage button opcode

### DIFF
--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -3265,8 +3265,8 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 			case 41:
 				if (g->config.play.battle == 1) {
 					isClickSuccess = g->procSelecter == 4 || g->procSelecter == 5 || g->procSelecter == 13 ?
-						ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->gameplay.player[0].gaugeType, 0, 5, g->sSelect.panel) :
-						ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.gaugeOption[0], 0, 5, g->sSelect.panel);
+						ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->gameplay.player[1].gaugeType, 0, 5, g->sSelect.panel) :
+						ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.gaugeOption[1], 0, 5, g->sSelect.panel);
 					if (isClickSuccess == 2) {
 						PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 						SetObjectStrings_SongSelect(g);

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -2463,6 +2463,32 @@ int SetObjectValue_Bargraph(game *g) {
 					max = mybest.total_notes * 2;
 					val = mybest.stat_exscore;
 					break;
+
+				case 48:
+					max = g->gameplay.player[0].extendedStats.slow + g->gameplay.player[0].extendedStats.fast;
+					val = g->gameplay.player[0].extendedStats.slow;
+					break;
+
+				case 49:
+					max = g->gameplay.player[0].extendedStats.slow + g->gameplay.player[0].extendedStats.fast;
+					val = g->gameplay.player[0].extendedStats.fast;
+					break;
+
+				case 58:
+					if (g->config.play.battle == 1) {
+						max = g->gameplay.player[1].extendedStats.slow + g->gameplay.player[1].extendedStats.fast;
+						val = g->gameplay.player[1].extendedStats.slow;
+					}
+					else continue;
+					break;
+
+				case 59:
+					if (g->config.play.battle == 1) {
+						max = g->gameplay.player[1].extendedStats.slow + g->gameplay.player[1].extendedStats.fast;
+						val = g->gameplay.player[1].extendedStats.fast;
+					}
+					else continue;
+					break;
 			}
 
 			if (val > 0) {

--- a/OpcodeScript/bargraphOP.txt
+++ b/OpcodeScript/bargraphOP.txt
@@ -43,3 +43,8 @@
 45 HIGHSCORE_MAXCOMBO_totalnotes
 46 HIGHSCORE_SCORE_200000
 47 HIGHSCORE_EXSCORE_totalnotes__2
+
+48 1P_ratio_slow
+49 1P_ratio_fast
+58 2P_ratio_slow
+59 2P_ratio_slow


### PR DESCRIPTION
<img width="2564" height="752" alt="image" src="https://github.com/user-attachments/assets/19078125-02e6-4006-90bf-a6edf0c69f8a" />

( <- 260623 / This PR branch ->)
This PR implements F/S rate bargraph opcode (from the F/S patched LR2HD).
Opcodes 48 and 49 return Player 1's fast/slow ratio.  
According to the documentation, opcodes 58 and 59 should return Player 2's fast/slow ratio. However, this did not work in the specific LR2HD version I have.

Since the actual implementation details of LR2HD are unknown, there might be some differences. However, I believe the intended return values should remain the same.

This PR also fixes button opcode 41, which was returning Player 1's gauge instead of Player 2's.

I'm not sure if the F/S opcodes need to be added to OpcodeScript, and I'm also not exactly sure how to modify it.