### PR TITLE
feat(customir): add songPlayLevel and reserved tail fields to IRScoreV1

### DIFF
--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -383,6 +383,7 @@ struct IRScoreInternal {
 	double rate{};
 	int clearType{};
 	int inputType{};
+	int songPlayLevel{};
 	std::string ghostData;
 	struct GRAPHDATA {
 		std::array<std::array<int, 1000>, 6> hp{};
@@ -488,6 +489,7 @@ void IRScoreInternal::MakeScoreV1(IRScoreV1& scoreOut) const {
 	scoreOut.graphs.exscore = graphs.exscore;
 	scoreOut.graphs.rate = graphs.rate;
 	scoreOut.ghostData = ghostData;
+	scoreOut.songPlayLevel = songPlayLevel;
 }
 
 IRScoreInternal::IRScoreInternal(game& game, sqlite3* sql, int _player) {
@@ -508,6 +510,7 @@ IRScoreInternal::IRScoreInternal(game& game, sqlite3* sql, int _player) {
 		song.longnote = songData.longnote;
 		song.random = songData.random;
 		song.judge = songData.judge;
+		songPlayLevel = songData.level;
 	}
 	else {
 		song.hash = curSong.hash.body;
@@ -523,6 +526,7 @@ IRScoreInternal::IRScoreInternal(game& game, sqlite3* sql, int _player) {
 		song.judge = curSong.judge;
 		song.courseStageCount = curSong.courseStageCount;
 		song.courseType = curSong.courseType;
+		songPlayLevel = curSong.level;
 	}
 	CONFIG_PLAY& cfg = game.config.play;
 	settings.gaugeOption = cfg.gaugeOption[_player];

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -111,13 +111,10 @@ struct IRScoreV1 {
 	std::string ghostData;
 	// Chart level at play time (SONGDATA::level). 0 if unknown or not applicable.
 	int songPlayLevel{};
-	bool reserved1{};
-	bool reserved2{};
-	bool reserved3{};
+	uint64_t reserved1{};
+	uint64_t reserved2{};
+	uint64_t reserved3{};
 	uint64_t reserved4{};
-	uint64_t reserved5{};
-	uint64_t reserved6{};
-	uint64_t reserved7{};
 };
 
 enum class SendScoreStatus: int {

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -109,6 +109,15 @@ struct IRScoreV1 {
 	} graphs{};
 	// In LR2 ghost format. May not be present in some cases, e.g. course scores. Example: E@3ZZ.
 	std::string ghostData;
+	// Chart level at play time (SONGDATA::level). 0 if unknown or not applicable.
+	int songPlayLevel{};
+	bool reserved1{};
+	bool reserved2{};
+	bool reserved3{};
+	uint64_t reserved4{};
+	uint64_t reserved5{};
+	uint64_t reserved6{};
+	uint64_t reserved7{};
 };
 
 enum class SendScoreStatus: int {


### PR DESCRIPTION
Fixes https://github.com/GOMazk/OpenLR2/issues/163

The `level` field was not included in the `IRScoreV1` structure, preventing `CustomIR` from reading the level. This patch addresses that issue.
As advised in the issue, to avoid breaking ABI compatibility, `level` has been added to the very end of the structure, and reserved slots have also been included following the previous format.