### PR TITLE
fix(bmsload): use correct value type for #BPM (RE issue)

### DIFF
--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -2449,7 +2449,7 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 				isPMS = is9key;
 			}
 			else if (fBuf.left(5).isSame("#BPM ")) {
-				int val = atof(fBuf.right(fBuf.length() - 5));
+				double val = atof(fBuf.right(fBuf.length() - 5));
 				if (gp->BPM_fix <= 0.0) {
 					gp->BPM_fix = val * gp->freqSpeedMultiplier;
 				}


### PR DESCRIPTION
Fixes https://github.com/GOMazk/OpenLR2/issues/171 "Decimal part of #BPM is ignored".