### PR TITLE
Fix extra mode crash

### DIFF
--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -1137,7 +1137,7 @@ void MakeExtraChart(gameplay *gp, CHARTCONVERTER *cc) {  //test completed
 	qsort(gp->bmsobj.notes, gp->bmsobj.count, sizeof(NoteStruct), CMP_NotesByRealTimingOp);
 
 	for (int i = 0; i < gp->bmsobj.count; i++) {
-		if (CHANNEL_1P_NOTE_SC <= gp->bmsobj.notes[i].op && gp->bmsobj.notes[i].op <= CHANNEL_1P_HIDDEN_SC) {
+		if (CHANNEL_1P_NOTE_SC <= gp->bmsobj.notes[i].op && gp->bmsobj.notes[i].op <= CHANNEL_2P_NOTE_END) {
 			notecount++;
 			endtime = gp->bmsobj.notes[i].bmsTiming;
 		}
@@ -1173,7 +1173,7 @@ void MakeExtraChart(gameplay *gp, CHARTCONVERTER *cc) {  //test completed
 		laneOfSound[i] = -1;
 
 		for (int j = 0; j < gp->bmsobj.count; j++) {
-			if (CHANNEL_1P_NOTE_SC <= gp->bmsobj.notes[j].op && gp->bmsobj.notes[j].op <= CHANNEL_1P_HIDDEN_SC) {
+			if (CHANNEL_1P_NOTE_SC <= gp->bmsobj.notes[j].op && gp->bmsobj.notes[j].op <= CHANNEL_2P_NOTE_END) {
 				if ((int)gp->bmsobj.notes[j].val == i) {
 					Lane[gp->bmsobj.notes[j].op-10]++;
 				}

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1335,6 +1335,7 @@ int ProcGame(game *g) {
 		int stage = g->gameplay.bmsobj.notes[g->gameplay.bmsobj.note_count].stage;
 		if (op < 50) {
 			switch (op) {
+			case -1: break; // HACK: don't go out of bounds when g->gameplay.bmsobj.count is 0 on chart loading error
 			case 1:
 				if (g->rec.recMode != 2) {
 					PlaySound(&g->audio, &g->gameplay.keysound[val], g->audio.chnStageBgm[stage], stage);


### PR DESCRIPTION
fixes wrong `notecount` here
https://github.com/GOMazk/OpenLR2/blob/17abcad740b1ba632841a2a1adde88d917d98c4f/LR2/LR2_bmsload.cpp#L1140-L1143

out of bounds access for `Lane` here
https://github.com/GOMazk/OpenLR2/blob/17abcad740b1ba632841a2a1adde88d917d98c4f/LR2/LR2_bmsload.cpp#L1176-L1180

out of bounds access for `bmsobj_note` on uninit op (-1) here
https://github.com/GOMazk/OpenLR2/blob/17abcad740b1ba632841a2a1adde88d917d98c4f/LR2/Scene04_Play.cpp#L1459

closes https://github.com/GOMazk/OpenLR2/issues/211