### PR TITLE
Stretch to fit, Fullscreen scaling filter selection

### DIFF
--- a/LR2/En_xml.cpp
+++ b/LR2/En_xml.cpp
@@ -139,6 +139,10 @@ void WriteXML_Tab2Int(FILE *hFile, const char *tag, int value){
 	fputs(buf, hFile);
 }
 
+void WriteXML_Tab2BoolAsInt(FILE* hFile, const char* tag, bool value) {
+	WriteXML_Tab2Int(hFile, tag, value ? 1 : 0);
+}
+
 void WriteXML_Tab2Str(FILE *hFile, const char *tag, CSTR str){
 	char buf[256];
 

--- a/LR2/En_xml.h
+++ b/LR2/En_xml.h
@@ -14,4 +14,5 @@ int ReadXml_Str(const char *level1, const char *level2, const char *level3, cons
 int ReadXml_Int_Multi(const char * level1, const char * level2, const char * level3, int * oBuf, TiXmlDocument * xmlData);
 
 void WriteXML_Tab2Int(FILE * hFile, const char * tag, int value);
+void WriteXML_Tab2BoolAsInt(FILE* hFile, const char* tag, bool value);
 void WriteXML_Tab2Str(FILE * hFile, const char * tag, CSTR str);

--- a/LR2/LR2_configsave.cpp
+++ b/LR2/LR2_configsave.cpp
@@ -576,8 +576,7 @@ int WriteOpenLr2ConfigXml(game *g, const char *filename){
 	fputs("\t</system>\n", pFile);
 
 	fputs("\t<play>\n", pFile);
-	sprintf(buf, "\t\t<%s>%d</%s>\n", "gaugeautoshift", (g->config).play.m_gas, "gaugeautoshift");
-	fputs(buf, pFile);
+	WriteXML_Tab2BoolAsInt(pFile, "gaugeautoshift", (g->config).play.m_gas);
 	fputs("\t</play>\n", pFile);
 
 	fputs("\t<skin>\n", pFile);

--- a/LR2/LR2_configsave.cpp
+++ b/LR2/LR2_configsave.cpp
@@ -573,6 +573,8 @@ int WriteOpenLr2ConfigXml(game *g, const char *filename){
 
 	fputs("\t<system>\n", pFile);
 	WriteXML_Tab2Int(pFile, "resolution", (g->config).system.resolution);
+	WriteXML_Tab2Int(pFile, "fullscreenfilter", (g->config).system.fullscreenfilter);
+	WriteXML_Tab2BoolAsInt(pFile, "fullscreenfitstretch", (g->config).system.fullscreenfitstretch);
 	fputs("\t</system>\n", pFile);
 
 	fputs("\t<play>\n", pFile);
@@ -1178,6 +1180,8 @@ int ReadOpenLr2Config(game* g, const char* filepath) {
 		return 0;
 	}
 	ReadXml_Int("config", "system", "resolution", 0, &g->config.system.resolution, hXml);
+	ReadXml_Int("config", "system", "fullscreenfilter", 0, &g->config.system.fullscreenfilter, hXml);
+	ReadXml_PositiveIntAsBool("config", "system", "fullscreenfitstretch", false, &g->config.system.fullscreenfitstretch, hXml);
 	ReadXml_PositiveIntAsBool("config", "play", "gaugeautoshift", false, &g->config.play.m_gas, hXml);
 	ReadXml_Str("config", "skin", "courseresult", "", &g->config.skin.skinFilePath[15], hXml);
 	ReadXml_Str("config", "network", "display_ir", "", &g->config.network.displayIr, hXml);

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -4024,6 +4024,25 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 					}
 				}
 				break;
+			case 400:
+				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.system.fullscreenfilter, 0, 1, g->sSelect.panel);
+				if (isClickSuccess == 2) {
+					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
+					SetFullScreenScalingMode(g->config.system.fullscreenfilter, g->config.system.fullscreenfitstretch ? 1 : 0);
+					SetObjectStrings_SongSelect(g);
+				}
+				break;
+			case 401: {
+				int tmp = g->config.system.fullscreenfitstretch ? 1 : 0;
+				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &tmp, 0, 1, g->sSelect.panel);
+				if (isClickSuccess == 2) {
+					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
+					g->config.system.fullscreenfitstretch = !g->config.system.fullscreenfitstretch;
+					SetFullScreenScalingMode(g->config.system.fullscreenfilter, g->config.system.fullscreenfitstretch ? 1 : 0);
+					SetObjectStrings_SongSelect(g);
+				}
+				break;
+			}
 			default:
 				continue;
 		}
