### PR TITLE
Small refactorings

### DIFF
--- a/LR2/En_audio.cpp
+++ b/LR2/En_audio.cpp
@@ -518,11 +518,6 @@ int SOUND_normalize(AUDIO */*aud*/, SOUNDDATA *sound){
 	
 	memcpy(sound->raw.data, sound, len);
 
-	if (sound->raw.bits == 8 && sound->flag2c) { //TODO : flag2c rename
-		for (uint i = 0; i < len; i++) {
-			sound->raw.data[i] += 0x80;
-		}
-	}
 
 	FMOD_Sound_Unlock(sound->fmod_sound, ptr1, ptr2, len1, len2);
 	
@@ -634,7 +629,6 @@ int LoadSound(AUDIO *aud, SOUNDDATA *sound, CSTR filepath, int loop, int /*disab
 			result = FMOD_System_CreateSound(aud->fmodSys, filepath.body, mode, nullptr, &sound->fmod_sound);
 		}
 
-		sound->flag2c = 0;
 		sound->loop = (loop != 0);
 		if (result == FMOD_OK) {
 			sound->filename.assign(&filepath);
@@ -664,7 +658,6 @@ int LoadSound(AUDIO *aud, SOUNDDATA *sound, CSTR filepath, int loop, int /*disab
 	sound->length = GetSoundTotalTime(sound->soundHandle);
 	sound->load = 1;
 	sound->loop = (loop != 0);
-	sound->unused0C = 0;
 	return 1;
 }
 
@@ -1173,15 +1166,6 @@ int InitSound(AUDIO *aud, uint bufferLength, int numBuffer, char fDisable, int o
 		return 0;
 	}
 	return 1;
-}
-
-RAWSOUND::RAWSOUND() {
-	channels = 0;
-	samples = 0;
-	bits = 0;
-	length = 0;
-	dataSize = 0;
-	data = NULL;
 }
 
 void RAWSOUND::ExpandBuffer(int minSize) { 

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -318,8 +318,6 @@ int InitGameplay(gameplay *gp, CONFIG_PLAY *cfg) {
 	}
 	for (int i = 0; i < SLOTS; i++) {
 		gp->bgaHandle[i] = -1;
-		gp->bgaHandleHandle[i] = -1;
-		gp->bgaUnused656b8[i] = 0;
 	}
 	gp->bgaLayer1 = -1;
 	gp->bgaLayer2 = -1;
@@ -708,7 +706,6 @@ int InitGameplay_retry(gameplay *gp, AUDIO *snd, game *g) {
 	for (int i = 0; i < SINGLESLOTS; i++) {
 		PauseMovieToGraph(gp->bgaHandle[i]);
 		SeekMovieToGraph(gp->bgaHandle[i], 0);
-		gp->bgaHandleHandle[i] = -1;
 	}
 
 	gp->BPM = gp->BPM_fix;

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -21,12 +21,10 @@
 
 void MYRANKING::InitRanking() {
 	this->songMD5.fillzero();
-	this->unused.fillzero();
 	this->passMD5.fillzero();
 	this->title.fillzero();
 	this->genre.fillzero();
 	this->artist.fillzero();
-	this->_ghost.fillzero();
 	this->maxbpm = 0;
 	this->minbpm = 0;
 	this->playlevel = 0;
@@ -90,8 +88,6 @@ void RANKING::Init() {
 	for (int i = 0; i < this->rankingMax; i++) {
 		this->ranking[i].name.fillzero();
 		this->ranking[i].id = 0;
-		this->ranking[i].sp = 0;
-		this->ranking[i].dp = 0;
 		this->ranking[i].clear = 0;
 		this->ranking[i].notes = 0;
 		this->ranking[i].combo = 0;
@@ -101,8 +97,6 @@ void RANKING::Init() {
 		this->ranking[i].bd = 0;
 		this->ranking[i].pr = 0;
 		this->ranking[i].minbp = 0;
-		this->ranking[i].option = 0;
-		this->ranking[i].sussussuspected = 0;
 		this->ranking[i].playcount = 0;
 		this->ranking[i].ranking = 0;
 		this->ranking[i].comment.fillzero();

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -626,6 +626,8 @@ int NETWORK::HTTPrequest() {
 	ErrorLogAdd(this->request_debug);
 	return 0;
 #else
+	cstrSprintf(&this->request_debug, "Linux user error\n");
+	ErrorLogAdd(this->request_debug);
 	return -1; // TODO(linux): stub
 #endif // _WIN32
 }
@@ -862,14 +864,6 @@ int NETWORK::LR2IR_Login(int isDirectPlay) {
 		this->isOnline = false;
 		ErrorLogAdd(this->request_debug);
 		WSACleanup();
-		return -99;
-	}
-#else
-	if (true) { // TODO(linux): stub
-		this->request_debug = "linux\n";
-		this->request_result = "happy with yourself?\n";
-		this->isOnline = false;
-		ErrorLogAdd(this->request_debug);
 		return -99;
 	}
 #endif // _WIN32

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -544,7 +544,7 @@ int NETWORK::HTTPrequest() {
 		}
 
 		unsigned long argp = 1;
-		ioctlsocket(s, 0x8004667e, &argp);
+		ioctlsocket(s, FIONBIO, &argp);
 
 		request.fillzero();
 		cstrSprintf(&request, "POST %s HTTP/1.0\r\n"

--- a/LR2/LR2_skinmanage.cpp
+++ b/LR2/LR2_skinmanage.cpp
@@ -243,7 +243,6 @@ int ParseLR2SkinCustom(SkinManage *skm, CSTR filepath) {
 			skm->Data[skm->Count].maker.assign(&csvBuf.str[3]);
 			skm->Data[skm->Count].thumbnail.assign(&csvBuf.str[4]);
 			skm->Data[skm->Count].informationP5 = csvBuf.val[5];
-			skm->Data[skm->Count].unused18 = -1;
 			skm->Data[skm->Count].targetX = csvBuf.val[6] < 640 ? 640 : csvBuf.val[6];
 			skm->Data[skm->Count].targetY = csvBuf.val[7] < 480 ? 480 : csvBuf.val[7];
 			skm->Count ++;

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -2,6 +2,7 @@
 #include "Engine.h"
 #include "LR2.h"
 #include "filesystem.h"
+#include <filesystem>
 #include <format>
 #include <functional>
 #include <stdio.h>
@@ -585,14 +586,6 @@ int LoadFontForSongs(game *gs, char flag) {
 
 
 int ShowReadmes(game *g) {
-#ifdef _WIN32
-	CSTR search;
-	HANDLE hFindFile;
-	WIN32_FIND_DATAW FindFileData;
-	CSTR fBuf(2048);
-
-	FILE *pFile;
-
 	g->txtStruct.readme.file_count = 0;
 	g->txtStruct.readme.current = 0;
 	g->txtStruct.readme.folderpath.fillzero();
@@ -608,19 +601,22 @@ int ShowReadmes(game *g) {
 	}
 
 	g->txtStruct.readme.folderpath = g->sSelect.bmsList[g->sSelect.cur_song].filepath.getDirectory();
-	cstrSprintf(&search, "%s*.txt", g->txtStruct.readme.folderpath.body);
-	hFindFile = FindFirstFileW(utf2ws(search.body).c_str(), &FindFileData);
-	if (hFindFile == (HANDLE)-1) {
-		ErrorLogFmtAdd("テキストファイルが見つからない。%s\n", search.body);
-		return -1;
+
+	CSTR fBuf(2048);
+
+	std::error_code ec{};
+
+	for (auto& entry : std::filesystem::directory_iterator(g->txtStruct.readme.folderpath.c_str(), ec)) {
+		if (entry.path().extension() != ".txt") {
+			continue;
+		}
+		g->txtStruct.readme.file_count++;
 	}
 
-	do {
-		g->txtStruct.readme.file_count++;
-	} while (FindNextFileW(hFindFile, &FindFileData));
-	FindClose(hFindFile);
-
-	if (g->txtStruct.readme.file_count == 0) return 0;
+	if (g->txtStruct.readme.file_count == 0) {
+               ErrorLogFmtAdd("テキストファイルが見つからない。%s\n", g->txtStruct.readme.folderpath.c_str());
+               return -1;
+	}
 
 	if (g->txtStruct.readme.current >= g->txtStruct.readme.file_count) 
 		g->txtStruct.readme.current = 0;
@@ -628,51 +624,46 @@ int ShowReadmes(game *g) {
 		g->txtStruct.readme.current = g->txtStruct.readme.file_count-1;
 
 	int currentFileNum = 0;
-	hFindFile = FindFirstFileW(utf2ws(search.body).c_str(), &FindFileData);
-	do {
-		std::string filename = ws2utf(FindFileData.cFileName);
+	for (auto& entry : std::filesystem::directory_iterator(g->txtStruct.readme.folderpath.c_str(), ec)) {
+		if (entry.path().extension() != ".txt") {
+			continue;
+		}
+		const std::string filename = entry.path().filename().string();
 		g->txtStruct.readme.path = g->txtStruct.readme.folderpath;
 		g->txtStruct.readme.path.add(filename.c_str());
 
-		pFile = fopen(g->txtStruct.readme.path.body, "r");
-
-		char *pFbuf = fBuf.outstr();
-		if (pFile != NULL) {
-			
-			currentFileNum++;
-			if (g->txtStruct.readme.file_count == 1) {
-				g->txtStruct.readme.body[g->txtStruct.readme.lines] = filename.c_str();
-			}
-			else {
-				std::string line = std::format("{}/{} {}", currentFileNum, g->txtStruct.readme.file_count, filename);
-				g->txtStruct.readme.body[g->txtStruct.readme.lines] = line.c_str();
-			}
-			g->txtStruct.readme.lines+=2;
-
-			g->txtStruct.readme.show = 1;
-			pFbuf = fBuf.outstr();
-			for (pFbuf = fgets(pFbuf, 2048, pFile); pFbuf; pFbuf = fgets(pFbuf, 2048, pFile)) {
-				fBuf = ansi2utf(fBuf.body, 932).c_str();
-				DealWhiteSpace(&fBuf);
-				g->txtStruct.readme.body[g->txtStruct.readme.lines] = fBuf;
-				g->txtStruct.readme.lines++;
-				int len = GetTextGraphLength(&fBuf, &g->skstruct.ImageFonts[g->skstruct.src_README[0].cycle]);
-				if (g->txtStruct.readme.x < len) g->txtStruct.readme.x = len;
-				*fBuf.atPos(0) = '\0';
-				if (g->txtStruct.readme.lines >= 900) break;
-			}
-			fclose(pFile);
-			g->txtStruct.readme.lines += 2;
+		FILE* pFile = fopen(g->txtStruct.readme.path.body, "r");
+		if (pFile == NULL) {
+			continue;
 		}
-	} while (FindNextFileW(hFindFile, &FindFileData));
-	FindClose(hFindFile);
+
+		currentFileNum++;
+		if (g->txtStruct.readme.file_count == 1) {
+			g->txtStruct.readme.body[g->txtStruct.readme.lines] = filename.c_str();
+		}
+		else {
+			g->txtStruct.readme.body[g->txtStruct.readme.lines] = std::format("{}/{} {}", currentFileNum, g->txtStruct.readme.file_count, filename).c_str();
+		}
+		g->txtStruct.readme.lines+=2;
+
+		g->txtStruct.readme.show = 1;
+		char* pFbuf = fBuf.outstr();
+		for (pFbuf = fgets(pFbuf, 2048, pFile); pFbuf; pFbuf = fgets(pFbuf, 2048, pFile)) {
+			fBuf = ansi2utf(fBuf.body, 932).c_str();
+			DealWhiteSpace(&fBuf);
+			g->txtStruct.readme.body[g->txtStruct.readme.lines] = fBuf;
+			g->txtStruct.readme.lines++;
+			int len = GetTextGraphLength(&fBuf, &g->skstruct.ImageFonts[g->skstruct.src_README[0].cycle]);
+			if (g->txtStruct.readme.x < len) g->txtStruct.readme.x = len;
+			*fBuf.atPos(0) = '\0';
+			if (g->txtStruct.readme.lines >= 900) break;
+		}
+		fclose(pFile);
+		g->txtStruct.readme.lines += 2;
+	}
 
 	g->txtStruct.readme.y = g->skstruct.src_README[0].op1 * g->txtStruct.readme.lines;
 	return 1;
-#else
-	// TODO: reimplement with std::filesystem
-	return {};
-#endif // _WIN32
 }
 
 int ShowReadme(game *g, CSTR path) {

--- a/LR2/Scene11_Po4select.cpp
+++ b/LR2/Scene11_Po4select.cpp
@@ -20,8 +20,6 @@ int ProcI_PO4Select(game *g, sqlite3 *sql) { //not tested
 
 	if (g->po4procSelecter == 0) {
 		g->po4procSelecter = 1;
-		g->po4_unk23d84 = 0;
-		g->po4_unk23d88 = 0;
 		g->po4flagSceneStart = '\x01';
 		g->po4flagSceneEnd = '\0';
 		g->sSelect.listCalculatedBar = 0;

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -629,14 +629,13 @@ struct RANKING {
 };
 
 struct RAWSOUND {
-	int channels;
-	int samples;
-	int bits;
-	int length;
-	int dataSize;
-	byte* data;
+	int channels{};
+	int samples{};
+	int bits{};
+	int length{};
+	int dataSize{};
+	byte* data{};
 
-	RAWSOUND();
 	void ExpandBuffer(int minSize);
 	void MakeBitDepth16(void);
 	void MakeStereo(void);
@@ -644,17 +643,15 @@ struct RAWSOUND {
 };
 
 struct SOUNDDATA {
-	char load;
+	struct RAWSOUND raw{};
+	struct FMOD_SOUND * fmod_sound{};
+	struct FMOD_CHANNEL * fmod_channel{};
+	CSTR filename{};
+	unsigned int length{};
+	int soundHandle{};
+	bool load{};
+	bool loop{};
 	bool streaming = false;
-	char loop;
-	CSTR filename;
-	uint length;
-	int unused0C;
-	int soundHandle;
-	struct RAWSOUND raw;
-	char flag2c;
-	struct FMOD_SOUND * fmod_sound;
-	struct FMOD_CHANNEL * fmod_channel;
 };
 
 struct inputStructure {
@@ -774,7 +771,6 @@ struct skstruct {
 	struct DSTstruct dst_BAR_LEVEL[10]{};
 	struct SRCstruct src_BAR_LAMP[10]{};
 	struct DSTstruct dst_BAR_LAMP[10]{};
-	//undefined unused[2240];
 	struct SRCstruct src_BAR_MY_LAMP[10]{};
 	struct DSTstruct dst_BAR_MY_LAMP[10]{};
 	struct SRCstruct src_BAR_RIVAL_LAMP[10]{};
@@ -854,7 +850,6 @@ struct skstruct {
 
 struct MYRANKING {
 	CSTR songMD5; /* struct from */
-	CSTR unused; /* ID?name? but unused */
 	CSTR passMD5;
 	CSTR title;
 	CSTR genre;
@@ -884,7 +879,6 @@ struct MYRANKING {
 	int clear_sd;
 	int clear_db;
 	int rseed;
-	CSTR _ghost; // TODO: remove when we throw out memset usage
 
 	void InitRanking();
 };
@@ -1243,9 +1237,7 @@ struct gameplay {
 	CSTR keysound_filename[SLOTS];
 	CSTR BMP_filename[SLOTS];
 	struct SOUNDDATA muon;
-	char bgaUnused656b8[SLOTS];
 	int bgaHandle[SLOTS];
-	int bgaHandleHandle[SLOTS];
 	int bgaLayer1;
 	int bgaLayer2;
 	int missLayer;
@@ -1444,37 +1436,35 @@ struct game {
 	struct RECORDING rec;
 	struct TextStruct txtStruct;
 	struct AUDIO audio;
+	struct NETWORK net;
+	std::vector<std::future<std::pair<std::pair<std::string, std::string>, int>>> hThreadBanner;
 	int po4procSelecter;
-	int po4_unk23d84;
-	int po4_unk23d88;
-	char po4flagSceneStart;
-	char po4flagSceneEnd;
 	int po4nextProc;
 	int po4sceneTimerID	;
 	int po4sceneTimerIDNext;
 	int po4sceneFadeout;
 	int po4cur_song;
-	char po4_23da8;
 	int po4MainMenuCursor;
 	int procSelecter; /* 2:select 3:deciide 4:play 5:result 6:keyconfig 7:skinselect */
 	int procPhase;
-	std::vector<std::future<std::pair<std::pair<std::string, std::string>, int>>> hThreadBanner;
 	struct gameplay gameplay;
-	char is_clicked_screenModeChange;
 	int isSkipDrawTick; /* skip frame? */
-	bool flag_Screenshot{};
-	bool flag_showFPS{};
-	char cmd_nosave;
-	int cmd_directplay;
-	char cmd_auto;
-	char cmd_n;
-	char is_recordmode;
-	char auto2avi;
 	CSTR directoryPath;
 	CSTR directoryFilename;
 	CSTR baseDirectory;
 	int is_starter;
-	struct NETWORK net;
+	bool is_clicked_screenModeChange;
+	bool flag_Screenshot{};
+	bool flag_showFPS{};
+	bool cmd_nosave;
+	bool cmd_directplay;
+	bool cmd_auto;
+	bool cmd_n;
+	bool is_recordmode;
+	bool auto2avi;
+	bool po4_23da8;
+	bool po4flagSceneStart;
+	bool po4flagSceneEnd;
 };
 
 struct SkinHeader { /* SkinInfo */
@@ -1483,22 +1473,20 @@ struct SkinHeader { /* SkinInfo */
 	CSTR title;
 	CSTR maker;
 	enum SKINTYPE type;
-	int unused18;
 	int informationP5;
 	struct SkinCustom customs[100];
 	int custom_count;
 
 	//RESOLUTION
-	bool hasResolutionTag = false; // true if the skin declared #RESOLUTION; else fall back to config global
 	int targetX = 640;
 	int targetY = 480;
+	bool hasResolutionTag = false; // true if the skin declared #RESOLUTION; else fall back to config global
 };
 
 struct RANKINGPLAYER {
 	CSTR name;
+	CSTR comment;
 	int id{};
-	int sp{}; // TODO: remove when we throw out memset usage
-	int dp{}; // TODO: remove when we throw out memset usage
 	int clear{};
 	int notes{};
 	int combo{};
@@ -1508,11 +1496,8 @@ struct RANKINGPLAYER {
 	int bd{};
 	int pr{};
 	int minbp{};
-	int option{}; // TODO: remove when we throw out memset usage
-	int sussussuspected{};
 	int playcount{};
 	int ranking{};
-	CSTR comment; /* hash */
 };
 
 struct SkinUser {
@@ -1522,8 +1507,8 @@ struct SkinUser {
 };
 
 struct struct_0x14 {
-	int ID;
 	CSTR filenameHead;
+	int ID;
 	int count;
 	int side;
 	int field4_0x10;
@@ -1547,14 +1532,14 @@ struct CHARTCONVERTER {
 	int unk14428;
 	int unk1442c;
 	int unk14430;
-	char flagSplitScratch;
 	int unk14438;
 	int RealTimingSplitScratch;
-	char flagSplitUnknown;
-	char flagSplit;
 	int assist1p;
 	int assist2p;
 	int playlevel;
+	bool flagSplitScratch;
+	bool flagSplitUnknown;
+	bool flagSplit;
 };
 
 #ifdef _MSC_VER


### PR DESCRIPTION
- perf: optimize struct memory usage -> reordering fields in a reverse engineered code base is scary, but I've been running these changes for a few days without problems.
- refactor(songselect): reimplement ShowReadmes with std::filesystem -> I will be converting bmsload later in a similar way
- refactor(ir): avoid magic number -> this may also be useful on the beta3 branch :) This also highlights the LR2 bug below making request answers very slow to process and limited to 3 megabytes in size.
- feat(ir): Linux: implement NETWORK::Login -> no effective difference, just less special-casing