### PR TITLE
[Bugfix] Make imported scores non-volatile

### DIFF
--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -951,13 +951,13 @@ int LoadFolderDataFromDB(CSTR query, SONGDATA *song, sqlite3 *sql, int difficult
 			if (slist[i].myIRbest.has_value())
 			{
 				const STATUS& myIRbest = *(slist[i].myIRbest);
-				song->mybest.clear = min(song->mybest.clear, myIRbest.clear);
-				song->mybest.clear_db = min(song->mybest.clear_db, myIRbest.clear_db);
+				song->mybest.clear = std::min(song->mybest.clear, myIRbest.clear);
+				song->mybest.clear_db = std::min(song->mybest.clear_db, myIRbest.clear_db);
 			}
 			else
 			{
-				song->mybest.clear = min(slist[i].mybest.clear, song->mybest.clear);
-				song->mybest.clear_db = min(slist[i].mybest.clear_db, song->mybest.clear_db);
+				song->mybest.clear = std::min(slist[i].mybest.clear, song->mybest.clear);
+				song->mybest.clear_db = std::min(slist[i].mybest.clear_db, song->mybest.clear_db);
 			}
 		}
 	}

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -951,17 +951,13 @@ int LoadFolderDataFromDB(CSTR query, SONGDATA *song, sqlite3 *sql, int difficult
 			if (slist[i].myIRbest.has_value())
 			{
 				const STATUS& myIRbest = *(slist[i].myIRbest);
-				if (myIRbest.clear != song->mybest.clear && myIRbest.clear <= song->mybest.clear)
-					song->mybest.clear = myIRbest.clear;
-				if (myIRbest.clear_db != song->mybest.clear_db && myIRbest.clear_db <= song->mybest.clear_db)
-					song->mybest.clear_db = myIRbest.clear_db;
+				song->mybest.clear = min(song->mybest.clear, myIRbest.clear);
+				song->mybest.clear_db = min(song->mybest.clear_db, myIRbest.clear_db);
 			}
 			else
 			{
-				if (slist[i].mybest.clear != song->mybest.clear && slist[i].mybest.clear <= song->mybest.clear)
-					song->mybest.clear = slist[i].mybest.clear;
-				if (slist[i].mybest.clear_db != song->mybest.clear_db && slist[i].mybest.clear_db <= song->mybest.clear_db)
-					song->mybest.clear_db = slist[i].mybest.clear_db;
+				song->mybest.clear = min(slist[i].mybest.clear, song->mybest.clear);
+				song->mybest.clear_db = min(slist[i].mybest.clear_db, song->mybest.clear_db);
 			}
 		}
 	}

--- a/LR2/LR2_statlong.cpp
+++ b/LR2/LR2_statlong.cpp
@@ -243,10 +243,6 @@ int UpdateScoreDB(CSTR hash, STATUS *stat, sqlite3 *sql, CSTR *passMD5) {
 		SQL_Run(query, sql);
 	}
 
-	// delete imported score from IR
-	CSTR delQuery;
-	cstrSprintf(&delQuery, "DELETE FROM imported_score WHERE hash = \'%s\'", hash.body);
-	SQL_Run(delQuery, sql);
 	sqlite3_exec(sql, "COMMIT", 0, 0, 0);
 	return 1;
 }


### PR DESCRIPTION
# Changes

- Make imported scores non-volatile
- Clean folder lamp calculating syntax with `std::min`

# Related issues

Fixes #221 