### PR TITLE
Unload stale keysounds of previous song

### DIFF
--- a/LR2/En_audio.cpp
+++ b/LR2/En_audio.cpp
@@ -257,10 +257,11 @@ int IsAltSoundExist(CSTR *filepath){
 int ReleaseSound(AUDIO *aud, SOUNDDATA *sound){
 	CSTR &filepath = sound->filename;
 
+	sound->streaming = false;
 	if (!sound->load) {
 		return -1;
 	}
-	if (filepath.length() <= 1) {
+	if (filepath.length() == 0) {
 		filepath.fillzero();
 		sound->length = 0;
 		sound->load = false;

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -669,6 +669,11 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 
 	std::unique_lock l{gp->criticalSection};
 
+	// Unloading keysounds of previous song.
+	for (auto [keysound, filename] : std::views::zip(gp->keysound, gp->keysound_filename)) {
+		if (filename.length() == 0) ReleaseSound(aud, &keysound);
+	}
+
 	std::vector<unsigned int> keysoundLoadQueue;
 	std::vector<std::jthread> keysoundsLoadWorkers;
 	std::atomic<unsigned int> keysoundsLoaded = 0;


### PR DESCRIPTION
doesn't necessarily fix any bugs, but keeps the state clean, and prevents keysounds of particularly big songs staying in memory forever.