### PR TITLE
Add hiterror functionality

### DIFF
--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -1850,92 +1850,76 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 					case "#SRC_HITERROR"_hash:{
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 1, line, pFbuf)) {
-							int player = csv.val[1];
-							ReadSRC(&sk->src_HITERROR[player], &csv, sk);
-							for (int i = 0; i < sk->src_HITERROR[player].graphcount; i++)
-								sk->src_HITERROR[player].grHandles[i] = sk->GrHandle[GRHTYPE_WHITE];
-
+							ReadSRC(&sk->src_HITERROR[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
 					case "#DST_HITERROR"_hash:{
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 1, line, pFbuf)) {
-							ReadDST(&sk->dst_HITERROR[csv.val[1]], &csv, tSkin_num);
+							ReadDST(&sk->dst_HITERROR[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
 					case "#SRC_HITERROR_CENTER"_hash:{
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_HITERROR_CENTER, &csv, sk);
-						for (int i = 0; i < sk->src_HITERROR_CENTER.graphcount; i++)
-							sk->src_HITERROR_CENTER.grHandles[i] = sk->GrHandle[GRHTYPE_WHITE];
 						break;
 					}
 					case "#DST_HITERROR_CENTER"_hash:{
 						SplitCSV(fBuf, &csv, ",");
-						ReadDST(&sk->dst_HITERROR_CENTER[0], &csv, tSkin_num);
+						ReadDST(&sk->dst_HITERROR_CENTER[0], &csv, tSkin_num, line);
 						sk->dst_HITERROR_CENTER[1] = sk->dst_HITERROR_CENTER[0];
 						break;
 					}
 					case "#SRC_HITERROR_PGREAT"_hash:{
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_HITERROR_PGREAT, &csv, sk);
-						for (int i = 0; i < sk->src_HITERROR_PGREAT.graphcount; i++)
-							sk->src_HITERROR_PGREAT.grHandles[i] = sk->GrHandle[GRHTYPE_WHITE];
 						break;
 					}
 					case "#DST_HITERROR_PGREAT"_hash:{
 						SplitCSV(fBuf, &csv, ",");
-						ReadDST(&sk->dst_HITERROR_PGREAT, &csv, tSkin_num);
+						ReadDST(&sk->dst_HITERROR_PGREAT, &csv, tSkin_num, line);
 						break;
 					}
 					case "#SRC_HITERROR_GREAT"_hash:{
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_HITERROR_GREAT, &csv, sk);
-						for (int i = 0; i < sk->src_HITERROR_GREAT.graphcount; i++)
-							sk->src_HITERROR_GREAT.grHandles[i] = sk->GrHandle[GRHTYPE_WHITE];
 						break;
 					}
 					case "#DST_HITERROR_GREAT"_hash:{
 						SplitCSV(fBuf, &csv, ",");
-						ReadDST(&sk->dst_HITERROR_GREAT, &csv, tSkin_num);
+						ReadDST(&sk->dst_HITERROR_GREAT, &csv, tSkin_num, line);
 						break;
 					}
 					case "#SRC_HITERROR_GOOD"_hash:{
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_HITERROR_GOOD, &csv, sk);
-						for (int i = 0; i < sk->src_HITERROR_GOOD.graphcount; i++)
-							sk->src_HITERROR_GOOD.grHandles[i] = sk->GrHandle[GRHTYPE_WHITE];
 						break;
 					}
 					case "#DST_HITERROR_GOOD"_hash:{
 						SplitCSV(fBuf, &csv, ",");
-						ReadDST(&sk->dst_HITERROR_GOOD, &csv, tSkin_num);
+						ReadDST(&sk->dst_HITERROR_GOOD, &csv, tSkin_num, line);
 						break;
 					}
 					case "#SRC_HITERROR_BAD"_hash:{
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_HITERROR_BAD, &csv, sk);
-						for (int i = 0; i < sk->src_HITERROR_BAD.graphcount; i++)
-							sk->src_HITERROR_BAD.grHandles[i] = sk->GrHandle[GRHTYPE_WHITE];
 						break;
 					}
 					case "#DST_HITERROR_BAD"_hash:{
 						SplitCSV(fBuf, &csv, ",");
-						ReadDST(&sk->dst_HITERROR_BAD, &csv, tSkin_num);
+						ReadDST(&sk->dst_HITERROR_BAD, &csv, tSkin_num, line);
 						break;
 					}
 					case "#SRC_HITERROR_EMA"_hash:{
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_HITERROR_EMA, &csv, sk);
-						for (int i = 0; i < sk->src_HITERROR_EMA.graphcount; i++)
-							sk->src_HITERROR_EMA.grHandles[i] = sk->GrHandle[GRHTYPE_WHITE];
 						break;
 					}
 					case "#DST_HITERROR_EMA"_hash:{
 						SplitCSV(fBuf, &csv, ",");
-						ReadDST(&sk->dst_HITERROR_EMA, &csv, tSkin_num);
+						ReadDST(&sk->dst_HITERROR_EMA, &csv, tSkin_num, line);
 						break;
 					}
 				}

--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -421,6 +421,7 @@ int InitSkin(skstruct *sk, int /*unused*/, char font) {
 	InitDST(&sk->dst_HITERROR_POOR);
 	InitSRC(&sk->src_HITERROR_EMA);
 	InitDST(&sk->dst_HITERROR_EMA);
+	sk->HiterrorDSTPool.clear();
 	return 1;
 }
 
