### PR TITLE
[Bugfix] Fix FMOD initialization order

### DIFF
--- a/LR2/En_audio.cpp
+++ b/LR2/En_audio.cpp
@@ -1089,11 +1089,6 @@ int InitSound(AUDIO *aud, uint bufferLength, int numBuffer, char fDisable, int o
 		FMOD_System_SetDSPBufferSize(aud->fmodSys, bufferLength, numBuffer);
 		ErrorLogAdd("\n");
 		FMOD_System_SetSoftwareChannels(aud->fmodSys, 0x100);
-		if (FMOD_System_Init(aud->fmodSys, 0x100, FMOD_INIT_NORMAL, NULL) != FMOD_OK) {
-			ErrorLogAdd("FMOD_System_Init failed!\n");
-			EndSound(aud);
-			return 1;
-		}
 
 #ifdef _WIN32
 		if ([&] {
@@ -1131,6 +1126,12 @@ int InitSound(AUDIO *aud, uint bufferLength, int numBuffer, char fDisable, int o
 			ErrorLogFmtAdd("FMOD_System_GetDriverInfo failed\n");
 		}
 		FMOD_System_SetDriver(aud->fmodSys, driver);
+		if (FMOD_System_Init(aud->fmodSys, 0x100, FMOD_INIT_NORMAL, NULL) != FMOD_OK) {
+			ErrorLogAdd("FMOD_System_Init failed!\n");
+			EndSound(aud);
+			return 1;
+		}
+
 		ErrorLogAdd("バッファサイズの設定を行います...\n");
 		FMOD_System_CreateChannelGroup(aud->fmodSys, "bgm", &aud->chnBgm);
 		FMOD_System_CreateChannelGroup(aud->fmodSys, "key", &aud->chnKey);


### PR DESCRIPTION
# Background
Audio drivers have been **replaced** after initializing fmod system.
For example, at first the driver is set to default one, and after initializing, it is replaced into the intended one.
In my case, it was first set to ASIO4ALL (probably default ASIO driver), and then replaced into the intended driver.
It should be initialized after setting parameters to prevent overhead and potential deadlock possibilities.
In short, I fixed the audio initialization sequence.

# Changes
Fixed fmod init sequence like this :
1. FMOD_System_Create
2. FMOD_System_SetDSPBufferSize
3.  FMOD_System_SetSoftwareChannels
4.  FMOD_System_SetOutput 
5. FMOD_System_SetDriver 
6. FMOD_System_Init 
