### PR TITLE
fix(exclusive_fullscreen): correct mouse coordinates when multiscreen environment is present

### DIFF
--- a/LR2/En_input.cpp
+++ b/LR2/En_input.cpp
@@ -35,7 +35,7 @@ static MIDI midi;
 
 #ifdef _WIN32
 static void FixMousePointWithClientPosition(int* mouseX, int* mouseY) {
-	if (GetUseFullScreenResolutionMode() != DX_FSRESOLUTIONMODE_BORDERLESS_WINDOW) return;
+	if (GetWindowModeFlag() == TRUE && GetUseFullScreenResolutionMode() != DX_FSRESOLUTIONMODE_BORDERLESS_WINDOW) return;
 
 	const HWND hWnd = GetMainWindowHandle();
 	if (hWnd == nullptr) return;


### PR DESCRIPTION
Version 260707 introduced the monitor-switching issue tracked in #215, which can be avoided by running the game with the -dx11 argument.

However, with -dx11 there is still a mouse-coordinate issue in multi-monitor setups. This is the same kind of issue that was already fixed for borderless mode: after moving the game between monitors, DxLib can report mouse coordinates relative to the wrong monitor. I mentioned this case in the second point of my comment here:
https://github.com/GOMazk/OpenLR2/pull/156#issuecomment-4794432595

This change reuses the existing WinAPI-based coordinate correction for desktop fullscreen/exclusive mode as well, so both borderless and exclusive fullscreen use the cursor position relative to the actual game window.