@@ -1833,6 +1834,20 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 					case "#SRC_HITERROR"_hash:{
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_HITERROR, &csv, sk);
+						for (int i = 0; i < sk->src_HITERROR.graphcount; i++)
+							sk->src_HITERROR.grHandles[i] = sk->GrHandle[GRHTYPE_WHITE];
+						sk->HiterrorDSTPool.resize(sk->src_HITERROR.graphcount);
+						for (auto &entry : sk->HiterrorDSTPool) {
+							if (entry.draw == nullptr) {
+								entry.dataSize = 1;
+								entry.dstCount = 1;
+								entry.draw = (DSTdraw*)malloc(sizeof(DSTdraw));
+							}
+							entry.draw[0] = {};
+							entry.draw[0].acc = 1;
+							entry.draw[0].blend = 1;
+							entry.draw[0].sortID = ++tSkin_num;
+						}
 						break;
 					}
 					case "#DST_HITERROR"_hash:{
@@ -1843,6 +1858,8 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 					case "#SRC_HITERROR_CENTER"_hash:{
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_HITERROR_CENTER, &csv, sk);
+						for (int i = 0; i < sk->src_HITERROR_CENTER.graphcount; i++)
+							sk->src_HITERROR_CENTER.grHandles[i] = sk->GrHandle[GRHTYPE_WHITE];
 						break;
 					}
 					case "#DST_HITERROR_CENTER"_hash:{
@@ -1853,6 +1870,8 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 					case "#SRC_HITERROR_PGREAT"_hash:{
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_HITERROR_PGREAT, &csv, sk);
+						for (int i = 0; i < sk->src_HITERROR_PGREAT.graphcount; i++)
+							sk->src_HITERROR_PGREAT.grHandles[i] = sk->GrHandle[GRHTYPE_WHITE];
 						break;
 					}
 					case "#DST_HITERROR_PGREAT"_hash:{
@@ -1863,6 +1882,8 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 					case "#SRC_HITERROR_GREAT"_hash:{
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_HITERROR_GREAT, &csv, sk);
+						for (int i = 0; i < sk->src_HITERROR_GREAT.graphcount; i++)
+							sk->src_HITERROR_GREAT.grHandles[i] = sk->GrHandle[GRHTYPE_WHITE];
 						break;
 					}
 					case "#DST_HITERROR_GREAT"_hash:{
@@ -1873,6 +1894,8 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 					case "#SRC_HITERROR_GOOD"_hash:{
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_HITERROR_GOOD, &csv, sk);
+						for (int i = 0; i < sk->src_HITERROR_GOOD.graphcount; i++)
+							sk->src_HITERROR_GOOD.grHandles[i] = sk->GrHandle[GRHTYPE_WHITE];
 						break;
 					}
 					case "#DST_HITERROR_GOOD"_hash:{
@@ -1883,6 +1906,8 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 					case "#SRC_HITERROR_BAD"_hash:{
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_HITERROR_BAD, &csv, sk);
+						for (int i = 0; i < sk->src_HITERROR_BAD.graphcount; i++)
+							sk->src_HITERROR_BAD.grHandles[i] = sk->GrHandle[GRHTYPE_WHITE];
 						break;
 					}
 					case "#DST_HITERROR_BAD"_hash:{
@@ -1893,6 +1918,8 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 					case "#SRC_HITERROR_POOR"_hash:{
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_HITERROR_POOR, &csv, sk);
+						for (int i = 0; i < sk->src_HITERROR_POOR.graphcount; i++)
+							sk->src_HITERROR_POOR.grHandles[i] = sk->GrHandle[GRHTYPE_WHITE];
 						break;
 					}
 					case "#DST_HITERROR_POOR"_hash:{
@@ -1903,6 +1930,8 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 					case "#SRC_HITERROR_EMA"_hash:{
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_HITERROR_EMA, &csv, sk);
+						for (int i = 0; i < sk->src_HITERROR_EMA.graphcount; i++)
+							sk->src_HITERROR_EMA.grHandles[i] = sk->GrHandle[GRHTYPE_WHITE];
 						break;
 					}
 					case "#DST_HITERROR_EMA"_hash:{

--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -975,7 +975,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 				if (!fBuf.left(1).isDiff("#")) {
 					std::string_view fBufStringView(fBuf.c_str());
 					switch (hash(fBufStringView.substr(0, fBufStringView.find(',')))) {
-					case "#IMAGE"_hash:{
+					case "#IMAGE"_hash: {
 						if (sk->count == 100) {
 							ErrorLogFmtAdd("スキン読み込みエラー %d行目\n%s\nこれ以上#IMAGEを登録できません。\n", line, fBuf.body);
 						}
@@ -997,7 +997,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 										sk->grIsMovie[sk->count] = 0;
 									}
 									for (int i = 0; i < sk->customfile_count; i++) {
-										if (sk->customfileRANDOM[i].isSame(csv.str[1].left(sk->customfileRANDOM[i].length())) && sk->customfile[i].isDiff("RANDOM") != 0 && sk->customfile[i].isDiff("ERROR") && sk->customfile[i].length() > 0 ) {
+										if (sk->customfileRANDOM[i].isSame(csv.str[1].left(sk->customfileRANDOM[i].length())) && sk->customfile[i].isDiff("RANDOM") != 0 && sk->customfile[i].isDiff("ERROR") && sk->customfile[i].length() > 0) {
 											csv.str[1].replace("*", sk->customfile[i]);
 											break;
 										}
@@ -1011,7 +1011,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						}
 						break;
 					}
-					case "#FONT"_hash:{
+					case "#FONT"_hash: {
 						if (flag_skipFont) break;
 						if (sk->num_of_struct == 10) {
 							ErrorLogFmtAdd("スキン読み込みエラー %d行目\n%s\nこれ以上#FONTを登録できません。\n", line, fBuf.body);
@@ -1027,7 +1027,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						}
 						break;
 					}
-					case "#SRC_IMAGE"_hash:{
+					case "#SRC_IMAGE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->image.src[sk->image.srcSize], &csv, sk);
 						if (sk->image.src[sk->image.srcSize].graphcount < 1 || sk->image.src[sk->image.srcSize].count < 1) {
@@ -1039,7 +1039,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						sk->image.srcSize++;
 						break;
 					}
-					case "#DST_IMAGE"_hash:{
+					case "#DST_IMAGE"_hash: {
 						if (sk->image.srcSize <= 0) break;
 						int oldDstCount = sk->image.dst[sk->image.srcSize - 1].dstCount;
 						SplitCSV(fBuf, &csv, ",");
@@ -1047,12 +1047,12 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						if (sk->image.dst[sk->image.srcSize - 1].dstCount < 1 || sk->image.dst[sk->image.srcSize - 1].dataSize < 1) {
 							ErrorLogFmtAdd("スキン読み込みエラー %d行目\n%s\nDSTの登録に失敗しました。DSTの一番最初がエラーを起こしている可能性があります。\n", line, fBuf.body);
 						}
-						else if (sk->image.dst[sk->image.srcSize - 1].dstCount == oldDstCount){
+						else if (sk->image.dst[sk->image.srcSize - 1].dstCount == oldDstCount) {
 							ErrorLogFmtAdd("スキン読み込みエラー %d行目\n%s\nDSTの登録に失敗しました。この行の登録のみ失敗しました。\n", line, fBuf.body);
 						}
 						break;
 					}
-					case "#SRC_TEXT"_hash:{
+					case "#SRC_TEXT"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						sk->otherObject[0].src[sk->otherObject[0].srcSize].n = csv.val[1];
 						sk->otherObject[0].src[sk->otherObject[0].srcSize].fontHandle = sk->fontHandle[csv.val[2]];
@@ -1067,13 +1067,13 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						sk->otherObject[0].srcSize++;
 						break;
 					}
-					case "#DST_TEXT"_hash:{
+					case "#DST_TEXT"_hash: {
 						if (sk->otherObject[0].srcSize <= 0) break;
 						SplitCSV(fBuf, &csv, ",");
 						ReadDST(&sk->otherObject[0].dst[sk->otherObject[0].srcSize - 1], &csv, tSkin_num, line);
 						break;
 					}
-					case "#SRC_SLIDER"_hash:{
+					case "#SRC_SLIDER"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->otherObject[2].src[sk->otherObject[2].srcSize], &csv, sk);
 						if (sk->otherObject[2].src[sk->otherObject[2].srcSize].graphcount < 1 || sk->otherObject[2].src[sk->otherObject[2].srcSize].count < 1) {
@@ -1085,13 +1085,13 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						sk->otherObject[2].srcSize++;
 						break;
 					}
-					case "#DST_SLIDER"_hash:{
+					case "#DST_SLIDER"_hash: {
 						if (sk->otherObject[2].srcSize <= 0) break;
 						SplitCSV(fBuf, &csv, ",");
 						ReadDST(&sk->otherObject[2].dst[sk->otherObject[2].srcSize - 1], &csv, tSkin_num, line);
 						break;
 					}
-					case "#SRC_BUTTON"_hash:{
+					case "#SRC_BUTTON"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->otherObject[1].src[sk->otherObject[1].srcSize], &csv, sk);
 						if (sk->otherObject[1].src[sk->otherObject[1].srcSize].graphcount < 1 || sk->otherObject[1].src[sk->otherObject[1].srcSize].count < 1) {
@@ -1103,13 +1103,13 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						sk->otherObject[1].srcSize++;
 						break;
 					}
-					case "#DST_BUTTON"_hash:{
+					case "#DST_BUTTON"_hash: {
 						if (sk->otherObject[1].srcSize <= 0) break;
 						SplitCSV(fBuf, &csv, ",");
 						ReadDST(&sk->otherObject[1].dst[sk->otherObject[1].srcSize - 1], &csv, tSkin_num, line);
 						break;
 					}
-					case "#SRC_ONMOUSE"_hash:{
+					case "#SRC_ONMOUSE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->otherObject[3].src[sk->otherObject[3].srcSize], &csv, sk);
 						if (sk->otherObject[3].src[sk->otherObject[3].srcSize].graphcount < 1 || sk->otherObject[3].src[sk->otherObject[3].srcSize].count < 1) {
@@ -1121,13 +1121,13 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						sk->otherObject[3].srcSize++;
 						break;
 					}
-					case "#DST_ONMOUSE"_hash:{
+					case "#DST_ONMOUSE"_hash: {
 						if (sk->otherObject[3].srcSize <= 0) break;
 						SplitCSV(fBuf, &csv, ",");
 						ReadDST(&sk->otherObject[3].dst[sk->otherObject[3].srcSize - 1], &csv, tSkin_num, line);
 						break;
 					}
-					case "#SRC_BGA"_hash:{
+					case "#SRC_BGA"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->otherObject[4].src[sk->otherObject[4].srcSize], &csv, sk);
 						if (sk->otherObject[4].src[sk->otherObject[4].srcSize].graphcount < 1 || sk->otherObject[4].src[sk->otherObject[4].srcSize].count < 1) {
@@ -1139,14 +1139,14 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						sk->otherObject[4].srcSize++;
 						break;
 					}
-					case "#DST_BGA"_hash:{
+					case "#DST_BGA"_hash: {
 						if (sk->otherObject[4].srcSize <= 0) break;
 						SplitCSV(fBuf, &csv, ",");
 						ReadDST(&sk->otherObject[4].dst[sk->otherObject[4].srcSize - 1], &csv, tSkin_num, line);
 						tSkin_num++;
 						break;
 					}
-					case "#SRC_NUMBER"_hash:{
+					case "#SRC_NUMBER"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->otherObject[6].src[sk->otherObject[6].srcSize], &csv, sk);
 						if (sk->otherObject[6].src[sk->otherObject[6].srcSize].graphcount < 1 || sk->otherObject[6].src[sk->otherObject[6].srcSize].count < 1) {
@@ -1158,25 +1158,25 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						sk->otherObject[6].srcSize++;
 						break;
 					}
-					case "#DST_NUMBER"_hash:{
+					case "#DST_NUMBER"_hash: {
 						if (sk->otherObject[6].srcSize <= 0) break;
 						SplitCSV(fBuf, &csv, ",");
 						ReadDST(&sk->otherObject[6].dst[sk->otherObject[6].srcSize - 1], &csv, tSkin_num, line);
 						break;
 					}
-					case "#SRC_MASK"_hash:{
+					case "#SRC_MASK"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->otherObject[7].src[sk->otherObject[7].srcSize], &csv, sk);
 						sk->otherObject[7].srcSize++;
 						break;
 					}
-					case "#DST_MASK"_hash:{
+					case "#DST_MASK"_hash: {
 						if (sk->otherObject[7].srcSize <= 0) break;
 						SplitCSV(fBuf, &csv, ",");
 						ReadDST(&sk->otherObject[7].dst[sk->otherObject[7].srcSize - 1], &csv, tSkin_num, line);
 						break;
 					}
-					case "#SRC_BARGRAPH"_hash:{
+					case "#SRC_BARGRAPH"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->otherObject[5].src[sk->otherObject[5].srcSize], &csv, sk);
 						if (sk->otherObject[5].src[sk->otherObject[5].srcSize].graphcount < 1 || sk->otherObject[5].src[sk->otherObject[5].srcSize].count < 1) {
@@ -1188,35 +1188,35 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						sk->otherObject[5].srcSize++;
 						break;
 					}
-					case "#DST_BARGRAPH"_hash:{
+					case "#DST_BARGRAPH"_hash: {
 						if (sk->otherObject[5].srcSize <= 0) break;
 						SplitCSV(fBuf, &csv, ",");
 						ReadDST(&sk->otherObject[5].dst[sk->otherObject[5].srcSize - 1], &csv, tSkin_num, line);
 						tSkin_num++;
 						break;
 					}
-					case "#SRC_BAR_BODY"_hash:{
+					case "#SRC_BAR_BODY"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 29, line, pFbuf)) {
 							ReadSRC(&sk->src_BAR_BODY[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#DST_BAR_BODY_OFF"_hash:{
+					case "#DST_BAR_BODY_OFF"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 29, line, pFbuf)) {
 							ReadDST(&sk->dst_BAR_BODY_OFF[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#DST_BAR_BODY_ON"_hash:{
+					case "#DST_BAR_BODY_ON"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 29, line, pFbuf)) {
 							ReadDST(&sk->dst_BAR_BODY_ON[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#BAR_CENTER"_hash:{
+					case "#BAR_CENTER"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 29, line, pFbuf)) {
 							SplitCSV(fBuf, &csv, ",");
@@ -1224,193 +1224,193 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						}
 						break;
 					}
-					case "#SRC_BAR_TITLE"_hash:{
+					case "#SRC_BAR_TITLE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 4, line, pFbuf)) {
 							ReadSRC_BAR_TITLE(&sk->src_BAR_TITLE[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#DST_BAR_TITLE"_hash:{
+					case "#DST_BAR_TITLE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 4, line, pFbuf)) {
 							ReadDST(&sk->dst_BAR_TITLE[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#TRANSCOLOR"_hash:{
+					case "#TRANSCOLOR"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						SetTransColor(csv.val[1], csv.val[2], csv.val[3]);
 						break;
 					}
-					case "#TRANSCLOLR"_hash:{
+					case "#TRANSCLOLR"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						SetTransColor(csv.val[1], csv.val[2], csv.val[3]);
 						break;
 					}
-					case "#TRANSCLOLOR"_hash:{
+					case "#TRANSCLOLOR"_hash: {
 						SplitCSV(fBuf, &csv, ",");
-						SetTransColor(csv.val[1], csv.val[2],csv.val[3]);
+						SetTransColor(csv.val[1], csv.val[2], csv.val[3]);
 						break;
 					}
-					case "#STARTINPUT"_hash:{
+					case "#STARTINPUT"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						sk->startinput_start = csv.val[1];
 						sk->startinput_rank = csv.val[2];
 						sk->startinput_update = csv.val[3];
 						break;
 					}
-					case "#SCENETIME"_hash:{
+					case "#SCENETIME"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						sk->scenetime = csv.val[1];
 						break;
 					}
-					case "#FADEOUT"_hash:{
+					case "#FADEOUT"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						sk->fadeout = csv.val[1];
 						break;
 					}
-					case "#CLOSE"_hash:{
+					case "#CLOSE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						sk->close = csv.val[1];
 						break;
 					}
-					case "#SKIP"_hash:{
+					case "#SKIP"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						sk->close = csv.val[1];
 						break;
 					}
-					case "#PLAYSTART"_hash:{
+					case "#PLAYSTART"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						sk->playstart = csv.val[1];
 						break;
 					}
-					case "#LOADSTART"_hash:{
+					case "#LOADSTART"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						sk->loadstart = csv.val[1];
 						break;
 					}
-					case "#LOADEND"_hash:{
+					case "#LOADEND"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						sk->loadend = csv.val[1];
 						break;
 					}
-					case "#BAR_AVAILABLE"_hash:{
+					case "#BAR_AVAILABLE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						sk->bar_availabe_from = csv.val[1];
 						sk->bar_availabe_to = csv.val[2];
 						break;
 					}
-					case "#SRC_BAR_FLASH"_hash:{
+					case "#SRC_BAR_FLASH"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_BAR_FLASH, &csv, sk);
 						break;
 					}
-					case "#DST_BAR_FLASH"_hash:{
+					case "#DST_BAR_FLASH"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadDST(&sk->dst_BAR_FLASH, &csv, tSkin_num, line);
 						break;
 					}
-					case "#DST_BAR_STAGEFILE"_hash:{
+					case "#DST_BAR_STAGEFILE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadDST(&sk->dst_BAR_STAGEFILE, &csv, tSkin_num, line);
 						break;
 					}
-					case "#SRC_MOUSECURSOR"_hash:{
+					case "#SRC_MOUSECURSOR"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_MOUSECURSOR, &csv, sk);
 						break;
 					}
-					case "#DST_MOUSECURSOR"_hash:{
+					case "#DST_MOUSECURSOR"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadDST(&sk->dst_MOUSECURSOR, &csv, tSkin_num, line);
 						break;
 					}
-					case "#SRC_BAR_LEVEL"_hash:{
+					case "#SRC_BAR_LEVEL"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 10, line, pFbuf)) {
 							ReadSRC(&sk->src_BAR_LEVEL[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#DST_BAR_LEVEL"_hash:{
+					case "#DST_BAR_LEVEL"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 10, line, pFbuf)) {
 							ReadDST(&sk->dst_BAR_LEVEL[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#SRC_NOTE"_hash:{
+					case "#SRC_NOTE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 19, line, pFbuf)) {
 							ReadSRC(&sk->src_NOTE[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#SRC_MINE"_hash:{
+					case "#SRC_MINE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 19, line, pFbuf)) {
 							ReadSRC(&sk->src_MINE[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#SRC_LN_START"_hash:{
+					case "#SRC_LN_START"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 19, line, pFbuf)) {
 							ReadSRC(&sk->src_LN_START[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#SRC_LN_END"_hash:{
+					case "#SRC_LN_END"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 19, line, pFbuf)) {
 							ReadSRC(&sk->src_LN_END[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#SRC_LN_BODY"_hash:{
+					case "#SRC_LN_BODY"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 19, line, pFbuf)) {
 							ReadSRC(&sk->src_LN_BODY[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#SRC_AUTO_NOTE"_hash:{
+					case "#SRC_AUTO_NOTE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 19, line, pFbuf)) {
 							ReadSRC(&sk->src_AUTO_NOTE[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#SRC_AUTO_MINE"_hash:{
+					case "#SRC_AUTO_MINE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 19, line, pFbuf)) {
 							ReadSRC(&sk->src_AUTO_MINE[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#SRC_AUTO_LN_START"_hash:{
+					case "#SRC_AUTO_LN_START"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 19, line, pFbuf)) {
 							ReadSRC(&sk->src_AUTO_LN_START[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#SRC_AUTO_LN_END"_hash:{
+					case "#SRC_AUTO_LN_END"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 19, line, pFbuf)) {
 							ReadSRC(&sk->src_AUTO_LN_END[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#SRC_AUTO_LN_BODY"_hash:{
+					case "#SRC_AUTO_LN_BODY"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 19, line, pFbuf)) {
 							ReadSRC(&sk->src_AUTO_LN_BODY[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#DST_NOTE"_hash:{
+					case "#DST_NOTE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 19, line, pFbuf)) {
 							ReadDST(&sk->dst_NOTE[csv.val[1]], &csv, tSkin_num, line);
@@ -1418,7 +1418,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						}
 						break;
 					}
-					case "#SRC_NOWJUDGE_1P"_hash:{
+					case "#SRC_NOWJUDGE_1P"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 5, line, pFbuf)) {
 							ReadSRC(&sk->src_NOWJUDGE[PLAYER_1][csv.val[1]], &csv, sk);
@@ -1426,7 +1426,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						}
 						break;
 					}
-					case "#DST_NOWJUDGE_1P"_hash:{
+					case "#DST_NOWJUDGE_1P"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 5, line, pFbuf)) {
 							ReadDST(&sk->dst_NOWJUDGE[PLAYER_1][csv.val[1]], &csv, tSkin_num, line);
@@ -1434,19 +1434,19 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						}
 						break;
 					}
-					case "#SRC_NOWCOMBO_1P"_hash:{
+					case "#SRC_NOWCOMBO_1P"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_NOWCOMBO[PLAYER_1][csv.val[1]], &csv, sk);
 						sk->src_NOWCOMBO[PLAYER_1][csv.val[1]].timer = 46;
 						break;
 					}
-					case "#DST_NOWCOMBO_1P"_hash:{
+					case "#DST_NOWCOMBO_1P"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadDST(&sk->dst_NOWCOMBO[PLAYER_1][csv.val[1]], &csv, tSkin_num, line);
 						sk->dst_NOWJUDGE[PLAYER_1][csv.val[1]].timer = 46; //???mistake?
 						break;
 					}
-					case "#SRC_NOWJUDGE_2P"_hash:{
+					case "#SRC_NOWJUDGE_2P"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 5, line, pFbuf)) {
 							ReadSRC(&sk->src_NOWJUDGE[PLAYER_2][csv.val[1]], &csv, sk);
@@ -1454,7 +1454,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						}
 						break;
 					}
-					case "#DST_NOWJUDGE_2P"_hash:{
+					case "#DST_NOWJUDGE_2P"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 5, line, pFbuf)) {
 							ReadDST(&sk->dst_NOWJUDGE[PLAYER_2][csv.val[1]], &csv, tSkin_num, line);
@@ -1462,7 +1462,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						}
 						break;
 					}
-					case "#SRC_NOWCOMBO_2P"_hash:{
+					case "#SRC_NOWCOMBO_2P"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 5, line, pFbuf)) {
 							ReadSRC(&sk->src_NOWCOMBO[PLAYER_2][csv.val[1]], &csv, sk);
@@ -1470,7 +1470,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						}
 						break;
 					}
-					case "#DST_NOWCOMBO_2P"_hash:{
+					case "#DST_NOWCOMBO_2P"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 5, line, pFbuf)) {
 							ReadDST(&sk->dst_NOWCOMBO[PLAYER_2][csv.val[1]], &csv, tSkin_num, line);
@@ -1478,197 +1478,197 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						}
 						break;
 					}
-					case "#SRC_GROOVEGAUGE"_hash:{
+					case "#SRC_GROOVEGAUGE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 1, line, pFbuf)) {
 							ReadSRC(&sk->src_GROOVEGAUGE[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#DST_GROOVEGAUGE"_hash:{
+					case "#DST_GROOVEGAUGE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 1, line, pFbuf)) {
 							ReadDST(&sk->dst_GROOVEGAUGE[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#SRC_GAUGECHART_1P"_hash:{
+					case "#SRC_GAUGECHART_1P"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 1, line, pFbuf)) {
 							ReadSRC(&sk->src_GAUGECHART[PLAYER_1][csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#DST_GAUGECHART_1P"_hash:{
+					case "#DST_GAUGECHART_1P"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 1, line, pFbuf)) {
 							ReadDST(&sk->dst_GAUGECHART[PLAYER_1][csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#SRC_GAUGECHART_2P"_hash:{
+					case "#SRC_GAUGECHART_2P"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 1, line, pFbuf)) {
 							ReadSRC(&sk->src_GAUGECHART[PLAYER_2][csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#DST_GAUGECHART_2P"_hash:{
+					case "#DST_GAUGECHART_2P"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 1, line, pFbuf)) {
 							ReadDST(&sk->dst_GAUGECHART[PLAYER_2][csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#SRC_SCORECHART"_hash:{
+					case "#SRC_SCORECHART"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 2, line, pFbuf)) {
 							ReadSRC(&sk->src_SCORECHART[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#DST_SCORECHART"_hash:{
+					case "#DST_SCORECHART"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 2, line, pFbuf)) {
 							ReadDST(&sk->dst_SCORECHART[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#SRC_LINE"_hash:{
+					case "#SRC_LINE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 1, line, pFbuf)) {
 							ReadSRC(&sk->src_LINE[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#DST_LINE"_hash:{
+					case "#DST_LINE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 1, line, pFbuf)) {
 							ReadDST(&sk->dst_LINE[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#SRC_JUDGELINE"_hash:{
+					case "#SRC_JUDGELINE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 1, line, pFbuf)) {
 							ReadSRC(&sk->src_JUDGELINE[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#DST_JUDGELINE"_hash:{
+					case "#DST_JUDGELINE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 1, line, pFbuf)) {
 							ReadDST(&sk->dst_JUDGELINE[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#SRC_BAR_LAMP"_hash:{
+					case "#SRC_BAR_LAMP"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 9, line, pFbuf)) {
 							ReadSRC(&sk->src_BAR_LAMP[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#DST_BAR_LAMP"_hash:{
+					case "#DST_BAR_LAMP"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 9, line, pFbuf)) {
 							ReadDST(&sk->dst_BAR_LAMP[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#SRC_BAR_MY_LAMP"_hash:{
+					case "#SRC_BAR_MY_LAMP"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 9, line, pFbuf)) {
 							ReadSRC(&sk->src_BAR_MY_LAMP[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#DST_BAR_MY_LAMP"_hash:{
+					case "#DST_BAR_MY_LAMP"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 9, line, pFbuf)) {
 							ReadDST(&sk->dst_BAR_MY_LAMP[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#SRC_BAR_RIVAL_LAMP"_hash:{
+					case "#SRC_BAR_RIVAL_LAMP"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 9, line, pFbuf)) {
 							ReadSRC(&sk->src_BAR_RIVAL_LAMP[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#DST_BAR_RIVAL_LAMP"_hash:{
+					case "#DST_BAR_RIVAL_LAMP"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 9, line, pFbuf)) {
 							ReadDST(&sk->dst_BAR_RIVAL_LAMP[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#SRC_BAR_STAR"_hash:{
+					case "#SRC_BAR_STAR"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 5, line, pFbuf)) {
 							ReadSRC(&sk->src_BAR_STAR[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#DST_BAR_STAR"_hash:{
+					case "#DST_BAR_STAR"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 5, line, pFbuf)) {
 							ReadDST(&sk->dst_BAR_STAR[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#SRC_THUMBNAIL"_hash:{
+					case "#SRC_THUMBNAIL"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_THUMBNAIL, &csv, sk);
 						break;
 					}
-					case "#DST_THUMBNAIL"_hash:{
+					case "#DST_THUMBNAIL"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadDST(&sk->dst_THUMBNAIL, &csv, tSkin_num, line);
 						break;
 					}
-					case "#SRC_README"_hash:{
+					case "#SRC_README"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 1, line, pFbuf)) {
 							ReadSRC_BAR_TITLE(&sk->src_README[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#DST_README"_hash:{
+					case "#DST_README"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 1, line, pFbuf)) {
 							ReadDST(&sk->dst_README[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#DST_EVENT_LOADINGBG"_hash:{
+					case "#DST_EVENT_LOADINGBG"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 4, line, pFbuf)) {
 							ReadDST(&sk->dst_EVENT_LOADINGBG[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#SRC_EVENT_MODE_CURSOR"_hash:{
+					case "#SRC_EVENT_MODE_CURSOR"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_EVENT_MODE_CURSOR, &csv, sk);
 						break;
 					}
-					case "#DST_EVENT_MODE_CURSOR_ON"_hash:{
+					case "#DST_EVENT_MODE_CURSOR_ON"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 10, line, pFbuf)) {
 							ReadDST(&sk->dst_EVENT_MODE_CURSOR_ON[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#DST_EVENT_MODE_CURSOR_OFF"_hash:{
+					case "#DST_EVENT_MODE_CURSOR_OFF"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 10, line, pFbuf)) {
 							ReadDST(&sk->dst_EVENT_MODE_CURSOR_OFF[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#EVENT_STARTINPUT"_hash:{
+					case "#EVENT_STARTINPUT"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						sk->event_STARTINPUT[0] = csv.val[1];
 						sk->event_STARTINPUT[1] = csv.val[2];
@@ -1682,7 +1682,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						sk->event_STARTINPUT[9] = csv.val[10];
 						break;
 					}
-					case "#EVENT_FADEOUT"_hash:{
+					case "#EVENT_FADEOUT"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						sk->event_FADEOUT[0] = csv.val[1];
 						sk->event_FADEOUT[1] = csv.val[2];
@@ -1696,7 +1696,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						sk->event_FADEOUT[9] = csv.val[10];
 						break;
 					}
-					case "#LR2FONT"_hash:{
+					case "#LR2FONT"_hash: {
 						if (flag_skipFont) break;
 						SplitCSV(fBuf, &csv, ",");
 						adjust_input_filepath(csv.str[1]);
@@ -1706,7 +1706,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						else if (csv.val[2] == 1 || !sk->disableImageFont) {
 							if (csv.str[1].isDiff("CONTINUE")) {
 								for (int i = 0; i < sk->customfile_count; i++) {
-									if(sk->customfileRANDOM[i].isSame(csv.str[1].left(sk->customfileRANDOM[i].length())) && sk->customfile[i].isDiff("RANDOM") && sk->customfile[i].isDiff("ERROR") && sk->customfile[i].length() > 0){
+									if (sk->customfileRANDOM[i].isSame(csv.str[1].left(sk->customfileRANDOM[i].length())) && sk->customfile[i].isDiff("RANDOM") && sk->customfile[i].isDiff("ERROR") && sk->customfile[i].length() > 0) {
 										csv.str[1].replace("*", sk->customfile[i]);
 										//line?
 										break;
@@ -1722,7 +1722,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						}
 						break;
 					}
-					case "#HELPFILE"_hash:{
+					case "#HELPFILE"_hash: {
 						adjust_input_filepath(csv.str[1]);
 						SplitCSV(fBuf, &csv, ",");
 						if (sk->helpfileCount < 10) {
@@ -1731,39 +1731,39 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						}
 						break;
 					}
-					case "#NOBGA"_hash:{
+					case "#NOBGA"_hash: {
 						sk->flag_BGA = 0;
 						break;
 					}
-					case "#FLIPRESULT"_hash:{
+					case "#FLIPRESULT"_hash: {
 						sk->flag_flip = true;
 						sk->op[350] = false;
 						sk->op[351] = true;
 						break;
 					}
-					case "#FLIPSIDE"_hash:{
+					case "#FLIPSIDE"_hash: {
 						flipside = true;
 						break;
 					}
-					case "#DISABLEFLIP"_hash:{
+					case "#DISABLEFLIP"_hash: {
 						sk->flag_flip = false;
 						sk->op[350] = true;
 						sk->op[351] = false;
 						break;
 					}
-					case "#TEXTMERGIN"_hash:{
+					case "#TEXTMERGIN"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						sk->textmergin_1 = csv.val[1];
 						sk->textmergin_2 = csv.val[2];
 						break;
 					}
-					case "#SCRATCHSIDE"_hash:{
+					case "#SCRATCHSIDE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						sk->scratchside_1 = csv.val[1];
 						sk->scratchside_2 = csv.val[2];
 						break;
 					}
-					case "#INCLUDE"_hash:{
+					case "#INCLUDE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						adjust_input_filepath(csv.str[1]);
 						for (int i = 0; i < sk->customfile_count; i++) {
@@ -1778,22 +1778,22 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						tSkin_num += ReadSkin(sk, GetRandomFileNoError(csv.str[1], dir), unused, tSkin_num, sku, flag_skipFont);
 						break;
 					}
-					case "#CUSTOMOPTION"_hash:{
+					case "#CUSTOMOPTION"_hash: {
 						sk->customfile_count++;
 						break;
 					}
-					case "#CUSTOMFILE"_hash:{
+					case "#CUSTOMFILE"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						adjust_input_filepath(csv.str[2]);
 						sk->customfileRANDOM[sk->customfile_count].assign(&csv.str[2]);
 						sk->customfile[sk->customfile_count].assign(&sku->customize_filename[sk->customfile_count]);
 						if (sk->customfile[sk->customfile_count].isSame("RANDOM")) {
-							sk->customfile[sk->customfile_count].assign( GetRandomFile(sk->customfileRANDOM[sk->customfile_count], 1) );
+							sk->customfile[sk->customfile_count].assign(GetRandomFile(sk->customfileRANDOM[sk->customfile_count], 1));
 						}
 						sk->customfile_count++;
 						break;
 					}
-					case "#CUSTOMFOLDER"_hash:{
+					case "#CUSTOMFOLDER"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						adjust_input_filepath(csv.str[2]);
 						sk->customfileRANDOM[sk->customfile_count].assign(&csv.str[2]);
@@ -1801,11 +1801,11 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						sk->customfile_count++;
 						break;
 					}
-					case "#RELOADBANNER"_hash:{
+					case "#RELOADBANNER"_hash: {
 						sk->reloadbanner = 1;
 						break;
 					}
-					case "#SETOPTION"_hash:{
+					case "#SETOPTION"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (csv.val[1] < 1000) {
 							sk->op[csv.val[1]] = (csv.val[2] != 0);
@@ -1815,119 +1815,119 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						}
 						break;
 					}
-					case "#SRC_BAR_RANK"_hash:{
+					case "#SRC_BAR_RANK"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 9, line, pFbuf)) {
 							ReadSRC(&sk->src_BAR_RANK[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#DST_BAR_RANK"_hash:{
+					case "#DST_BAR_RANK"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 9, line, pFbuf)) {
 							ReadDST(&sk->dst_BAR_RANK[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#SRC_BAR_RIVAL"_hash:{
+					case "#SRC_BAR_RIVAL"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 9, line, pFbuf)) {
 							ReadSRC(&sk->src_BAR_RIVAL[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#DST_BAR_RIVAL"_hash:{
+					case "#DST_BAR_RIVAL"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 9, line, pFbuf)) {
 							ReadDST(&sk->dst_BAR_RIVAL[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#HORIZONTAL"_hash:{
+					case "#HORIZONTAL"_hash: {
 						sk->horizontal = 1;
 						break;
 					}
-					case "#SRC_HITERROR"_hash:{
+					case "#SRC_HITERROR"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 1, line, pFbuf)) {
 							ReadSRC(&sk->src_HITERROR[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
-					case "#DST_HITERROR"_hash:{
+					case "#DST_HITERROR"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						if (CheckIndexRange(csv.val[1], 0, 1, line, pFbuf)) {
 							ReadDST(&sk->dst_HITERROR[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;
 					}
-					case "#SRC_HITERROR_CENTER"_hash:{
+					case "#SRC_HITERROR_CENTER"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_HITERROR_CENTER, &csv, sk);
 						break;
 					}
-					case "#DST_HITERROR_CENTER"_hash:{
+					case "#DST_HITERROR_CENTER"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadDST(&sk->dst_HITERROR_CENTER[0], &csv, tSkin_num, line);
 						sk->dst_HITERROR_CENTER[1] = sk->dst_HITERROR_CENTER[0];
 						break;
 					}
-					case "#SRC_HITERROR_PGREAT"_hash:{
+					case "#SRC_HITERROR_PGREAT"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_HITERROR_PGREAT, &csv, sk);
 						break;
 					}
-					case "#DST_HITERROR_PGREAT"_hash:{
+					case "#DST_HITERROR_PGREAT"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadDST(&sk->dst_HITERROR_PGREAT, &csv, tSkin_num, line);
 						break;
 					}
-					case "#SRC_HITERROR_GREAT"_hash:{
+					case "#SRC_HITERROR_GREAT"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_HITERROR_GREAT, &csv, sk);
 						break;
 					}
-					case "#DST_HITERROR_GREAT"_hash:{
+					case "#DST_HITERROR_GREAT"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadDST(&sk->dst_HITERROR_GREAT, &csv, tSkin_num, line);
 						break;
 					}
-					case "#SRC_HITERROR_GOOD"_hash:{
+					case "#SRC_HITERROR_GOOD"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_HITERROR_GOOD, &csv, sk);
 						break;
 					}
-					case "#DST_HITERROR_GOOD"_hash:{
+					case "#DST_HITERROR_GOOD"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadDST(&sk->dst_HITERROR_GOOD, &csv, tSkin_num, line);
 						break;
 					}
-					case "#SRC_HITERROR_BAD"_hash:{
+					case "#SRC_HITERROR_BAD"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_HITERROR_BAD, &csv, sk);
 						break;
 					}
-					case "#DST_HITERROR_BAD"_hash:{
+					case "#DST_HITERROR_BAD"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadDST(&sk->dst_HITERROR_BAD, &csv, tSkin_num, line);
 						break;
 					}
-					case "#SRC_HITERROR_EMA"_hash:{
+					case "#SRC_HITERROR_EMA"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadSRC(&sk->src_HITERROR_EMA, &csv, sk);
 						break;
 					}
-					case "#DST_HITERROR_EMA"_hash:{
+					case "#DST_HITERROR_EMA"_hash: {
 						SplitCSV(fBuf, &csv, ",");
 						ReadDST(&sk->dst_HITERROR_EMA, &csv, tSkin_num, line);
 						break;
+					}
 					}
 				}
 				tSkin_num++;
 			}
 		}
 		*fBuf.atPos(0) = '\0';
-	}
 	}
 	fclose(pFile);
 	if (skin_num == 0) {

--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -405,10 +405,13 @@ int InitSkin(skstruct *sk, int /*unused*/, char font) {
 		InitDST(&sk->dst_EVENT_LOADINGBG[i]);
 	}
 
-	InitSRC(&sk->src_HITERROR);
-	InitDST(&sk->dst_HITERROR);
+	for (int i = 0; i < 2; i++) {
+		InitSRC(&sk->src_HITERROR[i]);
+		InitDST(&sk->dst_HITERROR[i]);
+	}
 	InitSRC(&sk->src_HITERROR_CENTER);
-	InitDST(&sk->dst_HITERROR_CENTER);
+	InitDST(&sk->dst_HITERROR_CENTER[0]);
+	InitDST(&sk->dst_HITERROR_CENTER[1]);
 	InitSRC(&sk->src_HITERROR_PGREAT);
 	InitDST(&sk->dst_HITERROR_PGREAT);
 	InitSRC(&sk->src_HITERROR_GREAT);
@@ -417,11 +420,8 @@ int InitSkin(skstruct *sk, int /*unused*/, char font) {
 	InitDST(&sk->dst_HITERROR_GOOD);
 	InitSRC(&sk->src_HITERROR_BAD);
 	InitDST(&sk->dst_HITERROR_BAD);
-	InitSRC(&sk->src_HITERROR_POOR);
-	InitDST(&sk->dst_HITERROR_POOR);
 	InitSRC(&sk->src_HITERROR_EMA);
 	InitDST(&sk->dst_HITERROR_EMA);
-	sk->HiterrorDSTPool.clear();
 	return 1;
 }
 
@@ -1833,26 +1833,20 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 					}
 					case "#SRC_HITERROR"_hash:{
 						SplitCSV(fBuf, &csv, ",");
-						ReadSRC(&sk->src_HITERROR, &csv, sk);
-						for (int i = 0; i < sk->src_HITERROR.graphcount; i++)
-							sk->src_HITERROR.grHandles[i] = sk->GrHandle[GRHTYPE_WHITE];
-						sk->HiterrorDSTPool.resize(sk->src_HITERROR.graphcount);
-						for (auto &entry : sk->HiterrorDSTPool) {
-							if (entry.draw == nullptr) {
-								entry.dataSize = 1;
-								entry.dstCount = 1;
-								entry.draw = (DSTdraw*)malloc(sizeof(DSTdraw));
-							}
-							entry.draw[0] = {};
-							entry.draw[0].acc = 1;
-							entry.draw[0].blend = 1;
-							entry.draw[0].sortID = ++tSkin_num;
+						if (CheckIndexRange(csv.val[1], 0, 1, line, pFbuf)) {
+							int player = csv.val[1];
+							ReadSRC(&sk->src_HITERROR[player], &csv, sk);
+							for (int i = 0; i < sk->src_HITERROR[player].graphcount; i++)
+								sk->src_HITERROR[player].grHandles[i] = sk->GrHandle[GRHTYPE_WHITE];
+
 						}
 						break;
 					}
 					case "#DST_HITERROR"_hash:{
 						SplitCSV(fBuf, &csv, ",");
-						ReadDST(&sk->dst_HITERROR, &csv, tSkin_num);
+						if (CheckIndexRange(csv.val[1], 0, 1, line, pFbuf)) {
+							ReadDST(&sk->dst_HITERROR[csv.val[1]], &csv, tSkin_num);
+						}
 						break;
 					}
 					case "#SRC_HITERROR_CENTER"_hash:{
@@ -1864,7 +1858,8 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 					}
 					case "#DST_HITERROR_CENTER"_hash:{
 						SplitCSV(fBuf, &csv, ",");
-						ReadDST(&sk->dst_HITERROR_CENTER, &csv, tSkin_num);
+						ReadDST(&sk->dst_HITERROR_CENTER[0], &csv, tSkin_num);
+						sk->dst_HITERROR_CENTER[1] = sk->dst_HITERROR_CENTER[0];
 						break;
 					}
 					case "#SRC_HITERROR_PGREAT"_hash:{
@@ -1913,18 +1908,6 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 					case "#DST_HITERROR_BAD"_hash:{
 						SplitCSV(fBuf, &csv, ",");
 						ReadDST(&sk->dst_HITERROR_BAD, &csv, tSkin_num);
-						break;
-					}
-					case "#SRC_HITERROR_POOR"_hash:{
-						SplitCSV(fBuf, &csv, ",");
-						ReadSRC(&sk->src_HITERROR_POOR, &csv, sk);
-						for (int i = 0; i < sk->src_HITERROR_POOR.graphcount; i++)
-							sk->src_HITERROR_POOR.grHandles[i] = sk->GrHandle[GRHTYPE_WHITE];
-						break;
-					}
-					case "#DST_HITERROR_POOR"_hash:{
-						SplitCSV(fBuf, &csv, ",");
-						ReadDST(&sk->dst_HITERROR_POOR, &csv, tSkin_num);
 						break;
 					}
 					case "#SRC_HITERROR_EMA"_hash:{

--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -404,6 +404,23 @@ int InitSkin(skstruct *sk, int /*unused*/, char font) {
 	for (int i = 0; i < 5; i++) {
 		InitDST(&sk->dst_EVENT_LOADINGBG[i]);
 	}
+
+	InitSRC(&sk->src_HITERROR);
+	InitDST(&sk->dst_HITERROR);
+	InitSRC(&sk->src_HITERROR_CENTER);
+	InitDST(&sk->dst_HITERROR_CENTER);
+	InitSRC(&sk->src_HITERROR_PGREAT);
+	InitDST(&sk->dst_HITERROR_PGREAT);
+	InitSRC(&sk->src_HITERROR_GREAT);
+	InitDST(&sk->dst_HITERROR_GREAT);
+	InitSRC(&sk->src_HITERROR_GOOD);
+	InitDST(&sk->dst_HITERROR_GOOD);
+	InitSRC(&sk->src_HITERROR_BAD);
+	InitDST(&sk->dst_HITERROR_BAD);
+	InitSRC(&sk->src_HITERROR_POOR);
+	InitDST(&sk->dst_HITERROR_POOR);
+	InitSRC(&sk->src_HITERROR_EMA);
+	InitDST(&sk->dst_HITERROR_EMA);
 	return 1;
 }
 
@@ -1813,12 +1830,92 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						sk->horizontal = 1;
 						break;
 					}
+					case "#SRC_HITERROR"_hash:{
+						SplitCSV(fBuf, &csv, ",");
+						ReadSRC(&sk->src_HITERROR, &csv, sk);
+						break;
+					}
+					case "#DST_HITERROR"_hash:{
+						SplitCSV(fBuf, &csv, ",");
+						ReadDST(&sk->dst_HITERROR, &csv, tSkin_num);
+						break;
+					}
+					case "#SRC_HITERROR_CENTER"_hash:{
+						SplitCSV(fBuf, &csv, ",");
+						ReadSRC(&sk->src_HITERROR_CENTER, &csv, sk);
+						break;
+					}
+					case "#DST_HITERROR_CENTER"_hash:{
+						SplitCSV(fBuf, &csv, ",");
+						ReadDST(&sk->dst_HITERROR_CENTER, &csv, tSkin_num);
+						break;
+					}
+					case "#SRC_HITERROR_PGREAT"_hash:{
+						SplitCSV(fBuf, &csv, ",");
+						ReadSRC(&sk->src_HITERROR_PGREAT, &csv, sk);
+						break;
+					}
+					case "#DST_HITERROR_PGREAT"_hash:{
+						SplitCSV(fBuf, &csv, ",");
+						ReadDST(&sk->dst_HITERROR_PGREAT, &csv, tSkin_num);
+						break;
+					}
+					case "#SRC_HITERROR_GREAT"_hash:{
+						SplitCSV(fBuf, &csv, ",");
+						ReadSRC(&sk->src_HITERROR_GREAT, &csv, sk);
+						break;
+					}
+					case "#DST_HITERROR_GREAT"_hash:{
+						SplitCSV(fBuf, &csv, ",");
+						ReadDST(&sk->dst_HITERROR_GREAT, &csv, tSkin_num);
+						break;
+					}
+					case "#SRC_HITERROR_GOOD"_hash:{
+						SplitCSV(fBuf, &csv, ",");
+						ReadSRC(&sk->src_HITERROR_GOOD, &csv, sk);
+						break;
+					}
+					case "#DST_HITERROR_GOOD"_hash:{
+						SplitCSV(fBuf, &csv, ",");
+						ReadDST(&sk->dst_HITERROR_GOOD, &csv, tSkin_num);
+						break;
+					}
+					case "#SRC_HITERROR_BAD"_hash:{
+						SplitCSV(fBuf, &csv, ",");
+						ReadSRC(&sk->src_HITERROR_BAD, &csv, sk);
+						break;
+					}
+					case "#DST_HITERROR_BAD"_hash:{
+						SplitCSV(fBuf, &csv, ",");
+						ReadDST(&sk->dst_HITERROR_BAD, &csv, tSkin_num);
+						break;
+					}
+					case "#SRC_HITERROR_POOR"_hash:{
+						SplitCSV(fBuf, &csv, ",");
+						ReadSRC(&sk->src_HITERROR_POOR, &csv, sk);
+						break;
+					}
+					case "#DST_HITERROR_POOR"_hash:{
+						SplitCSV(fBuf, &csv, ",");
+						ReadDST(&sk->dst_HITERROR_POOR, &csv, tSkin_num);
+						break;
+					}
+					case "#SRC_HITERROR_EMA"_hash:{
+						SplitCSV(fBuf, &csv, ",");
+						ReadSRC(&sk->src_HITERROR_EMA, &csv, sk);
+						break;
+					}
+					case "#DST_HITERROR_EMA"_hash:{
+						SplitCSV(fBuf, &csv, ",");
+						ReadDST(&sk->dst_HITERROR_EMA, &csv, tSkin_num);
+						break;
 					}
 				}
 				tSkin_num++;
 			}
 		}
 		*fBuf.atPos(0) = '\0';
+	}
 	}
 	fclose(pFile);
 	if (skin_num == 0) {

--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -425,8 +425,7 @@ int InitSkin(skstruct *sk, int /*unused*/, char font) {
 		InitDST(&sk->dst_HITERROR[i]);
 	}
 	InitSRC(&sk->src_HITERROR_CENTER);
-	InitDST(&sk->dst_HITERROR_CENTER[0]);
-	InitDST(&sk->dst_HITERROR_CENTER[1]);
+	InitDST(&sk->dst_HITERROR_CENTER);
 	InitSRC(&sk->src_HITERROR_PGREAT);
 	InitDST(&sk->dst_HITERROR_PGREAT);
 	InitSRC(&sk->src_HITERROR_GREAT);
@@ -1868,8 +1867,7 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 					}
 					case "#DST_HITERROR_CENTER"_hash: {
 						SplitCSV(fBuf, &csv, ",");
-						ReadDST(&sk->dst_HITERROR_CENTER[0], &csv, tSkin_num, line);
-						sk->dst_HITERROR_CENTER[1] = sk->dst_HITERROR_CENTER[0];
+						ReadDST(&sk->dst_HITERROR_CENTER, &csv, tSkin_num, line);
 						break;
 					}
 					case "#SRC_HITERROR_PGREAT"_hash: {

--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -420,7 +420,7 @@ int InitSkin(skstruct *sk, int /*unused*/, char font) {
 		InitDST(&sk->dst_EVENT_LOADINGBG[i]);
 	}
 
-	for (int i = 0; i < 2; i++) {
+	for (int i = 0; i < 4; i++) {
 		InitSRC(&sk->src_HITERROR[i]);
 		InitDST(&sk->dst_HITERROR[i]);
 	}
@@ -1848,14 +1848,14 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 					}
 					case "#SRC_HITERROR"_hash: {
 						SplitCSV(fBuf, &csv, ",");
-						if (CheckIndexRange(csv.val[1], 0, 1, line, pFbuf)) {
+						if (CheckIndexRange(csv.val[1], 0, 3, line, pFbuf)) {
 							ReadSRC(&sk->src_HITERROR[csv.val[1]], &csv, sk);
 						}
 						break;
 					}
 					case "#DST_HITERROR"_hash: {
 						SplitCSV(fBuf, &csv, ",");
-						if (CheckIndexRange(csv.val[1], 0, 1, line, pFbuf)) {
+						if (CheckIndexRange(csv.val[1], 0, 3, line, pFbuf)) {
 							ReadDST(&sk->dst_HITERROR[csv.val[1]], &csv, tSkin_num, line);
 						}
 						break;

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1127,6 +1127,25 @@ static void QuickRestart(game& game, bool newRandom) {
 	StopAllKeysound(&game);
 }
 
+static inline DSTstruct CloneDSTstruct(const DSTstruct src) {
+	DSTstruct clone = src;
+	if (src.dstCount > 0 && src.draw) {
+		clone.draw = (DSTdraw *) malloc(src.dstCount * sizeof(DSTdraw));
+		memcpy(clone.draw, src.draw, src.dstCount * sizeof(DSTdraw));
+	}
+	else {
+		clone.draw = nullptr;
+	}
+	return clone;
+}
+
+static inline void FreeDSTstructClone(DSTstruct *clone) {
+	if (clone && clone->draw) {
+		free(clone->draw);
+		clone->draw = nullptr;
+	}
+}
+
 int DrawHitError(game *g, skstruct *sk, Timer *T) {
 	for (int p = 0; p < 2; p++) {
 		if (sk->src_HITERROR[p].graphcount <= 0) continue;

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -2112,7 +2112,7 @@ int ProcS_Play(game *g, sqlite3* sql) {
 	}
 
 	for(size_t i = 0; i < 2; ++i) {
-		g->gameplay.player[i].hiterror.ema.reset();
+		g->gameplay.player[i].hiterror.ema = {};
 		g->gameplay.player[i].hiterror.notes = CircularBuffer<JudgeData>(g->skstruct.src_HITERROR[i].graphcount);
 	}
 

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -2113,7 +2113,7 @@ int ProcS_Play(game *g, sqlite3* sql) {
 
 	for(size_t i = 0; i < 2; ++i) {
 		g->gameplay.player[i].hiterror.ema = {};
-		g->gameplay.player[i].hiterror.notes = CircularBuffer<JudgeData>(g->skstruct.src_HITERROR[i].graphcount);
+		g->gameplay.player[i].hiterror.notes = CircularBuffer<JudgeData>(g->skstruct.src_HITERROR[i].op1);
 	}
 
 	SetObjectString(1, g->gameplay.targetScore.name, g->txtStruct.objectStr);

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1127,92 +1127,95 @@ static void QuickRestart(game& game, bool newRandom) {
 	StopAllKeysound(&game);
 }
 
-int DrawHitError(game *g, skstruct *sk, Timer *T) {
-	for (int p = 0; p < 2; p++) {
-		if (sk->src_HITERROR[p].graphcount <= 0) continue;
+int DrawHitErrorForPlayer(game *g, skstruct *sk, Timer *T, int player) {
+	if (sk->src_HITERROR[player].graphcount <= 0) return;
 
-		auto hiterrorByTime = SetDSTdrawByTime(sk->dst_HITERROR[p], GetTimeLapse(sk->dst_HITERROR[p].timer, T));
+	auto hiterrorByTime = SetDSTdrawByTime(sk->dst_HITERROR[player], GetTimeLapse(sk->dst_HITERROR[player].timer, T));
 
-		auto center = [&](DSTstruct *dst) -> void {
-			for (int i = 0; i < dst->dstCount; ++i) {
-				dst->draw[i].x = hiterrorByTime.x + (hiterrorByTime.w / 2) + (dst->draw[i].w / 2);
-				dst->draw[i].y = hiterrorByTime.y;
-			}
-		};
-
-		auto centerDraw = [&](DSTdraw &draw) -> void {
-			draw.x = hiterrorByTime.x + (hiterrorByTime.w / 2) + (draw.w / 2);
-			draw.y = hiterrorByTime.y;
-		};
-
-		auto offset = [&](double timing) -> int {
-			return timing * hiterrorByTime.w / 400.0; /* bad range is 200ms on easy guage, so this should catch that */
-		};
-
-		constexpr auto fadeAlpha = [](int originalAlpha, int time, int fadeTime) -> int {
-			return originalAlpha - (time * originalAlpha / fadeTime);
-		};
-
-		double noteTimer = GetTimeLapse(142, &g->timer1);
-
-		HITERRORDATA &hiterrorData = g->gameplay.player[p].hiterror;
-
-		AddDrawingBuffer_Image(&sk->drBuf, &sk->src_HITERROR[p], &sk->dst_HITERROR[p], T);
-
-		if (sk->src_HITERROR_CENTER.graphcount > 0) {
-			center(&sk->dst_HITERROR_CENTER);
-			AddDrawingBuffer_Image(&sk->drBuf, &sk->src_HITERROR_CENTER, &sk->dst_HITERROR_CENTER, T);
+	auto center = [&](DSTstruct *dst) -> void {
+		for (int i = 0; i < dst->dstCount; ++i) {
+			dst->draw[i].x = hiterrorByTime.x + (hiterrorByTime.w / 2) + (dst->draw[i].w / 2);
+			dst->draw[i].y = hiterrorByTime.y;
 		}
-		
-		double fadeTime = 0.75 * 1000;
-		if (hiterrorData.notes.size() > 50) fadeTime = hiterrorData.notes.size() / 50.0 * 1000;
+		};
 
-		for (int i = 0; i < hiterrorData.notes.size(); i++) {
-			const JudgeData& jd = hiterrorData.notes[i];
-			SRCstruct *parentSRC = nullptr;
-			DSTstruct *parentDST = nullptr;
+	auto centerDraw = [&](DSTdraw &draw) -> void {
+		draw.x = hiterrorByTime.x + (hiterrorByTime.w / 2) + (draw.w / 2);
+		draw.y = hiterrorByTime.y;
+		};
 
-			switch (jd.judge) {
-				case Judgement::PGREAT: 
-					parentDST = &sk->dst_HITERROR_PGREAT;
-					parentSRC = &sk->src_HITERROR_PGREAT;
-					break;
-				case Judgement::GREAT: 
-					parentDST = &sk->dst_HITERROR_GREAT;
-					parentSRC = &sk->src_HITERROR_GREAT;
-					break;
-				case Judgement::GOOD: 
-					parentDST = &sk->dst_HITERROR_GOOD;
-					parentSRC = &sk->src_HITERROR_GOOD;
-					break;
-				case Judgement::BAD: 
-					parentDST = &sk->dst_HITERROR_BAD;
-					parentSRC = &sk->src_HITERROR_BAD;
-					break;
-				default: 
-					continue;
-			}
+	auto offset = [&](double timing) -> int {
+		return timing * hiterrorByTime.w / 400.0; /* bad range is 200ms on easy guage, so this should catch that */
+		};
 
-			if (!parentSRC || parentSRC->graphcount <= 0) continue;
+	constexpr auto fadeAlpha = [](int originalAlpha, int time, int fadeTime) -> int {
+		return originalAlpha - (time * originalAlpha / fadeTime);
+		};
 
-			DSTdraw parentDSTByTime = SetDSTdrawByTime(*parentDST, GetTimeLapse(parentDST->timer, T));
-			parentDSTByTime.a = fadeAlpha(parentDSTByTime.a, noteTimer - jd.timeHit, fadeTime);
-			centerDraw(parentDSTByTime);
+	double noteTimer = GetTimeLapse(142, &g->timer1);
 
-			int grh = parentSRC->timer == parentDST->timer ?
-				parentSRC->grHandles[GetSRCcycleNow(*parentSRC, GetTimeLapse(parentSRC->timer, T) - parentDST->draw->time)] : 
-				grh = parentSRC->grHandles[GetSRCcycleNow(*parentSRC, GetTimeLapse(parentSRC->timer, T))];
+	HITERRORDATA &hiterrorData = g->gameplay.player[player].hiterror;
 
-			parentDSTByTime.x += offset(jd.offset);
+	AddDrawingBuffer_Image(&sk->drBuf, &sk->src_HITERROR[player], &sk->dst_HITERROR[player], T);
 
-			AddDrawingBuffer(&sk->drBuf, grh, &parentDSTByTime);		
-		}
-
-		if (sk->src_HITERROR_EMA.graphcount > 0) {
-			center(&sk->dst_HITERROR_EMA);
-			AddDrawingBuffer_Object(&sk->drBuf, &sk->src_HITERROR_EMA, &sk->dst_HITERROR_EMA, T, offset(hiterrorData.ema.value), 0);
-		}
+	if (sk->src_HITERROR_CENTER.graphcount > 0) {
+		center(&sk->dst_HITERROR_CENTER);
+		AddDrawingBuffer_Image(&sk->drBuf, &sk->src_HITERROR_CENTER, &sk->dst_HITERROR_CENTER, T);
 	}
+
+	double fadeTime = 0.75 * 1000;
+	if (hiterrorData.notes.size() > 50) fadeTime = hiterrorData.notes.size() / 50.0 * 1000;
+
+	for (int i = 0; i < hiterrorData.notes.size(); i++) {
+		const JudgeData &jd = hiterrorData.notes[i];
+		SRCstruct *parentSRC = nullptr;
+		DSTstruct *parentDST = nullptr;
+
+		switch (jd.judge) {
+		case Judgement::PGREAT:
+			parentDST = &sk->dst_HITERROR_PGREAT;
+			parentSRC = &sk->src_HITERROR_PGREAT;
+			break;
+		case Judgement::GREAT:
+			parentDST = &sk->dst_HITERROR_GREAT;
+			parentSRC = &sk->src_HITERROR_GREAT;
+			break;
+		case Judgement::GOOD:
+			parentDST = &sk->dst_HITERROR_GOOD;
+			parentSRC = &sk->src_HITERROR_GOOD;
+			break;
+		case Judgement::BAD:
+			parentDST = &sk->dst_HITERROR_BAD;
+			parentSRC = &sk->src_HITERROR_BAD;
+			break;
+		default:
+			continue;
+		}
+
+		if (!parentSRC || parentSRC->graphcount <= 0) continue;
+
+		DSTdraw parentDSTByTime = SetDSTdrawByTime(*parentDST, GetTimeLapse(parentDST->timer, T));
+		parentDSTByTime.a = fadeAlpha(parentDSTByTime.a, noteTimer - jd.timeHit, fadeTime);
+		centerDraw(parentDSTByTime);
+
+		int grh = parentSRC->timer == parentDST->timer ?
+			parentSRC->grHandles[GetSRCcycleNow(*parentSRC, GetTimeLapse(parentSRC->timer, T) - parentDST->draw->time)] :
+			grh = parentSRC->grHandles[GetSRCcycleNow(*parentSRC, GetTimeLapse(parentSRC->timer, T))];
+
+		parentDSTByTime.x += offset(jd.offset);
+
+		AddDrawingBuffer(&sk->drBuf, grh, &parentDSTByTime);
+	}
+
+	if (sk->src_HITERROR_EMA.graphcount > 0) {
+		center(&sk->dst_HITERROR_EMA);
+		AddDrawingBuffer_Object(&sk->drBuf, &sk->src_HITERROR_EMA, &sk->dst_HITERROR_EMA, T, offset(hiterrorData.ema.value), 0);
+	}
+}
+
+int DrawHitError(game *g, skstruct *sk, Timer *T) {
+	DrawHitErrorForPlayer(g, sk, T, PLAYER_1);
+	DrawHitErrorForPlayer(g, sk, T, PLAYER_2);
 	return 1;
 }
 

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1132,16 +1132,15 @@ static int DrawHitErrorForPlayer(game &g, skstruct &sk, Timer &T, int player) {
 
 	auto hiterrorByTime = SetDSTdrawByTime(sk.dst_HITERROR[player], GetTimeLapse(sk.dst_HITERROR[player].timer, &T));
 	
-	auto center = [&](DSTstruct *dst) -> void {
-		for (int i = 0; i < dst->dstCount; ++i) {
-			dst->draw[i].x = hiterrorByTime.x + (hiterrorByTime.w / 2) + (dst->draw[i].w / 2);
-			dst->draw[i].y = hiterrorByTime.y;
-		}
-	};
-
 	auto centerDraw = [&](DSTdraw &draw) -> void {
 		draw.x = hiterrorByTime.x + (hiterrorByTime.w / 2) + (draw.w / 2);
 		draw.y = hiterrorByTime.y;
+	};
+
+	auto center = [&](DSTstruct *dst) -> void {
+		for (int i = 0; i < dst->dstCount; ++i) {
+			centerDraw(dst->draw[i]);
+		}
 	};
 
 	auto offset = [&](double timing) -> int {
@@ -1152,8 +1151,6 @@ static int DrawHitErrorForPlayer(game &g, skstruct &sk, Timer &T, int player) {
 		return originalAlpha - (time * originalAlpha / fadeTime);
 	};
 
-	double noteTimer = GetTimeLapse(142, &g.timer1);
-
 	HITERRORDATA &hiterrorData = g.gameplay.player[player].hiterror;
 
 	AddDrawingBuffer_Image(&sk.drBuf, &sk.src_HITERROR[player], &sk.dst_HITERROR[player], &T);
@@ -1163,49 +1160,53 @@ static int DrawHitErrorForPlayer(game &g, skstruct &sk, Timer &T, int player) {
 		AddDrawingBuffer_Image(&sk.drBuf, &sk.src_HITERROR_CENTER, &sk.dst_HITERROR_CENTER, &T);
 	}
 
-	double fadeTime = 0.75 * 1000;
-	if (hiterrorData.notes.size() > 50) fadeTime = hiterrorData.notes.size() / 50.0 * 1000;
+	/* Hiterror bars block */
+	{
+		double fadeTime = 0.75 * 1000;
+		if (hiterrorData.notes.size() > 50) fadeTime = hiterrorData.notes.size() / 50.0 * 1000;
 
-	for (int i = 0; i < hiterrorData.notes.size(); i++) {
-		const JudgeData &jd = hiterrorData.notes[i];
-		SRCstruct *parentSRC = nullptr;
-		DSTstruct *parentDST = nullptr;
+		double noteTimer = GetTimeLapse(142, &g.timer1);
+		for (int i = 0; i < hiterrorData.notes.size(); i++) {
+			const JudgeData &jd = hiterrorData.notes[i];
+			SRCstruct *parentSRC = nullptr;
+			DSTstruct *parentDST = nullptr;
 
-		switch (jd.judge) {
-		case Judgement::PGREAT:
-			parentDST = &sk.dst_HITERROR_PGREAT;
-			parentSRC = &sk.src_HITERROR_PGREAT;
-			break;
-		case Judgement::GREAT:
-			parentDST = &sk.dst_HITERROR_GREAT;
-			parentSRC = &sk.src_HITERROR_GREAT;
-			break;
-		case Judgement::GOOD:
-			parentDST = &sk.dst_HITERROR_GOOD;
-			parentSRC = &sk.src_HITERROR_GOOD;
-			break;
-		case Judgement::BAD:
-			parentDST = &sk.dst_HITERROR_BAD;
-			parentSRC = &sk.src_HITERROR_BAD;
-			break;
-		case Judgement::AIR_POOR:
-		case Judgement::MISS_POOR:
-			continue;
+			switch (jd.judge) {
+			case Judgement::PGREAT:
+				parentDST = &sk.dst_HITERROR_PGREAT;
+				parentSRC = &sk.src_HITERROR_PGREAT;
+				break;
+			case Judgement::GREAT:
+				parentDST = &sk.dst_HITERROR_GREAT;
+				parentSRC = &sk.src_HITERROR_GREAT;
+				break;
+			case Judgement::GOOD:
+				parentDST = &sk.dst_HITERROR_GOOD;
+				parentSRC = &sk.src_HITERROR_GOOD;
+				break;
+			case Judgement::BAD:
+				parentDST = &sk.dst_HITERROR_BAD;
+				parentSRC = &sk.src_HITERROR_BAD;
+				break;
+			case Judgement::AIR_POOR:
+			case Judgement::MISS_POOR:
+				continue;
+			}
+
+			if (!parentSRC || parentSRC->graphcount <= 0) continue;
+
+			DSTdraw parentDSTByTime = SetDSTdrawByTime(*parentDST, GetTimeLapse(parentDST->timer, &T));
+			parentDSTByTime.a = fadeAlpha(parentDSTByTime.a, noteTimer - jd.timeHit, fadeTime);
+			centerDraw(parentDSTByTime);
+
+			int grh = parentSRC->timer == parentDST->timer ?
+				parentSRC->grHandles[GetSRCcycleNow(*parentSRC, GetTimeLapse(parentSRC->timer, &T) - parentDST->draw->time)] :
+				grh = parentSRC->grHandles[GetSRCcycleNow(*parentSRC, GetTimeLapse(parentSRC->timer, &T))];
+
+			parentDSTByTime.x += offset(jd.offset);
+
+			AddDrawingBuffer(&sk.drBuf, grh, &parentDSTByTime);
 		}
-
-		if (!parentSRC || parentSRC->graphcount <= 0) continue;
-
-		DSTdraw parentDSTByTime = SetDSTdrawByTime(*parentDST, GetTimeLapse(parentDST->timer, &T));
-		parentDSTByTime.a = fadeAlpha(parentDSTByTime.a, noteTimer - jd.timeHit, fadeTime);
-		centerDraw(parentDSTByTime);
-
-		int grh = parentSRC->timer == parentDST->timer ?
-			parentSRC->grHandles[GetSRCcycleNow(*parentSRC, GetTimeLapse(parentSRC->timer, &T) - parentDST->draw->time)] :
-			grh = parentSRC->grHandles[GetSRCcycleNow(*parentSRC, GetTimeLapse(parentSRC->timer, &T))];
-
-		parentDSTByTime.x += offset(jd.offset);
-
-		AddDrawingBuffer(&sk.drBuf, grh, &parentDSTByTime);
 	}
 
 	if (sk.src_HITERROR_EMA.graphcount > 0) {

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1129,71 +1129,84 @@ static void QuickRestart(game& game, bool newRandom) {
 
 int DrawHitError(game *g, skstruct *sk, Timer *T) {
 	for (int p = 0; p < 2; p++) {
-		PLAYERSTATUS& ps = g->gameplay.player[p];
-		if (!ps.flag_active) continue;
+		if (sk->src_HITERROR[p].graphcount <= 0) continue;
 
-		sk->dst_HITERROR_CENTER.draw[0].x = sk->dst_HITERROR.draw[0].x + (sk->dst_HITERROR.draw[0].w / 2) + (sk->dst_HITERROR_CENTER.draw[0].w / 2);
-		sk->dst_HITERROR_CENTER.draw[0].y = sk->dst_HITERROR.draw[0].y;
-		AddDrawingBuffer_Image(&sk->drBuf, &sk->src_HITERROR_CENTER, &sk->dst_HITERROR_CENTER, T);
-		
-		AddDrawingBuffer_Image(&sk->drBuf, &sk->src_HITERROR, &sk->dst_HITERROR, T);
+		auto hiterrorByTime = SetDSTdrawByTime(sk->dst_HITERROR[p], GetTimeLapse(sk->dst_HITERROR[p].timer, T));
 
-		auto applyJudge = [&](DSTstruct* dst, DSTstruct& dstRef) {
-			dst->draw[0].r = dstRef.draw[0].r;
-			dst->draw[0].g = dstRef.draw[0].g;
-			dst->draw[0].b = dstRef.draw[0].b;
-			dst->draw[0].a = dstRef.draw[0].a;
-			dst->draw[0].w = dstRef.draw[0].w;
-			dst->draw[0].h = dstRef.draw[0].h;
+		auto center = [&](DSTstruct *dst) -> void {
+			for (int i = 0; i < dst->dstCount; ++i) {
+				dst->draw[i].x = hiterrorByTime.x + (hiterrorByTime.w / 2) + (dst->draw[i].w / 2);
+				dst->draw[i].y = hiterrorByTime.y;
+			}
 		};
 
-		for (int i = 0; i < ps.hiterror.notes.size(); i++) {
-			const JudgeData& jd = ps.hiterror.notes[i];
-			int judgeOffset = (int) (jd.offset * sk->dst_HITERROR.draw[0].w / 256.0);
-			SRCstruct *src = nullptr;
-			DSTstruct* dst = &sk->HiterrorDSTPool[i];
+		auto offset = [&](double timing) -> int {
+			return timing * hiterrorByTime.w / 400.0; /* bad range is 200ms on easy guage, so this should catch that */
+		};
 
-			dst->draw[0].x = sk->dst_HITERROR.draw[0].x + (sk->dst_HITERROR.draw[0].w / 2) + (dst->draw[0].w / 2);
-			dst->draw[0].y = sk->dst_HITERROR.draw[0].y;
+		constexpr auto fadeAlpha = [](int originalAlpha, int time, int fadeTime) -> int {
+			return originalAlpha - (time * originalAlpha / fadeTime);
+		};
+
+		double noteTimer = GetTimeLapse(142, &g->timer1);
+
+		HITERRORDATA &hiterrorData = g->gameplay.player[p].hiterror;
+
+		AddDrawingBuffer_Image(&sk->drBuf, &sk->src_HITERROR[p], &sk->dst_HITERROR[p], T);
+
+		if (sk->src_HITERROR_CENTER.graphcount > 0) {
+			center(&sk->dst_HITERROR_CENTER[p]);
+			AddDrawingBuffer_Image(&sk->drBuf, &sk->src_HITERROR_CENTER, &sk->dst_HITERROR_CENTER[p], T);
+		}
+		
+		double fadeTime = 0.75 * 1000;
+		if (hiterrorData.notes.size() > 50) fadeTime = hiterrorData.notes.size() / 50 * 1000;
+
+		for (int i = 0; i < hiterrorData.notes.size(); i++) {
+			const JudgeData& jd = hiterrorData.notes[i];
+			SRCstruct *parentSRC = nullptr;
+			DSTstruct *parentDST = nullptr;
+
+			DSTstruct childDST = DSTstruct{};
 
 			switch (jd.judge) {
 				case 5: 
-					applyJudge(dst, sk->dst_HITERROR_PGREAT);
-					src = &sk->src_HITERROR_PGREAT;
+					parentDST = &sk->dst_HITERROR_PGREAT;
+					parentSRC = &sk->src_HITERROR_PGREAT;
 					break;
 				case 4: 
-					applyJudge(dst, sk->dst_HITERROR_GREAT);
-					src = &sk->src_HITERROR_GREAT;
+					parentDST = &sk->dst_HITERROR_GREAT;
+					parentSRC = &sk->src_HITERROR_GREAT;
 					break;
 				case 3: 
-					applyJudge(dst, sk->dst_HITERROR_GOOD);
-					src = &sk->src_HITERROR_GOOD;
+					parentDST = &sk->dst_HITERROR_GOOD;
+					parentSRC = &sk->src_HITERROR_GOOD;
 					break;
 				case 2: 
-					applyJudge(dst, sk->dst_HITERROR_BAD);
-					src = &sk->src_HITERROR_BAD;
+					parentDST = &sk->dst_HITERROR_BAD;
+					parentSRC = &sk->src_HITERROR_BAD;
 					break;
 				default: 
-					applyJudge(dst, sk->dst_HITERROR_POOR);
-					src = &sk->src_HITERROR_POOR;
-					break;
+					continue;
 			}
+
+			if (!parentSRC || parentSRC->graphcount <= 0) continue;
+
+			childDST = CloneDSTstruct(parentDST);
 			
-			double t142 = GetTimeLapse(142, &g->timer1);
+			for (size_t j = 0; j < childDST.dstCount; ++j) {
+				childDST.draw[j].a = fadeAlpha(parentDST->draw[j].a, noteTimer - jd.timeHit, fadeTime);
+			}
 
-			auto fadeAlpha = [](int value, int fadeTime) -> int {
-				return 255 - (value * 255 / fadeTime);
-			};
-
-			dst->draw[0].a = fadeAlpha(t142 - jd.timeHit, 500);
-
-			AddDrawingBuffer_Object(&sk->drBuf, src, dst, T, judgeOffset, 0);
+			center(&childDST);
+			AddDrawingBuffer_Object(&sk->drBuf, parentSRC, &childDST, T, offset(jd.offset), 0);
+			FreeDSTstructClone(&childDST);
 		}
 
-		//int emaOffset = (int)(ps.hiterror.ema.value * sk->dst_HITERROR.draw[0].w / 256.0);
-		//sk->dst_HITERROR_EMA.draw[0].x = sk->dst_HITERROR.draw[0].x + (sk->dst_HITERROR.draw[0].w / 2) + (sk->dst_HITERROR_EMA.draw[0].w / 2);
-		//sk->dst_HITERROR_EMA.draw[0].y = sk->dst_HITERROR.draw[0].y;
-		//AddDrawingBuffer_Object(&sk->drBuf, &sk->src_HITERROR_EMA, &sk->dst_HITERROR_EMA, T, emaOffset, 0);
+		if (sk->src_HITERROR_EMA.graphcount > 0) {
+			center(&sk->dst_HITERROR_EMA);
+			AddDrawingBuffer_Object(&sk->drBuf, &sk->src_HITERROR_EMA, &sk->dst_HITERROR_EMA, T, offset(hiterrorData.ema.value), 0);
+		}
 	}
 	return 1;
 }
@@ -2098,8 +2111,9 @@ int ProcS_Play(game *g, sqlite3* sql) {
 
 	for(size_t i = 0; i < 2; ++i) {
 		g->gameplay.player[i].hiterror.ema.reset();
-		g->gameplay.player[i].hiterror.notes = CircularBuffer<JudgeData>(g->skstruct.src_HITERROR.graphcount);
+		g->gameplay.player[i].hiterror.notes = CircularBuffer<JudgeData>(g->skstruct.src_HITERROR[i].graphcount);
 	}
+
 	SetObjectString(1, g->gameplay.targetScore.name, g->txtStruct.objectStr);
 	std::jthread(ProcGameThread, g).detach(); // removed SetThreadPriority(hG, -1);
 	return 1;

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1209,7 +1209,7 @@ int DrawHitError(game *g, skstruct *sk, Timer *T) {
 
 			if (!parentSRC || parentSRC->graphcount <= 0) continue;
 
-			DSTstruct childDST = CloneDSTstruct(parentDST);
+			DSTstruct childDST = CloneDSTstruct(*parentDST);
 
 			for (size_t j = 0; j < childDST.dstCount; ++j) {
 				childDST.draw[j].a = fadeAlpha(parentDST->draw[j].a, noteTimer - jd.timeHit, fadeTime);

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1127,11 +1127,11 @@ static void QuickRestart(game& game, bool newRandom) {
 	StopAllKeysound(&game);
 }
 
-int DrawHitErrorForPlayer(game *g, skstruct *sk, Timer *T, int player) {
-	if (sk->src_HITERROR[player].graphcount <= 0) return;
+static int DrawHitErrorForPlayer(game &g, skstruct &sk, Timer &T, int player) {
+	if (sk.src_HITERROR[player].graphcount <= 0) return 0;
 
-	auto hiterrorByTime = SetDSTdrawByTime(sk->dst_HITERROR[player], GetTimeLapse(sk->dst_HITERROR[player].timer, T));
-
+	auto hiterrorByTime = SetDSTdrawByTime(sk.dst_HITERROR[player], GetTimeLapse(sk.dst_HITERROR[player].timer, &T));
+	
 	auto center = [&](DSTstruct *dst) -> void {
 		for (int i = 0; i < dst->dstCount; ++i) {
 			dst->draw[i].x = hiterrorByTime.x + (hiterrorByTime.w / 2) + (dst->draw[i].w / 2);
@@ -1152,15 +1152,15 @@ int DrawHitErrorForPlayer(game *g, skstruct *sk, Timer *T, int player) {
 		return originalAlpha - (time * originalAlpha / fadeTime);
 	};
 
-	double noteTimer = GetTimeLapse(142, &g->timer1);
+	double noteTimer = GetTimeLapse(142, &g.timer1);
 
-	HITERRORDATA &hiterrorData = g->gameplay.player[player].hiterror;
+	HITERRORDATA &hiterrorData = g.gameplay.player[player].hiterror;
 
-	AddDrawingBuffer_Image(&sk->drBuf, &sk->src_HITERROR[player], &sk->dst_HITERROR[player], T);
+	AddDrawingBuffer_Image(&sk.drBuf, &sk.src_HITERROR[player], &sk.dst_HITERROR[player], &T);
 
-	if (sk->src_HITERROR_CENTER.graphcount > 0) {
-		center(&sk->dst_HITERROR_CENTER);
-		AddDrawingBuffer_Image(&sk->drBuf, &sk->src_HITERROR_CENTER, &sk->dst_HITERROR_CENTER, T);
+	if (sk.src_HITERROR_CENTER.graphcount > 0) {
+		center(&sk.dst_HITERROR_CENTER);
+		AddDrawingBuffer_Image(&sk.drBuf, &sk.src_HITERROR_CENTER, &sk.dst_HITERROR_CENTER, &T);
 	}
 
 	double fadeTime = 0.75 * 1000;
@@ -1173,20 +1173,20 @@ int DrawHitErrorForPlayer(game *g, skstruct *sk, Timer *T, int player) {
 
 		switch (jd.judge) {
 		case Judgement::PGREAT:
-			parentDST = &sk->dst_HITERROR_PGREAT;
-			parentSRC = &sk->src_HITERROR_PGREAT;
+			parentDST = &sk.dst_HITERROR_PGREAT;
+			parentSRC = &sk.src_HITERROR_PGREAT;
 			break;
 		case Judgement::GREAT:
-			parentDST = &sk->dst_HITERROR_GREAT;
-			parentSRC = &sk->src_HITERROR_GREAT;
+			parentDST = &sk.dst_HITERROR_GREAT;
+			parentSRC = &sk.src_HITERROR_GREAT;
 			break;
 		case Judgement::GOOD:
-			parentDST = &sk->dst_HITERROR_GOOD;
-			parentSRC = &sk->src_HITERROR_GOOD;
+			parentDST = &sk.dst_HITERROR_GOOD;
+			parentSRC = &sk.src_HITERROR_GOOD;
 			break;
 		case Judgement::BAD:
-			parentDST = &sk->dst_HITERROR_BAD;
-			parentSRC = &sk->src_HITERROR_BAD;
+			parentDST = &sk.dst_HITERROR_BAD;
+			parentSRC = &sk.src_HITERROR_BAD;
 			break;
 		case Judgement::AIR_POOR:
 		case Judgement::MISS_POOR:
@@ -1195,28 +1195,29 @@ int DrawHitErrorForPlayer(game *g, skstruct *sk, Timer *T, int player) {
 
 		if (!parentSRC || parentSRC->graphcount <= 0) continue;
 
-		DSTdraw parentDSTByTime = SetDSTdrawByTime(*parentDST, GetTimeLapse(parentDST->timer, T));
+		DSTdraw parentDSTByTime = SetDSTdrawByTime(*parentDST, GetTimeLapse(parentDST->timer, &T));
 		parentDSTByTime.a = fadeAlpha(parentDSTByTime.a, noteTimer - jd.timeHit, fadeTime);
 		centerDraw(parentDSTByTime);
 
 		int grh = parentSRC->timer == parentDST->timer ?
-			parentSRC->grHandles[GetSRCcycleNow(*parentSRC, GetTimeLapse(parentSRC->timer, T) - parentDST->draw->time)] :
-			grh = parentSRC->grHandles[GetSRCcycleNow(*parentSRC, GetTimeLapse(parentSRC->timer, T))];
+			parentSRC->grHandles[GetSRCcycleNow(*parentSRC, GetTimeLapse(parentSRC->timer, &T) - parentDST->draw->time)] :
+			grh = parentSRC->grHandles[GetSRCcycleNow(*parentSRC, GetTimeLapse(parentSRC->timer, &T))];
 
 		parentDSTByTime.x += offset(jd.offset);
 
-		AddDrawingBuffer(&sk->drBuf, grh, &parentDSTByTime);
+		AddDrawingBuffer(&sk.drBuf, grh, &parentDSTByTime);
 	}
 
-	if (sk->src_HITERROR_EMA.graphcount > 0) {
-		center(&sk->dst_HITERROR_EMA);
-		AddDrawingBuffer_Object(&sk->drBuf, &sk->src_HITERROR_EMA, &sk->dst_HITERROR_EMA, T, offset(hiterrorData.ema.value), 0);
+	if (sk.src_HITERROR_EMA.graphcount > 0) {
+		center(&sk.dst_HITERROR_EMA);
+		AddDrawingBuffer_Object(&sk.drBuf, &sk.src_HITERROR_EMA, &sk.dst_HITERROR_EMA, &T, offset(hiterrorData.ema.value), 0);
 	}
+	return 1;
 }
 
 int DrawHitError(game *g, skstruct *sk, Timer *T) {
-	DrawHitErrorForPlayer(g, sk, T, PLAYER_1);
-	DrawHitErrorForPlayer(g, sk, T, PLAYER_2);
+	DrawHitErrorForPlayer(*g, *sk, *T, PLAYER_1);
+	DrawHitErrorForPlayer(*g, *sk, *T, PLAYER_2);
 	return 1;
 }
 

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1137,20 +1137,20 @@ int DrawHitErrorForPlayer(game *g, skstruct *sk, Timer *T, int player) {
 			dst->draw[i].x = hiterrorByTime.x + (hiterrorByTime.w / 2) + (dst->draw[i].w / 2);
 			dst->draw[i].y = hiterrorByTime.y;
 		}
-		};
+	};
 
 	auto centerDraw = [&](DSTdraw &draw) -> void {
 		draw.x = hiterrorByTime.x + (hiterrorByTime.w / 2) + (draw.w / 2);
 		draw.y = hiterrorByTime.y;
-		};
+	};
 
 	auto offset = [&](double timing) -> int {
 		return timing * hiterrorByTime.w / 400.0; /* bad range is 200ms on easy guage, so this should catch that */
-		};
+	};
 
 	constexpr auto fadeAlpha = [](int originalAlpha, int time, int fadeTime) -> int {
 		return originalAlpha - (time * originalAlpha / fadeTime);
-		};
+	};
 
 	double noteTimer = GetTimeLapse(142, &g->timer1);
 
@@ -1188,7 +1188,8 @@ int DrawHitErrorForPlayer(game *g, skstruct *sk, Timer *T, int player) {
 			parentDST = &sk->dst_HITERROR_BAD;
 			parentSRC = &sk->src_HITERROR_BAD;
 			break;
-		default:
+		case Judgement::AIR_POOR:
+		case Judgement::MISS_POOR:
 			continue;
 		}
 

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -2113,7 +2113,7 @@ int ProcS_Play(game *g, sqlite3* sql) {
 
 	for(size_t i = 0; i < 2; ++i) {
 		g->gameplay.player[i].hiterror.ema = {};
-		g->gameplay.player[i].hiterror.notes = CircularBuffer<JudgeData>(g->skstruct.src_HITERROR[i].op1);
+		g->gameplay.player[i].hiterror.notes.reset(g->skstruct.src_HITERROR[i].op1);
 	}
 
 	SetObjectString(1, g->gameplay.targetScore.name, g->txtStruct.objectStr);

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -787,6 +787,8 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedStatsCourse, isFast, offset);
 			increment_extended(extendedColumnStatsCourse, isFast, offset);
 			lastOffsetColumnIdx = lane;
+			g->gameplay.player[player].hiterror.notes.push({ (size_t)lane, (double)offset, 5 });
+			g->gameplay.player[player].hiterror.ema.add((double)offset);
 			return 1;
 		}
 		if (gap <= g->gameplay.player[player].judgetime[4] && g->gameplay.player[player].note_current < g->gameplay.player[player].totalnotes) {
@@ -810,6 +812,8 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedStatsCourse, isFast, offset);
 			increment_extended(extendedColumnStatsCourse, isFast, offset);
 			lastOffsetColumnIdx = lane;
+			g->gameplay.player[player].hiterror.notes.push({ (size_t)lane, (double)offset, 4 });
+			g->gameplay.player[player].hiterror.ema.add((double)offset);
 			return 1;
 		}
 		if (gap <= g->gameplay.player[player].judgetime[3] && g->gameplay.player[player].note_current < g->gameplay.player[player].totalnotes) {
@@ -832,6 +836,8 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedStatsCourse, isFast, offset);
 			increment_extended(extendedColumnStatsCourse, isFast, offset);
 			lastOffsetColumnIdx = lane;
+			g->gameplay.player[player].hiterror.notes.push({ (size_t)lane, (double)offset, 3 });
+			g->gameplay.player[player].hiterror.ema.add((double)offset);
 			return 1;
 		}
 
@@ -857,6 +863,8 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedStatsCourse, isFast, offset);
 			increment_extended(extendedColumnStatsCourse, isFast, offset);
 			lastOffsetColumnIdx = lane;
+			g->gameplay.player[player].hiterror.notes.push({ (size_t)lane, (double)offset, 2 });
+			g->gameplay.player[player].hiterror.ema.add((double)offset);
 
 			if (g->gameplay.bmsobj_note[lane].note_count < g->gameplay.bmsobj_note[lane].size && abs(timing - (int)g->gameplay.bmsobj_note[lane].notes[g->gameplay.bmsobj_note[lane].note_count].realTiming) <= g->gameplay.player[player].judgetime[2]) {
 				ProcSinglenote(g, lane, 1, timing, player);

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1127,25 +1127,6 @@ static void QuickRestart(game& game, bool newRandom) {
 	StopAllKeysound(&game);
 }
 
-static inline DSTstruct CloneDSTstruct(const DSTstruct src) {
-	DSTstruct clone = src;
-	if (src.dstCount > 0 && src.draw) {
-		clone.draw = (DSTdraw *) malloc(src.dstCount * sizeof(DSTdraw));
-		memcpy(clone.draw, src.draw, src.dstCount * sizeof(DSTdraw));
-	}
-	else {
-		clone.draw = nullptr;
-	}
-	return clone;
-}
-
-static inline void FreeDSTstructClone(DSTstruct *clone) {
-	if (clone && clone->draw) {
-		free(clone->draw);
-		clone->draw = nullptr;
-	}
-}
-
 int DrawHitError(game *g, skstruct *sk, Timer *T) {
 	for (int p = 0; p < 2; p++) {
 		if (sk->src_HITERROR[p].graphcount <= 0) continue;
@@ -1157,6 +1138,11 @@ int DrawHitError(game *g, skstruct *sk, Timer *T) {
 				dst->draw[i].x = hiterrorByTime.x + (hiterrorByTime.w / 2) + (dst->draw[i].w / 2);
 				dst->draw[i].y = hiterrorByTime.y;
 			}
+		};
+
+		auto centerDraw = [&](DSTdraw &draw) -> void {
+			draw.x = hiterrorByTime.x + (hiterrorByTime.w / 2) + (draw.w / 2);
+			draw.y = hiterrorByTime.y;
 		};
 
 		auto offset = [&](double timing) -> int {
@@ -1209,15 +1195,17 @@ int DrawHitError(game *g, skstruct *sk, Timer *T) {
 
 			if (!parentSRC || parentSRC->graphcount <= 0) continue;
 
-			DSTstruct childDST = CloneDSTstruct(*parentDST);
+			DSTdraw parentDSTByTime = SetDSTdrawByTime(*parentDST, GetTimeLapse(parentDST->timer, T));
+			parentDSTByTime.a = fadeAlpha(parentDSTByTime.a, noteTimer - jd.timeHit, fadeTime);
+			centerDraw(parentDSTByTime);
 
-			for (size_t j = 0; j < childDST.dstCount; ++j) {
-				childDST.draw[j].a = fadeAlpha(parentDST->draw[j].a, noteTimer - jd.timeHit, fadeTime);
-			}
+			int grh = parentSRC->timer == parentDST->timer ?
+				parentSRC->grHandles[GetSRCcycleNow(*parentSRC, GetTimeLapse(parentSRC->timer, T) - parentDST->draw->time)] : 
+				grh = parentSRC->grHandles[GetSRCcycleNow(*parentSRC, GetTimeLapse(parentSRC->timer, T))];
 
-			center(&childDST);
-			AddDrawingBuffer_Object(&sk->drBuf, parentSRC, &childDST, T, offset(jd.offset), 0);
-			FreeDSTstructClone(&childDST);
+			parentDSTByTime.x += offset(jd.offset);
+
+			AddDrawingBuffer(&sk->drBuf, grh, &parentDSTByTime);		
 		}
 
 		if (sk->src_HITERROR_EMA.graphcount > 0) {

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -787,7 +787,7 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedStatsCourse, isFast, offset);
 			increment_extended(extendedColumnStatsCourse, isFast, offset);
 			lastOffsetColumnIdx = lane;
-			g->gameplay.player[player].hiterror.notes.push({ (size_t)lane, (double)offset, 5 });
+			g->gameplay.player[player].hiterror.notes.push({ (size_t)lane, (double)offset, (double)	timing, 5 });
 			g->gameplay.player[player].hiterror.ema.add((double)offset);
 			return 1;
 		}
@@ -812,7 +812,7 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedStatsCourse, isFast, offset);
 			increment_extended(extendedColumnStatsCourse, isFast, offset);
 			lastOffsetColumnIdx = lane;
-			g->gameplay.player[player].hiterror.notes.push({ (size_t)lane, (double)offset, 4 });
+			g->gameplay.player[player].hiterror.notes.push({ (size_t)lane, (double)offset, (double) timing, 4 });
 			g->gameplay.player[player].hiterror.ema.add((double)offset);
 			return 1;
 		}
@@ -836,7 +836,7 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedStatsCourse, isFast, offset);
 			increment_extended(extendedColumnStatsCourse, isFast, offset);
 			lastOffsetColumnIdx = lane;
-			g->gameplay.player[player].hiterror.notes.push({ (size_t)lane, (double)offset, 3 });
+			g->gameplay.player[player].hiterror.notes.push({ (size_t)lane, (double)offset, (double) timing, 3 });
 			g->gameplay.player[player].hiterror.ema.add((double)offset);
 			return 1;
 		}
@@ -863,7 +863,7 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedStatsCourse, isFast, offset);
 			increment_extended(extendedColumnStatsCourse, isFast, offset);
 			lastOffsetColumnIdx = lane;
-			g->gameplay.player[player].hiterror.notes.push({ (size_t)lane, (double)offset, 2 });
+			g->gameplay.player[player].hiterror.notes.push({ (size_t)lane, (double)offset, (double)timing, 2 });
 			g->gameplay.player[player].hiterror.ema.add((double)offset);
 
 			if (g->gameplay.bmsobj_note[lane].note_count < g->gameplay.bmsobj_note[lane].size && abs(timing - (int)g->gameplay.bmsobj_note[lane].notes[g->gameplay.bmsobj_note[lane].note_count].realTiming) <= g->gameplay.player[player].judgetime[2]) {
@@ -1127,6 +1127,77 @@ static void QuickRestart(game& game, bool newRandom) {
 	StopAllKeysound(&game);
 }
 
+int DrawHitError(game *g, skstruct *sk, Timer *T) {
+	for (int p = 0; p < 2; p++) {
+		PLAYERSTATUS& ps = g->gameplay.player[p];
+		if (!ps.flag_active) continue;
+
+		sk->dst_HITERROR_CENTER.draw[0].x = sk->dst_HITERROR.draw[0].x + (sk->dst_HITERROR.draw[0].w / 2) + (sk->dst_HITERROR_CENTER.draw[0].w / 2);
+		sk->dst_HITERROR_CENTER.draw[0].y = sk->dst_HITERROR.draw[0].y;
+		AddDrawingBuffer_Image(&sk->drBuf, &sk->src_HITERROR_CENTER, &sk->dst_HITERROR_CENTER, T);
+		
+		AddDrawingBuffer_Image(&sk->drBuf, &sk->src_HITERROR, &sk->dst_HITERROR, T);
+
+		auto applyJudge = [&](DSTstruct* dst, DSTstruct& dstRef) {
+			dst->draw[0].r = dstRef.draw[0].r;
+			dst->draw[0].g = dstRef.draw[0].g;
+			dst->draw[0].b = dstRef.draw[0].b;
+			dst->draw[0].a = dstRef.draw[0].a;
+			dst->draw[0].w = dstRef.draw[0].w;
+			dst->draw[0].h = dstRef.draw[0].h;
+		};
+
+		for (int i = 0; i < ps.hiterror.notes.size(); i++) {
+			const JudgeData& jd = ps.hiterror.notes[i];
+			int judgeOffset = (int) (jd.offset * sk->dst_HITERROR.draw[0].w / 256.0);
+			SRCstruct *src = nullptr;
+			DSTstruct* dst = &sk->HiterrorDSTPool[i];
+
+			dst->draw[0].x = sk->dst_HITERROR.draw[0].x + (sk->dst_HITERROR.draw[0].w / 2) + (dst->draw[0].w / 2);
+			dst->draw[0].y = sk->dst_HITERROR.draw[0].y;
+
+			switch (jd.judge) {
+				case 5: 
+					applyJudge(dst, sk->dst_HITERROR_PGREAT);
+					src = &sk->src_HITERROR_PGREAT;
+					break;
+				case 4: 
+					applyJudge(dst, sk->dst_HITERROR_GREAT);
+					src = &sk->src_HITERROR_GREAT;
+					break;
+				case 3: 
+					applyJudge(dst, sk->dst_HITERROR_GOOD);
+					src = &sk->src_HITERROR_GOOD;
+					break;
+				case 2: 
+					applyJudge(dst, sk->dst_HITERROR_BAD);
+					src = &sk->src_HITERROR_BAD;
+					break;
+				default: 
+					applyJudge(dst, sk->dst_HITERROR_POOR);
+					src = &sk->src_HITERROR_POOR;
+					break;
+			}
+			
+			double t142 = GetTimeLapse(142, &g->timer1);
+
+			auto fadeAlpha = [](int value, int fadeTime) -> int {
+				return 255 - (value * 255 / fadeTime);
+			};
+
+			dst->draw[0].a = fadeAlpha(t142 - jd.timeHit, 500);
+
+			AddDrawingBuffer_Object(&sk->drBuf, src, dst, T, judgeOffset, 0);
+		}
+
+		//int emaOffset = (int)(ps.hiterror.ema.value * sk->dst_HITERROR.draw[0].w / 256.0);
+		//sk->dst_HITERROR_EMA.draw[0].x = sk->dst_HITERROR.draw[0].x + (sk->dst_HITERROR.draw[0].w / 2) + (sk->dst_HITERROR_EMA.draw[0].w / 2);
+		//sk->dst_HITERROR_EMA.draw[0].y = sk->dst_HITERROR.draw[0].y;
+		//AddDrawingBuffer_Object(&sk->drBuf, &sk->src_HITERROR_EMA, &sk->dst_HITERROR_EMA, T, emaOffset, 0);
+	}
+	return 1;
+}
+
 int ProcI_Play(game *g) {
 	int timeLimit;
 	double gameTime;
@@ -1137,6 +1208,7 @@ int ProcI_Play(game *g) {
 	if (GetTimeLapse(41, &g->timer1) > 0.0 && g->config.play.m_lunaris == 0) {
 		DrawNotes(g, &g->skstruct, &g->timer1, &g->config.play);
 		DrawJudgeCombo(g, &g->skstruct, &g->timer1, &g->config.play);
+		DrawHitError(g, &g->skstruct, &g->timer1);
 	}
 	else if (GetTimeLapse(41, &g->timer1) > 0.0 && g->config.play.m_lunaris) {
 		DrawLunaris(g);
@@ -2024,6 +2096,10 @@ int ProcS_Play(game *g, sqlite3* sql) {
 		}
 	}
 
+	for(size_t i = 0; i < 2; ++i) {
+		g->gameplay.player[i].hiterror.ema.reset();
+		g->gameplay.player[i].hiterror.notes = CircularBuffer<JudgeData>(g->skstruct.src_HITERROR.graphcount);
+	}
 	SetObjectString(1, g->gameplay.targetScore.name, g->txtStruct.objectStr);
 	std::jthread(ProcGameThread, g).detach(); // removed SetThreadPriority(hG, -1);
 	return 1;

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -787,8 +787,8 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedStatsCourse, isFast, offset);
 			increment_extended(extendedColumnStatsCourse, isFast, offset);
 			lastOffsetColumnIdx = lane;
-			g->gameplay.player[player].hiterror.notes.push({ (size_t)lane, (double)offset, (double)	timing, 5 });
-			g->gameplay.player[player].hiterror.ema.add((double)offset);
+			g->gameplay.player[player].hiterror.notes.push({ offset, timing, Judgement::PGREAT });
+			g->gameplay.player[player].hiterror.ema.add(static_cast<double>(offset));
 			return 1;
 		}
 		if (gap <= g->gameplay.player[player].judgetime[4] && g->gameplay.player[player].note_current < g->gameplay.player[player].totalnotes) {
@@ -812,8 +812,8 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedStatsCourse, isFast, offset);
 			increment_extended(extendedColumnStatsCourse, isFast, offset);
 			lastOffsetColumnIdx = lane;
-			g->gameplay.player[player].hiterror.notes.push({ (size_t)lane, (double)offset, (double) timing, 4 });
-			g->gameplay.player[player].hiterror.ema.add((double)offset);
+			g->gameplay.player[player].hiterror.notes.push({ offset, timing, Judgement::GREAT });
+			g->gameplay.player[player].hiterror.ema.add(static_cast<double>(offset));
 			return 1;
 		}
 		if (gap <= g->gameplay.player[player].judgetime[3] && g->gameplay.player[player].note_current < g->gameplay.player[player].totalnotes) {
@@ -836,8 +836,8 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedStatsCourse, isFast, offset);
 			increment_extended(extendedColumnStatsCourse, isFast, offset);
 			lastOffsetColumnIdx = lane;
-			g->gameplay.player[player].hiterror.notes.push({ (size_t)lane, (double)offset, (double) timing, 3 });
-			g->gameplay.player[player].hiterror.ema.add((double)offset);
+			g->gameplay.player[player].hiterror.notes.push({ offset, timing, Judgement::GOOD });
+			g->gameplay.player[player].hiterror.ema.add(static_cast<double>(offset));
 			return 1;
 		}
 
@@ -863,8 +863,8 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedStatsCourse, isFast, offset);
 			increment_extended(extendedColumnStatsCourse, isFast, offset);
 			lastOffsetColumnIdx = lane;
-			g->gameplay.player[player].hiterror.notes.push({ (size_t)lane, (double)offset, (double)timing, 2 });
-			g->gameplay.player[player].hiterror.ema.add((double)offset);
+			g->gameplay.player[player].hiterror.notes.push({ offset, timing, Judgement::BAD });
+			g->gameplay.player[player].hiterror.ema.add(static_cast<double>(offset));
 
 			if (g->gameplay.bmsobj_note[lane].note_count < g->gameplay.bmsobj_note[lane].size && abs(timing - (int)g->gameplay.bmsobj_note[lane].notes[g->gameplay.bmsobj_note[lane].note_count].realTiming) <= g->gameplay.player[player].judgetime[2]) {
 				ProcSinglenote(g, lane, 1, timing, player);
@@ -1167,22 +1167,20 @@ int DrawHitError(game *g, skstruct *sk, Timer *T) {
 			SRCstruct *parentSRC = nullptr;
 			DSTstruct *parentDST = nullptr;
 
-			DSTstruct childDST = DSTstruct{};
-
 			switch (jd.judge) {
-				case 5: 
+				case Judgement::PGREAT: 
 					parentDST = &sk->dst_HITERROR_PGREAT;
 					parentSRC = &sk->src_HITERROR_PGREAT;
 					break;
-				case 4: 
+				case Judgement::GREAT: 
 					parentDST = &sk->dst_HITERROR_GREAT;
 					parentSRC = &sk->src_HITERROR_GREAT;
 					break;
-				case 3: 
+				case Judgement::GOOD: 
 					parentDST = &sk->dst_HITERROR_GOOD;
 					parentSRC = &sk->src_HITERROR_GOOD;
 					break;
-				case 2: 
+				case Judgement::BAD: 
 					parentDST = &sk->dst_HITERROR_BAD;
 					parentSRC = &sk->src_HITERROR_BAD;
 					break;
@@ -1192,8 +1190,8 @@ int DrawHitError(game *g, skstruct *sk, Timer *T) {
 
 			if (!parentSRC || parentSRC->graphcount <= 0) continue;
 
-			childDST = CloneDSTstruct(parentDST);
-			
+			DSTstruct childDST = CloneDSTstruct(parentDST);
+
 			for (size_t j = 0; j < childDST.dstCount; ++j) {
 				childDST.draw[j].a = fadeAlpha(parentDST->draw[j].a, noteTimer - jd.timeHit, fadeTime);
 			}

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1160,12 +1160,12 @@ int DrawHitError(game *g, skstruct *sk, Timer *T) {
 		AddDrawingBuffer_Image(&sk->drBuf, &sk->src_HITERROR[p], &sk->dst_HITERROR[p], T);
 
 		if (sk->src_HITERROR_CENTER.graphcount > 0) {
-			center(&sk->dst_HITERROR_CENTER[p]);
-			AddDrawingBuffer_Image(&sk->drBuf, &sk->src_HITERROR_CENTER, &sk->dst_HITERROR_CENTER[p], T);
+			center(&sk->dst_HITERROR_CENTER);
+			AddDrawingBuffer_Image(&sk->drBuf, &sk->src_HITERROR_CENTER, &sk->dst_HITERROR_CENTER, T);
 		}
 		
 		double fadeTime = 0.75 * 1000;
-		if (hiterrorData.notes.size() > 50) fadeTime = hiterrorData.notes.size() / 50 * 1000;
+		if (hiterrorData.notes.size() > 50) fadeTime = hiterrorData.notes.size() / 50.0 * 1000;
 
 		for (int i = 0; i < hiterrorData.notes.size(); i++) {
 			const JudgeData& jd = hiterrorData.notes[i];

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1127,21 +1127,15 @@ static void QuickRestart(game& game, bool newRandom) {
 	StopAllKeysound(&game);
 }
 
+void CenterDraw(DSTdraw &draw, const DSTdraw &hiterrorByTime) {
+	draw.x = hiterrorByTime.x + (hiterrorByTime.w / 2) + (draw.w / 2);
+	draw.y = hiterrorByTime.y;
+}
+
 static int DrawHitErrorForPlayer(game &g, skstruct &sk, Timer &T, int player) {
 	if (sk.src_HITERROR[player].graphcount <= 0) return 0;
 
 	auto hiterrorByTime = SetDSTdrawByTime(sk.dst_HITERROR[player], GetTimeLapse(sk.dst_HITERROR[player].timer, &T));
-	
-	auto centerDraw = [&](DSTdraw &draw) -> void {
-		draw.x = hiterrorByTime.x + (hiterrorByTime.w / 2) + (draw.w / 2);
-		draw.y = hiterrorByTime.y;
-	};
-
-	auto center = [&](DSTstruct *dst) -> void {
-		for (int i = 0; i < dst->dstCount; ++i) {
-			centerDraw(dst->draw[i]);
-		}
-	};
 
 	auto offset = [&](double timing) -> int {
 		return timing * hiterrorByTime.w / 400.0; /* bad range is 200ms on easy guage, so this should catch that */
@@ -1156,7 +1150,9 @@ static int DrawHitErrorForPlayer(game &g, skstruct &sk, Timer &T, int player) {
 	AddDrawingBuffer_Image(&sk.drBuf, &sk.src_HITERROR[player], &sk.dst_HITERROR[player], &T);
 
 	if (sk.src_HITERROR_CENTER.graphcount > 0) {
-		center(&sk.dst_HITERROR_CENTER);
+		for (int i = 0; i < sk.dst_HITERROR_CENTER.dstCount; ++i) {
+			CenterDraw(sk.dst_HITERROR_CENTER.draw[i], hiterrorByTime);
+		}
 		AddDrawingBuffer_Image(&sk.drBuf, &sk.src_HITERROR_CENTER, &sk.dst_HITERROR_CENTER, &T);
 	}
 
@@ -1197,7 +1193,7 @@ static int DrawHitErrorForPlayer(game &g, skstruct &sk, Timer &T, int player) {
 
 			DSTdraw parentDSTByTime = SetDSTdrawByTime(*parentDST, GetTimeLapse(parentDST->timer, &T));
 			parentDSTByTime.a = fadeAlpha(parentDSTByTime.a, noteTimer - jd.timeHit, fadeTime);
-			centerDraw(parentDSTByTime);
+			CenterDraw(parentDSTByTime, hiterrorByTime);
 
 			int grh = parentSRC->timer == parentDST->timer ?
 				parentSRC->grHandles[GetSRCcycleNow(*parentSRC, GetTimeLapse(parentSRC->timer, &T) - parentDST->draw->time)] :
@@ -1210,7 +1206,9 @@ static int DrawHitErrorForPlayer(game &g, skstruct &sk, Timer &T, int player) {
 	}
 
 	if (sk.src_HITERROR_EMA.graphcount > 0) {
-		center(&sk.dst_HITERROR_EMA);
+		for (int i = 0; i < sk.dst_HITERROR_EMA.dstCount; ++i) {
+			CenterDraw(sk.dst_HITERROR_EMA.draw[i], hiterrorByTime);
+		}
 		AddDrawingBuffer_Object(&sk.drBuf, &sk.src_HITERROR_EMA, &sk.dst_HITERROR_EMA, &T, offset(hiterrorData.ema.value), 0);
 	}
 	return 1;

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -789,6 +789,16 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			lastOffsetColumnIdx = lane;
 			g->gameplay.player[player].hiterror.notes.push({ offset, timing, Judgement::PGREAT });
 			g->gameplay.player[player].hiterror.ema.add(static_cast<double>(offset));
+			if (player == 0) {
+				if (lane < 10) {
+					g->gameplay.player[player].hiterror.notes_dp_p1.push({ offset, timing, Judgement::PGREAT });
+					g->gameplay.player[player].hiterror.ema_dp_p1.add(static_cast<double>(offset));
+				}
+				else {
+					g->gameplay.player[player].hiterror.notes_dp_p2.push({ offset, timing, Judgement::PGREAT });
+					g->gameplay.player[player].hiterror.ema_dp_p2.add(static_cast<double>(offset));
+				}
+			}
 			return 1;
 		}
 		if (gap <= g->gameplay.player[player].judgetime[4] && g->gameplay.player[player].note_current < g->gameplay.player[player].totalnotes) {
@@ -814,6 +824,16 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			lastOffsetColumnIdx = lane;
 			g->gameplay.player[player].hiterror.notes.push({ offset, timing, Judgement::GREAT });
 			g->gameplay.player[player].hiterror.ema.add(static_cast<double>(offset));
+			if (player == 0) {
+				if (lane < 10) {
+					g->gameplay.player[player].hiterror.notes_dp_p1.push({ offset, timing, Judgement::GREAT });
+					g->gameplay.player[player].hiterror.ema_dp_p1.add(static_cast<double>(offset));
+				}
+				else {
+					g->gameplay.player[player].hiterror.notes_dp_p2.push({ offset, timing, Judgement::GREAT });
+					g->gameplay.player[player].hiterror.ema_dp_p2.add(static_cast<double>(offset));
+				}
+			}
 			return 1;
 		}
 		if (gap <= g->gameplay.player[player].judgetime[3] && g->gameplay.player[player].note_current < g->gameplay.player[player].totalnotes) {
@@ -838,6 +858,16 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			lastOffsetColumnIdx = lane;
 			g->gameplay.player[player].hiterror.notes.push({ offset, timing, Judgement::GOOD });
 			g->gameplay.player[player].hiterror.ema.add(static_cast<double>(offset));
+			if (player == 0) {
+				if (lane < 10) {
+					g->gameplay.player[player].hiterror.notes_dp_p1.push({ offset, timing, Judgement::GOOD });
+					g->gameplay.player[player].hiterror.ema_dp_p1.add(static_cast<double>(offset));
+				}
+				else {
+					g->gameplay.player[player].hiterror.notes_dp_p2.push({ offset, timing, Judgement::GOOD });
+					g->gameplay.player[player].hiterror.ema_dp_p2.add(static_cast<double>(offset));
+				}
+			}
 			return 1;
 		}
 
@@ -865,6 +895,16 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			lastOffsetColumnIdx = lane;
 			g->gameplay.player[player].hiterror.notes.push({ offset, timing, Judgement::BAD });
 			g->gameplay.player[player].hiterror.ema.add(static_cast<double>(offset));
+			if (player == 0) {
+				if (lane < 10) {
+					g->gameplay.player[player].hiterror.notes_dp_p1.push({ offset, timing, Judgement::BAD });
+					g->gameplay.player[player].hiterror.ema_dp_p1.add(static_cast<double>(offset));
+				}
+				else {
+					g->gameplay.player[player].hiterror.notes_dp_p2.push({ offset, timing, Judgement::BAD });
+					g->gameplay.player[player].hiterror.ema_dp_p2.add(static_cast<double>(offset));
+				}
+			}
 
 			if (g->gameplay.bmsobj_note[lane].note_count < g->gameplay.bmsobj_note[lane].size && abs(timing - (int)g->gameplay.bmsobj_note[lane].notes[g->gameplay.bmsobj_note[lane].note_count].realTiming) <= g->gameplay.player[player].judgetime[2]) {
 				ProcSinglenote(g, lane, 1, timing, player);
@@ -1132,10 +1172,11 @@ void CenterDraw(DSTdraw &draw, const DSTdraw &hiterrorByTime) {
 	draw.y = hiterrorByTime.y;
 }
 
-static int DrawHitErrorForPlayer(game &g, skstruct &sk, Timer &T, int player) {
-	if (sk.src_HITERROR[player].graphcount <= 0) return 0;
+static int DrawHitErrorForPlayer(game &g, skstruct &sk, Timer &T, int slot) {
+	if (slot < 0 || slot >= 4) return 0;
+	if (sk.src_HITERROR[slot].graphcount <= 0) return 0;
 
-	auto hiterrorByTime = SetDSTdrawByTime(sk.dst_HITERROR[player], GetTimeLapse(sk.dst_HITERROR[player].timer, &T));
+	auto hiterrorByTime = SetDSTdrawByTime(sk.dst_HITERROR[slot], GetTimeLapse(sk.dst_HITERROR[slot].timer, &T));
 
 	auto offset = [&](double timing) -> int {
 		return timing * hiterrorByTime.w / 400.0; /* bad range is 200ms on easy guage, so this should catch that */
@@ -1145,9 +1186,16 @@ static int DrawHitErrorForPlayer(game &g, skstruct &sk, Timer &T, int player) {
 		return originalAlpha - (time * originalAlpha / fadeTime);
 	};
 
+	int player = (slot <= 1) ? slot : 0; /* slots 2/3 are DP data on player[0] */
 	HITERRORDATA &hiterrorData = g.gameplay.player[player].hiterror;
+	CircularBuffer<JudgeData> &notes = (slot == 2) ? hiterrorData.notes_dp_p1 :
+	                                    (slot == 3) ? hiterrorData.notes_dp_p2 :
+	                                    hiterrorData.notes;
+	EMA &ema = (slot == 2) ? hiterrorData.ema_dp_p1 :
+	           (slot == 3) ? hiterrorData.ema_dp_p2 :
+	           hiterrorData.ema;
 
-	AddDrawingBuffer_Image(&sk.drBuf, &sk.src_HITERROR[player], &sk.dst_HITERROR[player], &T);
+	AddDrawingBuffer_Image(&sk.drBuf, &sk.src_HITERROR[slot], &sk.dst_HITERROR[slot], &T);
 
 	if (sk.src_HITERROR_CENTER.graphcount > 0) {
 		for (int i = 0; i < sk.dst_HITERROR_CENTER.dstCount; ++i) {
@@ -1159,11 +1207,11 @@ static int DrawHitErrorForPlayer(game &g, skstruct &sk, Timer &T, int player) {
 	/* Hiterror bars block */
 	{
 		double fadeTime = 0.75 * 1000;
-		if (hiterrorData.notes.size() > 50) fadeTime = hiterrorData.notes.size() / 50.0 * 1000;
+		if (notes.size() > 50) fadeTime = notes.size() / 50.0 * 1000;
 
 		double noteTimer = GetTimeLapse(142, &g.timer1);
-		for (int i = 0; i < hiterrorData.notes.size(); i++) {
-			const JudgeData &jd = hiterrorData.notes[i];
+		for (int i = 0; i < notes.size(); i++) {
+			const JudgeData &jd = notes[i];
 			SRCstruct *parentSRC = nullptr;
 			DSTstruct *parentDST = nullptr;
 
@@ -1209,14 +1257,14 @@ static int DrawHitErrorForPlayer(game &g, skstruct &sk, Timer &T, int player) {
 		for (int i = 0; i < sk.dst_HITERROR_EMA.dstCount; ++i) {
 			CenterDraw(sk.dst_HITERROR_EMA.draw[i], hiterrorByTime);
 		}
-		AddDrawingBuffer_Object(&sk.drBuf, &sk.src_HITERROR_EMA, &sk.dst_HITERROR_EMA, &T, offset(hiterrorData.ema.value), 0);
+		AddDrawingBuffer_Object(&sk.drBuf, &sk.src_HITERROR_EMA, &sk.dst_HITERROR_EMA, &T, offset(ema.value), 0);
 	}
 	return 1;
 }
 
 int DrawHitError(game *g, skstruct *sk, Timer *T) {
-	DrawHitErrorForPlayer(*g, *sk, *T, PLAYER_1);
-	DrawHitErrorForPlayer(*g, *sk, *T, PLAYER_2);
+	for (int slot = 0; slot < 4; ++slot)
+		DrawHitErrorForPlayer(*g, *sk, *T, slot);
 	return 1;
 }
 
@@ -2126,6 +2174,10 @@ int ProcS_Play(game *g, sqlite3* sql) {
 		g->gameplay.player[i].hiterror.ema = {};
 		g->gameplay.player[i].hiterror.notes.reset(g->skstruct.src_HITERROR[i].op1);
 	}
+	g->gameplay.player[PLAYER_1].hiterror.ema_dp_p1 = {};
+	g->gameplay.player[PLAYER_1].hiterror.notes_dp_p1.reset(g->skstruct.src_HITERROR[2].op1);
+	g->gameplay.player[PLAYER_1].hiterror.ema_dp_p2 = {};
+	g->gameplay.player[PLAYER_1].hiterror.notes_dp_p2.reset(g->skstruct.src_HITERROR[3].op1);
 
 	SetObjectString(1, g->gameplay.targetScore.name, g->txtStruct.objectStr);
 	std::jthread(ProcGameThread, g).detach(); // removed SetThreadPriority(hG, -1);

--- a/LR2/Scene04_Play.h
+++ b/LR2/Scene04_Play.h
@@ -11,6 +11,7 @@ int DrawNotes(game *g, skstruct *sk, Timer *T, CONFIG_PLAY *cfg);
 
  int DrawJudgeCombo(game *g, skstruct *sk, Timer *T, CONFIG_PLAY *cfg);
  int DrawHPgauge(game * g);
+int DrawHitError(game *g, skstruct *sk, Timer *T);
 
 int JudgeToScore(int judge, game *g, int player, int lane, char isReplay);
 int ProcSinglenote(game *g, int lane, int keypress, int timing, int player);

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1015,7 +1015,7 @@ struct skstruct {
 	struct SRCstruct src_HITERROR[2] {};
 	struct DSTstruct dst_HITERROR[2] {};
 	struct SRCstruct src_HITERROR_CENTER {};
-	struct DSTstruct dst_HITERROR_CENTER[2] {};
+	struct DSTstruct dst_HITERROR_CENTER {};
 	struct SRCstruct src_HITERROR_PGREAT {};
 	struct DSTstruct dst_HITERROR_PGREAT {};
 	struct SRCstruct src_HITERROR_GREAT {};

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1319,7 +1319,6 @@ struct EMA {
 	double value = 0.0;
 	static constexpr double alpha = 0.07;
 	void add(double x) { value = alpha * x + (1.0 - alpha) * value; }
-	void reset() { value = 0.0; }
 };
 
 template<typename T>

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -720,24 +720,6 @@ struct DSTstruct { /* 44bytes.4*0x0b */
 	int dstCount;
 };
 
-inline DSTstruct CloneDSTstruct(const DSTstruct* src) {
-	DSTstruct clone = *src;
-	if (src->dstCount > 0 && src->draw) {
-		clone.draw = (DSTdraw*)malloc(src->dstCount * sizeof(DSTdraw));
-		memcpy(clone.draw, src->draw, src->dstCount * sizeof(DSTdraw));
-	} else {
-		clone.draw = nullptr;
-	}
-	return clone;
-}
-
-inline void FreeDSTstructClone(DSTstruct* clone) {
-	if (clone && clone->draw) {
-		free(clone->draw);
-		clone->draw = nullptr;
-	}
-}
-
 struct FontChar {
 	int srcX{};
 	int srcY{};

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1328,7 +1328,6 @@ class CircularBuffer {
 
 public:
 	CircularBuffer() = default;
-	explicit CircularBuffer(size_t capacity) : buf(capacity) {}
 
 	void push(const T& val) {
 		if (buf.empty()) return;
@@ -1343,6 +1342,7 @@ public:
 	}
 
 	size_t size() const { return buf.size(); }
+	void reset(size_t capacity) { buf.clear(); buf.resize(capacity); }
 
 	const T& operator[](size_t i) const { return buf[i]; }
 };

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1353,11 +1353,19 @@ public:
 	const T& operator[](size_t i) const { return buf[i]; }
 };
 
+enum class Judgement {
+	AIR_POOR,
+	MISS_POOR,
+	BAD,
+	GOOD,
+	GREAT,
+	PGREAT
+};
+
 struct JudgeData {
-	size_t column = 0;
-	double offset = 0.0;
-	double timeHit = 0.0;
-	size_t judge = 0;
+	int offset = 0.0;
+	int timeHit = 0.0;
+	Judgement judge;
 };
 
 struct HITERRORDATA {

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1319,7 +1319,7 @@ public:
 
 	void push(T&& val) {
 		if (buf.empty()) return;
-		buf[head] = std::move(val);
+		buf[head] = std::forward<T>(val);
 		head = (head + 1) % buf.size();
 	}
 

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1304,6 +1304,56 @@ struct EXTENDEDPLAYERSTATS {
 	int lastFastSlow = 0;
 };
 
+struct EMA {
+	double value = 0.0;
+	static constexpr double alpha = 0.07;
+	void add(double x) { value = alpha * x + (1.0 - alpha) * value; }
+	void reset() { value = 0.0; }
+};
+
+template<typename T>
+class CircularBuffer {
+	std::vector<T> buf;
+	size_t head = 0;
+
+public:
+	CircularBuffer() = default;
+	explicit CircularBuffer(size_t capacity) : buf(capacity) {}
+
+	void push(const T& val) {
+		if (buf.empty()) return;
+		buf[head] = val;
+		head = (head + 1) % buf.size();
+	}
+
+	void push(T&& val) {
+		if (buf.empty()) return;
+		buf[head] = std::move(val);
+		head = (head + 1) % buf.size();
+	}
+
+	struct Iterator {
+		const CircularBuffer* cb;
+		size_t pos;
+		const T& operator*() const { return cb->buf[(cb->head + pos) % cb->buf.size()]; }
+		Iterator& operator++() { ++pos; return *this; }
+		bool operator!=(const Iterator& other) const { return pos != other.pos; }
+	};
+
+	Iterator begin() const { return {this, 0}; }
+	Iterator end() const { return {this, buf.size()}; }
+};
+
+struct JudgeData {
+	size_t column = 0;
+	double offset = 0.0;
+};
+
+struct HITERRORDATA {
+	EMA ema;
+	CircularBuffer<JudgeData> notes;
+};
+
 struct PLAYERSTATUS {
 	int flag_active = 0;
 	int judgecount[6] = {}; /* 0unknown 1poor 2bad 3good 4great 5pgreat */
@@ -1345,6 +1395,7 @@ struct PLAYERSTATUS {
 	EXTENDEDPLAYERSTATS extendedStatsCourse = {};
 	std::array<EXTENDEDPLAYERSTATS, 20> extendedColumnStatsCourse = {};
 	int lastJudgedColumnIdx = 0;
+	HITERRORDATA hiterror;
 };
 
 struct PLAYSCORE {

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1019,6 +1019,22 @@ struct skstruct {
 	int event_FADEOUT[10]{};
 	struct DSTstruct dst_EVENT_LOADINGBG[5]{};
 	int horizontal{};
+	struct SRCstruct src_HITERROR {};
+	struct DSTstruct dst_HITERROR {};
+	struct SRCstruct src_HITERROR_CENTER {};
+	struct DSTstruct dst_HITERROR_CENTER {};
+	struct SRCstruct src_HITERROR_PGREAT {};
+	struct DSTstruct dst_HITERROR_PGREAT {};
+	struct SRCstruct src_HITERROR_GREAT {};
+	struct DSTstruct dst_HITERROR_GREAT {};
+	struct SRCstruct src_HITERROR_GOOD {};
+	struct DSTstruct dst_HITERROR_GOOD {};
+	struct SRCstruct src_HITERROR_BAD {};
+	struct DSTstruct dst_HITERROR_BAD {};
+	struct SRCstruct src_HITERROR_POOR {};
+	struct DSTstruct dst_HITERROR_POOR {};
+	struct SRCstruct src_HITERROR_EMA {};
+	struct DSTstruct dst_HITERROR_EMA {};
 };
 
 struct MYRANKING {

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1347,6 +1347,7 @@ public:
 struct JudgeData {
 	size_t column = 0;
 	double offset = 0.0;
+	size_t judge = 0;
 };
 
 struct HITERRORDATA {

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1035,6 +1035,7 @@ struct skstruct {
 	struct DSTstruct dst_HITERROR_POOR {};
 	struct SRCstruct src_HITERROR_EMA {};
 	struct DSTstruct dst_HITERROR_EMA {};
+	struct std::vector<DSTstruct> HiterrorDSTPool {};
 };
 
 struct MYRANKING {
@@ -1332,21 +1333,15 @@ public:
 		head = (head + 1) % buf.size();
 	}
 
-	struct Iterator {
-		const CircularBuffer* cb;
-		size_t pos;
-		const T& operator*() const { return cb->buf[(cb->head + pos) % cb->buf.size()]; }
-		Iterator& operator++() { ++pos; return *this; }
-		bool operator!=(const Iterator& other) const { return pos != other.pos; }
-	};
+	size_t size() const { return buf.size(); }
 
-	Iterator begin() const { return {this, 0}; }
-	Iterator end() const { return {this, buf.size()}; }
+	const T& operator[](size_t i) const { return buf[i]; }
 };
 
 struct JudgeData {
 	size_t column = 0;
 	double offset = 0.0;
+	double timeHit = 0.0;
 	size_t judge = 0;
 };
 

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -718,6 +718,24 @@ struct DSTstruct { /* 44bytes.4*0x0b */
 	int dstCount;
 };
 
+inline DSTstruct CloneDSTstruct(const DSTstruct* src) {
+	DSTstruct clone = *src;
+	if (src->dstCount > 0 && src->draw) {
+		clone.draw = (DSTdraw*)malloc(src->dstCount * sizeof(DSTdraw));
+		memcpy(clone.draw, src->draw, src->dstCount * sizeof(DSTdraw));
+	} else {
+		clone.draw = nullptr;
+	}
+	return clone;
+}
+
+inline void FreeDSTstructClone(DSTstruct* clone) {
+	if (clone && clone->draw) {
+		free(clone->draw);
+		clone->draw = nullptr;
+	}
+}
+
 struct FontChar {
 	int srcX{};
 	int srcY{};
@@ -1019,10 +1037,10 @@ struct skstruct {
 	int event_FADEOUT[10]{};
 	struct DSTstruct dst_EVENT_LOADINGBG[5]{};
 	int horizontal{};
-	struct SRCstruct src_HITERROR {};
-	struct DSTstruct dst_HITERROR {};
+	struct SRCstruct src_HITERROR[2] {};
+	struct DSTstruct dst_HITERROR[2] {};
 	struct SRCstruct src_HITERROR_CENTER {};
-	struct DSTstruct dst_HITERROR_CENTER {};
+	struct DSTstruct dst_HITERROR_CENTER[2] {};
 	struct SRCstruct src_HITERROR_PGREAT {};
 	struct DSTstruct dst_HITERROR_PGREAT {};
 	struct SRCstruct src_HITERROR_GREAT {};
@@ -1031,11 +1049,8 @@ struct skstruct {
 	struct DSTstruct dst_HITERROR_GOOD {};
 	struct SRCstruct src_HITERROR_BAD {};
 	struct DSTstruct dst_HITERROR_BAD {};
-	struct SRCstruct src_HITERROR_POOR {};
-	struct DSTstruct dst_HITERROR_POOR {};
 	struct SRCstruct src_HITERROR_EMA {};
 	struct DSTstruct dst_HITERROR_EMA {};
-	struct std::vector<DSTstruct> HiterrorDSTPool {};
 };
 
 struct MYRANKING {

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1012,8 +1012,8 @@ struct skstruct {
 	int event_FADEOUT[10]{};
 	struct DSTstruct dst_EVENT_LOADINGBG[5]{};
 	int horizontal{};
-	struct SRCstruct src_HITERROR[2] {};
-	struct DSTstruct dst_HITERROR[2] {};
+	struct SRCstruct src_HITERROR[4] {};
+	struct DSTstruct dst_HITERROR[4] {};
 	struct SRCstruct src_HITERROR_CENTER {};
 	struct DSTstruct dst_HITERROR_CENTER {};
 	struct SRCstruct src_HITERROR_PGREAT {};
@@ -1347,6 +1347,10 @@ struct JudgeData {
 struct HITERRORDATA {
 	EMA ema;
 	CircularBuffer<JudgeData> notes;
+	EMA ema_dp_p1;
+	CircularBuffer<JudgeData> notes_dp_p1;
+	EMA ema_dp_p2;
+	CircularBuffer<JudgeData> notes_dp_p2;
 };
 
 struct PLAYERSTATUS {


### PR DESCRIPTION
# Summary
Adds the following commands
```csv
#SRC_HITERROR,player,(NULL),(NULL),(NULL),(NULL),(NULL),barcount,(NULL),(NULL),(NULL),(NULL),(NULL),(NULL)
#DST_HITERROR,player,time,x,y,w,h,acc,a,r,g,b,blend,filter,angle,center,loop,timer,op1,op2,op3
#SRC_HITERROR_CENTER,0,0,0,0,0,0,0,0,0,0,0,0,0
#DST_HITERROR_CENTER,(NULL),time,x,y,w,h,acc,a,r,g,b,blend,filter,angle,center,loop,timer,op1,op2,op3

#SRC_HITERROR_POOR,0,0,0,0,0,0,0,0,0,0,0,0,0
#DST_HITERROR_POOR,(NULL),time,x,y,w,h,acc,a,r,g,b,blend,filter,angle,center,loop,timer,op1,op2,op3
#SRC_HITERROR_BAD,0,0,0,0,0,0,0,0,0,0,0,0,0
#DST_HITERROR_BAD,(NULL)

,time,x,y,w,h,acc,a,r,g,b,blend,filter,angle,center,loop,timer,op1,op2,op3
#SRC_HITERROR_GOOD,0,0,0,0,0,0,0,0,0,0,0,0,0
#DST_HITERROR_GOOD,(NULL),time,x,y,w,h,acc,a,r,g,b,blend,filter,angle,center,loop,timer,op1,op2,op3
#SRC_HITERROR_GREAT,0,0,0,0,0,0,0,0,0,0,0,0,0
#DST_HITERROR_GREAT,(NULL),time,x,y,w,h,acc,a,r,g,b,blend,filter,angle,center,loop,timer,op1,op2,op3
#SRC_HITERROR_PGREAT,0,0,0,0,0,0,0,0,0,0,0,0,0
#DST_HITERROR_PGREAT,(NULL),time,x,y,w,h,acc,a,r,g,b,blend,filter,angle,center,loop,timer,op1,op2,op3

#SRC_HITERROR_EMA,0,0,0,0,0,0,0,0,0,0,0,0,0
#DST_HITERROR_EMA,(NULL),time,x,y,w,h,acc,a,r,g,b,blend,filter,angle,center,loop,timer,op1,op2,op3
```
The SRC commands are very similar to `#SRC_BGA` in that for the most part they are entirely ignored, but I added them for convention, if determined unnecessary they can likely be removed, or potentially a proper support for images could be added. The commands defining the color/dimensions of the hiterror bars could also take a player index but I didn't know if that would be that important, so I haven't added it yet.

## Demonstration

https://github.com/user-attachments/assets/25b55a9a-b835-48c7-b137-b917d08179a0

