### PR TITLE
fix(customir): keep ghost data alive for result ghost on PB

### DIFF
--- a/LR2/LR2_ghost.cpp
+++ b/LR2/LR2_ghost.cpp
@@ -712,7 +712,6 @@ int WriteGhostInDatabase(sqlite3 *sql, CSTR songMD5, PLAYSCORE *score) {
 		ErrorLogAdd("sqlite3_finalize error\n");
 	}
 
-	score->InitJudgeQueue();
 	ErrorLogAdd("ゴーストの書き込みが終了しました\n");
 	return 0;
 }

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1793,6 +1793,7 @@ int ProcS_Play(game *g, sqlite3* sql) {
 
 	g->gameplay.hThreadPreview = {};
 	g->gameplay.flag_closingPhase = 0;
+	g->gameplay.p1Score.InitJudgeQueue();
 	
 	CSTR gData, gName;
 	CSTR md5;


### PR DESCRIPTION
WriteGhostInDatabase no longer clears the queue after saving to the local DB; ProcS_Play now calls InitJudgeQueue at play entry so the next chart starts with a fresh buffer.

Fixes #197