@@ -4209,7 +4228,7 @@ int ButtonByInput(DrawingBuf */*drb*/, SRCstruct *src, DSTstruct *dst, Timer *T,
 }
 
 int InitObjectString(TextStruct *txt){
-	for (int i = 0; i < 300; i++) {
+	for (int i = 0; i < std::size(txt->objectStr); i++) {
 		txt->objectStr[i].fillzero();
 	}
 	txt->objectStr[0].assign("これはテストこれはテストこれはテスト");
@@ -4218,7 +4237,7 @@ int InitObjectString(TextStruct *txt){
 }
 
 int SetObjectString(uint num, CSTR string, CSTR *objectList){
-	if (num > 299) {
+	if (num > 399) {
 		return 0;
 	}
 	if (string.isDiff("(null)") == 0) {
@@ -4240,56 +4259,45 @@ CSTR GetStringFromArray(int num, CSTR *strings) {
 	return strings[num];
 }
 
-
-int DefineOptionStrNum(OptionString *arrOpStr){
-	arrOpStr[19].count = 4;
-	arrOpStr[5].count = 4;
-	arrOpStr[14].count = 4;
-	arrOpStr[15].count = 4;
-	arrOpStr[22].count = 4;
-	arrOpStr[7].count = 9;
-	arrOpStr[8].count = 2;
-	arrOpStr[9].count = 3;
-	arrOpStr[13].count = 2;
-	arrOpStr[2].count = 6;
-	arrOpStr[6].count = 2;
-	arrOpStr[3].count = 6;
-	arrOpStr[0].count = 8;
-	arrOpStr[4].count = 6;
-	arrOpStr[16].count = 2;
-	arrOpStr[12].count = 3;
-	arrOpStr[10].count = 5;
-	arrOpStr[1].count = 6;
-	arrOpStr[11].count = 2;
-	arrOpStr[17].count = 3;
-	arrOpStr[18].count = 5;
-	arrOpStr[20].count = 6;
-	arrOpStr[23].count = 2;
-	arrOpStr[21].count = 2;
-	arrOpStr[24].count = 2;
-	return 1;
-}
-
-int ReadOptionstr(OptionString *opStr, CSVbuf csv) {
-	for (int i = 0; i < opStr->count; i++) {
+static int ReadOptionstr(OptionString *opStr, CSVbuf& csv) {
+	for (size_t i = 0; i < std::size(opStr->str); i++) {
 		opStr->str[i].assign(&csv.str[1+i]);
 	}
-	for (int i = opStr->count; i < 10; i++) {
-		opStr->str[i].fillzero();
-	}
 	return 1;
 }
 
-// : CSVbuf copy
-int ReadOptionstrFile(OptionString *arrOpStr, CSTR filepath) {
+static void ReadOptionStrVec(std::vector<std::string>& vec, CSVbuf& csv) {
+	for (const auto& src : csv.str) {
+		if (src.length() == 0) break;
+		vec.emplace_back(src.c_str());
+	}
+}
+
+static void MakeOLR2StrDefaults(TextStruct& txtStruct) {
+	if (txtStruct.option_str[10].str[5].length() == 0)
+		txtStruct.option_str[10].str[5].assign("MAINBPM");
+	if (txtStruct.option_str[12].str[2].length() == 0)
+		txtStruct.option_str[12].str[2].assign("BORDERLESS");
+
+	auto fill_default_vec = []<size_t size>(std::vector<std::string>&vec, const std::array<const char*, size>&defaults) {
+		for (size_t i = vec.size(); i < defaults.size(); i++) {
+			vec.emplace_back(defaults[i]);
+		}
+	};
+	constexpr std::array<const char*, 2> fullscreenfilter_defaults{ "BILINEAR", "NEAREST" };
+	constexpr std::array<const char*, 2> fullscreenfitstretch_defaults{ "OFF", "ON" };
+	fill_default_vec(txtStruct.option_fullscreenfilter, fullscreenfilter_defaults);
+	fill_default_vec(txtStruct.option_fullscreenfitstretch, fullscreenfitstretch_defaults);
+}
+
+int ReadOptionstrFile(TextStruct& txtStruct, CSTR filepath) {
 	int bufSize = 256;
 
 	FILE *pFile;
 	CSTR fBuf(bufSize);
 	char* pFbuf;
 	CSVbuf csv;
-
-	DefineOptionStrNum(arrOpStr);
+	OptionString* arrOpStr = txtStruct.option_str;
 	pFile = fopen(filepath.body, "r");
 	if (pFile == 0) {
 		ErrorLogAdd("オプション文字列リストが見つかりません。\n");
@@ -4377,6 +4385,12 @@ int ReadOptionstrFile(OptionString *arrOpStr, CSTR filepath) {
 			else if (fBuf.left(10).isSame("#COURSE_IR")) {
 				ReadOptionstr(&arrOpStr[24], csv);
 			}
+			else if (fBuf.starts_with("#FULLSCREEN_FILTER")) {
+				ReadOptionStrVec(txtStruct.option_fullscreenfilter, csv);
+			}
+			else if (fBuf.starts_with("#FULLSCREEN_FITSTRETCH")) {
+				ReadOptionStrVec(txtStruct.option_fullscreenfitstretch, csv);
+			}
 			*fBuf.atPos(0) = '\0';
 		}
 		pFbuf = fBuf.outstr();
@@ -4385,5 +4399,7 @@ int ReadOptionstrFile(OptionString *arrOpStr, CSTR filepath) {
 	fclose(pFile);
 
 	ErrorLogAdd("オプション文字列リストを読み込みました。\n");
+
+	MakeOLR2StrDefaults(txtStruct);
 	return 1;
 }

--- a/LR2/LR2_skinobject.h
+++ b/LR2/LR2_skinobject.h
@@ -29,6 +29,4 @@ int SetObjectStringInt(int at, int val, CSTR * arr);
 CSTR GetStringFromArray(int num, CSTR * strings);
 
 //panel constant text (options in songselect)
-int DefineOptionStrNum(OptionString * arrOpStr);
-int ReadOptionstr(OptionString * opStr, CSVbuf csv);
-int ReadOptionstrFile(OptionString * arrOpStr, CSTR filepath);
+int ReadOptionstrFile(TextStruct& txtStruct, CSTR filepath);

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -437,9 +437,7 @@ int main(int argc, char** argv) {
 	ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 	gs.is_clicked_screenModeChange = 0;
 	gs.flag_Screenshot = false;
-	ReadOptionstrFile(gs.txtStruct.option_str, fs::make_preferred("LR2files/Config/optionstr.csv").data());
-	if (gs.txtStruct.option_str[12].str[2].length() == 0)
-		gs.txtStruct.option_str[12].str[2].assign("BORDERLESS");
+	ReadOptionstrFile(gs.txtStruct, fs::make_preferred("LR2files/Config/optionstr.csv").data());
 	gs.audio.is_fmod_disabled = gs.config.sound.disablefmod;
 	if (gs.config.sound.disablefmod != 0) {
 		gs.config.select.preview = 0;
@@ -511,6 +509,7 @@ int main(int argc, char** argv) {
 		SetUseDirect3DVersion(use_dx);
 	}
 	SetUseDisplayIndex(-1);
+	SetFullScreenScalingMode(gs.config.system.fullscreenfilter, gs.config.system.fullscreenfitstretch ? 1 : 0);
 	if (DxLib_Init() == -1) return 0;
 	if constexpr (is_linux()) { SetMainWindowText(openlr2::versionName); }
 	ChangeFont("", 0);

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1015,8 +1015,7 @@ int SetObjectStrings_SongSelect(game *g) {
 	SetObjectString(71, g->txtStruct.option_str[16].str[g->config.play.scoregraph], g->txtStruct.objectStr);
 	SetObjectString(72, g->txtStruct.option_str[14].str[g->config.play.play_ghost], g->txtStruct.objectStr);
 	SetObjectString(73, g->txtStruct.option_str[15].str[g->config.play.p1_lanecover], g->txtStruct.objectStr);
-	if (g->txtStruct.option_str[10].count <= g->config.play.hsfix) SetObjectString(74, HSFIXSTRINGS[g->config.play.hsfix], g->txtStruct.objectStr);
-	else SetObjectString(74, g->txtStruct.option_str[10].str[g->config.play.hsfix], g->txtStruct.objectStr);
+	SetObjectString(74, g->txtStruct.option_str[10].str[g->config.play.hsfix], g->txtStruct.objectStr);
 	SetObjectString(76, g->txtStruct.option_str[9].str[g->config.play.bga], g->txtStruct.objectStr);
 	SetObjectString(75, g->txtStruct.option_str[8].str[g->config.play.bgasize], g->txtStruct.objectStr);
 	SetObjectString(77, g->txtStruct.option_str[13].str[g->config.system.highcolor], g->txtStruct.objectStr);
@@ -1096,6 +1095,9 @@ int SetObjectStrings_SongSelect(game *g) {
 	}
 
 	SetObjectString(199, g->txtStruct.option_str[22].str[g->config.course.defaultgauge], g->txtStruct.objectStr);
+
+	SetObjectString(300, g->txtStruct.option_fullscreenfilter[g->config.system.fullscreenfilter].c_str(), g->txtStruct.objectStr);
+	SetObjectString(301, g->txtStruct.option_fullscreenfitstretch[g->config.system.fullscreenfitstretch ? 1 : 0].c_str(), g->txtStruct.objectStr);
 
 	return 1;
 }

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -279,8 +279,6 @@ enum OPTION {
 	OPTION_RANDOM_END = OPTION_RANDOM_CONVERGE,
 };
 
-constexpr const char* HSFIXSTRINGS[] = { "OFF", "MAXBPM", "MINBPM", "AVERAGE", "CONSTANT", "MAINBPM" };
-
 struct BMSMETA {
 	CSTR hash;
 	CSTR title;
@@ -503,6 +501,7 @@ struct CONFIG_SOUND {
 };
 
 struct CONFIG_SYSTEM {
+	int fullscreenfilter{};
 	int screenmode{};
 	int vsync{};
 	int directdraw{};
@@ -525,6 +524,7 @@ struct CONFIG_SYSTEM {
 	int softwarerendering{};
 	int resolution{};   // 0=SD 640x480, 1=HD 1280x720, 2=UHD 1920x1080
 	unsigned int coreCount = 0;
+	bool fullscreenfitstretch{};
 };
 
 struct CONFIG_TOOLS {
@@ -766,7 +766,6 @@ struct RECORDING {
 
 struct OptionString {
 	CSTR str[10];
-	int count;
 };
 
 struct LaneStruct {
@@ -1253,11 +1252,13 @@ struct README {
 };
 
 struct TextStruct {
-	CSTR objectStr[300];
+	CSTR objectStr[400];
 	int hKeyInput;
 	int st_text_num;
 	struct README readme;
 	struct OptionString option_str[25];
+	std::vector<std::string> option_fullscreenfilter;
+	std::vector<std::string> option_fullscreenfitstretch;
 };
 
 struct REPLAY {

--- a/OpcodeScript/buttonOp.txt
+++ b/OpcodeScript/buttonOp.txt
@@ -217,3 +217,6 @@
 
 268 DefaultCourseConnection
 269 DefaultCourseGauge
+
+400 scalingFilter
+401 stretch

--- a/OpcodeScript/textOp.txt
+++ b/OpcodeScript/textOp.txt
@@ -164,3 +164,7 @@
 
 198 AllCourseOptionDefaultConnection
 199 AllCourseOptionDefaultGauge
+
+
+300 scalingFilter
+301 stretch

--- a/dep/DxLib/DxGraphics.cpp
+++ b/dep/DxLib/DxGraphics.cpp
@@ -28076,15 +28076,21 @@ extern	int		Graphics_Screen_SetupFullScreenScalingDestRect( void )
 			{
 				GSYS.Screen.MainScreenSizeY = DEFAULT_SCREEN_SIZE_Y ;
 			}
-			ScalingSizeX = DestSizeY * GSYS.Screen.MainScreenSizeX / GSYS.Screen.MainScreenSizeY ;
-			if( ScalingSizeX < DestSizeX )
-			{
-				ScalingSizeY = DestSizeY ;
+			if (GSYS.Screen.FullScreenFitScalingFlag) {
+				ScalingSizeX = DestSizeX;
+				ScalingSizeY = DestSizeY;
 			}
-			else
-			{
-				ScalingSizeX = DestSizeX ;
-				ScalingSizeY = DestSizeX * GSYS.Screen.MainScreenSizeY / GSYS.Screen.MainScreenSizeX ;
+			else {
+				ScalingSizeX = DestSizeY * GSYS.Screen.MainScreenSizeX / GSYS.Screen.MainScreenSizeY;
+				if (ScalingSizeX < DestSizeX)
+				{
+					ScalingSizeY = DestSizeY;
+				}
+				else
+				{
+					ScalingSizeX = DestSizeX;
+					ScalingSizeY = DestSizeX * GSYS.Screen.MainScreenSizeY / GSYS.Screen.MainScreenSizeX;
+				}
 			}
 
 			if( ScalingSizeXBackup != ScalingSizeX ||

--- a/new_command(skin).md
+++ b/new_command(skin).md
@@ -91,7 +91,24 @@ Running notes
 * 251128
 Main BPM
 
+### `400` (div:`3`)
+* 260710
+scaling filter
+
+### `401` (div:`2`)
+* 260710
+stretch
+
+
 ## text_st
 ### type:`74`, div:`5`
 * 251128
 Main BPM
+
+### type:`300`, div:`3`
+* 260710
+scaling filter
+
+### type:`301`, div:`2`
+* 260710
+stretch


### PR DESCRIPTION
Adds SRC_BUTTON 400 and SRC_TEXT 300 to control the filter that fullscreen scaling uses. Current selection is BILINEAR and NEAREST. It used to be BILINEAR by default. Additionally accepts #FULLSCREEN_FILTER in LR2files/Config/optionstr.csv.

Adds SRC_BUTTON 401 and SRC_TEXT 301 to control if fullscreen scaling will stretch to fit the screen. OFF or ON value. Additionally accepts #FULLSCREEN_FITSTRETCH in LR2files/Config/optionstr.csv.

Extends objectStr array which holds the strings available to the skins to 400 elements from previous 300.
Refactors how options strings are read a little. Should have been just pointless code removal.

New features can be used by editing the config file manually, instead of using GUI.

Closes https://github.com/GOMazk/OpenLR2/issues/178