### PR TITLE
feat(customir): add rival support

### DIFF
--- a/ExampleIR/ExternalIR.cpp
+++ b/ExampleIR/ExternalIR.cpp
@@ -113,6 +113,31 @@ static std::string OLR2_IR_API GetWebRankingUrl(const char* songHash) {
 	return std::format("https://example.com/{}", songHash);
 }
 
+static openlr2::GetStatus OLR2_IR_API GetRivals(openlr2::IRRivalListResult& out) {
+    std::println(std::cout, "GetRivals");
+    // A real module would fetch the rival list from its service (up to 20 rival ids/names).
+    // ExampleIR returns static in-memory data to show the API shape (no sqlite needed).
+    out = {};
+    out.fetched_at = 1;
+    out.rivals = {
+        { .id = 70100, .name = "ExampleRivalA" },
+        { .id = 70101, .name = "ExampleRivalB" },
+    };
+    return openlr2::GetStatus::Ok;
+}
+
+static openlr2::GetStatus OLR2_IR_API SyncRivalScores(int rivalId, uint64_t /*lastUpdateHint*/, std::vector<openlr2::IRRivalScore>& out) {
+    std::println(std::cout, "SyncRivalScores({})", rivalId);
+    // A real module would fetch this rival's complete score snapshot from its service.
+    // ExampleIR returns static in-memory data; OpenLR2 writes the .db and .lr2folder from it.
+    // Replace the hashes with real chart md5s to make the scores show up in-game.
+    out = {
+        { .hash = "e6f2a1c48b7d0359e1a2b3c4d5e6f708", .clear = 4, .notes = 1200, .combo = 1180, .pg = 1000, .gr = 180, .gd = 15, .bd = 3, .pr = 2, .minbp = 5, .option = 0, .lastupdate = 1262304000 },
+        { .hash = "1a2b3c4d5e6f70819aabbccddeeff0011", .clear = 5, .notes = 900, .combo = 900, .pg = 880, .gr = 20, .gd = 0, .bd = 0, .pr = 0, .minbp = 0, .option = 0, .lastupdate = 1262304000 },
+    };
+    return openlr2::GetStatus::Ok;
+}
+
 extern "C" OLR2_IR_EXPORT void OLR2_IR_API GetMethodTable(MethodTable& table) {
     // Fill out the pointers to methods you want to use. Leave them at nullptr if you don't want to use them.
     // As API gets updated, new methods may appear available at MethodTable, but old ones will never be removed or their
@@ -124,6 +149,8 @@ extern "C" OLR2_IR_EXPORT void OLR2_IR_API GetMethodTable(MethodTable& table) {
     table.RestoreCachedRank = &RestoreCachedRank;
     table.GetGhost = &GetGhost;
     table.GetWebRankingUrl = &GetWebRankingUrl;
+    table.GetRivals = &GetRivals;
+    table.SyncRivalScores = &SyncRivalScores;
 }
 
 #ifdef _WIN32

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -440,94 +440,117 @@ bool CUSTOMIR_MANAGER::IsDisplayIrOnline() const {
 	return (*irIt)->DidLoginSuccessfully();
 }
 
+bool CUSTOMIR_MANAGER::RivalSyncBatch::HasTasks() const {
+	return std::ranges::any_of(providers, [](const RivalSyncProvider& p) { return !p.tasks.empty(); });
+}
+
 CUSTOMIR_MANAGER::RivalSyncBatch CUSTOMIR_MANAGER::SyncRivals() {
 	RivalSyncBatch batch{};
 	mRivalPaths.clear();
 
-	if (!IsDisplayIrOnline()) {
-		ErrorLogAdd("CustomIR rival sync skipped: display IR offline\n");
-		return batch;
+	for (const auto& ir : mModules) {
+		if (!ir->DidLoginSuccessfully()) continue;
+
+		openlr2::IRRivalListResult list{};
+		switch (ir->GetRivals(list)) {
+		case openlr2::GetStatus::Ok:
+			break;
+		case openlr2::GetStatus::Retry:
+			OverlayNotification("'%s' GetRivals retry ignored\n", ir->Name().c_str());
+			continue;
+		case openlr2::GetStatus::Fail:
+		default:
+			if (ir->Name() == mDisplayIr) {
+				OverlayNotification("'%s' GetRivals failed - falling back to legacy rival\n", ir->Name().c_str());
+			}
+			continue;
+		}
+
+		RivalSyncProvider provider{};
+		provider.providerName = ir->Name();
+		provider.listOk = true;
+		const std::filesystem::path rivalDirectory = CustomIRRivalDirectory(provider.providerName);
+		std::error_code ec;
+		std::filesystem::create_directories(rivalDirectory, ec);
+		provider.tasks.reserve(list.rivals.size());
+		for (const auto& entry : list.rivals) {
+			if (entry.id < 1) continue;
+			const uint64_t lastUpdateHint = CustomIRRivalLastUpdateHint(rivalDirectory, entry.id);
+
+			provider.tasks.push_back(RivalSyncTask{
+				.name = entry.name,
+				.result = std::async(std::launch::async, [ir, id = entry.id, lastUpdateHint]() -> std::optional<std::vector<openlr2::IRRivalScore>> {
+					std::vector<openlr2::IRRivalScore> scores;
+					const auto syncStatus = ir->SyncRivalScores(id, lastUpdateHint, scores);
+					if (syncStatus != openlr2::GetStatus::Ok) {
+						ErrorLogFmtAdd("SyncRivalScores %s for %s id=%d\n",
+							syncStatus == openlr2::GetStatus::Retry ? "retry ignored" : "failed",
+							ir->Name().c_str(),
+							id);
+						return std::nullopt;
+					}
+					return scores;
+				}),
+				.id = entry.id,
+			});
+		}
+		batch.providers.push_back(std::move(provider));
 	}
-	const auto irIt = std::ranges::find(mModules, mDisplayIr, &CustomIR::Name);
-	if (irIt == mModules.end()) return batch;
-	auto ir = *irIt;
-	batch.providerName = ir->Name();
-	const std::filesystem::path rivalDirectory = CustomIRRivalDirectory(batch.providerName);
-	std::error_code ec;
-	std::filesystem::create_directories(rivalDirectory, ec);
 
-	openlr2::IRRivalListResult list{};
-	switch (ir->GetRivals(list)) {
-	case openlr2::GetStatus::Ok:
-		break;
-	case openlr2::GetStatus::Retry:
-		OverlayNotification("'%s' GetRivals retry ignored\n", ir->Name().c_str());
-		return batch;
-	case openlr2::GetStatus::Fail:
-	default:
-		OverlayNotification("'%s' GetRivals failed - falling back to legacy rival\n", ir->Name().c_str());
-		return batch;
+	if (batch.providers.empty()) {
+		ErrorLogAdd("CustomIR rival sync skipped: no logged-in CustomIR with rivals\n");
 	}
-
-	batch.supported = true;
-	batch.tasks.reserve(list.rivals.size());
-	for (const auto& entry : list.rivals) {
-		if (entry.id < 1) continue;
-		const uint64_t lastUpdateHint = CustomIRRivalLastUpdateHint(rivalDirectory, entry.id);
-
-		batch.tasks.push_back(RivalSyncTask{
-			.name = entry.name,
-			.result = std::async(std::launch::async, [ir, id = entry.id, lastUpdateHint]() -> std::optional<std::vector<openlr2::IRRivalScore>> {
-				std::vector<openlr2::IRRivalScore> scores;
-				const auto syncStatus = ir->SyncRivalScores(id, lastUpdateHint, scores);
-				if (syncStatus != openlr2::GetStatus::Ok) {
-					ErrorLogFmtAdd("SyncRivalScores %s for id=%d\n",
-						syncStatus == openlr2::GetStatus::Retry ? "retry ignored" : "failed",
-						id);
-					return std::nullopt;
-				}
-				return scores;
-			}),
-			.id = entry.id,
-		});
-	}
-
 	return batch;
 }
 
 bool CUSTOMIR_MANAGER::ApplyRivalSyncResults(RivalSyncBatch& sync) {
 	mRivalPaths.clear();
-	if (!sync.supported) return false;
-
 	cleanUpOldFutures(mDiscardedRivalSyncFutures);
 
-	const std::filesystem::path rivalDirectory = CustomIRRivalDirectory(sync.providerName);
-	int count = 0;
-	for (auto& task : sync.tasks) {
-		if (!task.result.valid()) continue;
+	bool displayListOk = false;
+	int displayCount = 0;
+	for (auto& provider : sync.providers) {
+		if (!provider.listOk) continue;
 
-		// Soft skip: do not block on unfinished downloads; park like discarded result-IR futures.
-		if (task.result.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
-			mDiscardedRivalSyncFutures.push_back(std::move(task.result));
-			continue;
+		const bool isDisplay = provider.providerName == mDisplayIr;
+		if (isDisplay) displayListOk = true;
+
+		const std::filesystem::path rivalDirectory = CustomIRRivalDirectory(provider.providerName);
+		int providerCount = 0;
+		for (auto& task : provider.tasks) {
+			if (!task.result.valid()) continue;
+
+			// Soft skip: do not block on unfinished downloads; park like discarded result-IR futures.
+			if (task.result.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
+				mDiscardedRivalSyncFutures.push_back(std::move(task.result));
+				continue;
+			}
+
+			std::optional<std::vector<openlr2::IRRivalScore>> scores = task.result.get();
+			if (!scores) continue;
+
+			if (!WriteCustomIRRivalArtifacts(rivalDirectory, task.id, task.name, *scores)) {
+				ErrorLogFmtAdd("CustomIR rival write failed for %s id=%d\n", provider.providerName.c_str(), task.id);
+				continue;
+			}
+
+			const std::filesystem::path rivalPath = rivalDirectory / std::to_string(task.id);
+			if (isDisplay) {
+				mRivalPaths.emplace_back(task.id, rivalPath);
+				++displayCount;
+			}
+			++providerCount;
+			ErrorLogFmtAdd("CustomIR rival ready: %s %d (%s, scores=%zu)\n",
+				provider.providerName.c_str(), task.id, task.name.c_str(), scores->size());
 		}
-
-		std::optional<std::vector<openlr2::IRRivalScore>> scores = task.result.get();
-		if (!scores) continue;
-
-		if (!WriteCustomIRRivalArtifacts(rivalDirectory, task.id, task.name, *scores)) {
-			ErrorLogFmtAdd("CustomIR rival write failed for id=%d\n", task.id);
-			continue;
-		}
-
-		const std::filesystem::path rivalPath = rivalDirectory / std::to_string(task.id);
-		mRivalPaths.emplace_back(task.id, rivalPath);
-		++count;
-		ErrorLogFmtAdd("CustomIR rival ready: %d (%s, scores=%zu)\n", task.id, task.name.c_str(), scores->size());
+		ErrorLogFmtAdd("CustomIR rival sync wrote %d rivals for %s%s\n",
+			providerCount, provider.providerName.c_str(), isDisplay ? " (display)" : "");
 	}
 
-	ErrorLogFmtAdd("CustomIR rival source active (%d rivals)\n", count);
-	return true;
+	if (displayListOk) {
+		ErrorLogFmtAdd("CustomIR rival source active (%d rivals)\n", displayCount);
+	}
+	return displayListOk;
 }
 
 std::string CUSTOMIR_MANAGER::GetWebRankingUrl(const char* songHash) const {

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -334,20 +334,14 @@ static bool WriteCustomIRRivalArtifacts(
 // Can hang for up to 15 minutes if score sending fails time and time again...
 CUSTOMIR_MANAGER::~CUSTOMIR_MANAGER() = default;
 
-std::vector<std::pair<int, std::filesystem::path>> CUSTOMIR_MANAGER::sRivalPaths;
-
-std::optional<std::filesystem::path> CUSTOMIR_MANAGER::RivalPath(int rivalId) {
-	const auto it = std::ranges::find(sRivalPaths, rivalId, &std::pair<int, std::filesystem::path>::first);
-	if (it == sRivalPaths.end()) return std::nullopt;
+std::optional<std::filesystem::path> CUSTOMIR_MANAGER::RivalPath(int rivalId) const {
+	const auto it = std::ranges::find(mRivalPaths, rivalId, &std::pair<int, std::filesystem::path>::first);
+	if (it == mRivalPaths.end()) return std::nullopt;
 	return it->second;
 }
 
-bool CUSTOMIR_MANAGER::CopyRivalIds(std::span<int> rivalsOut) {
-	std::ranges::fill(rivalsOut, 0); // Fill the remainder if rivalsOut.size() < sRivalPaths.size()
-	for (auto [to, from] : std::views::zip(rivalsOut, sRivalPaths)) {
-		to = from.first;
-	}
-	return true;
+std::span<const std::pair<int, std::filesystem::path>> CUSTOMIR_MANAGER::RivalEntries() const {
+	return mRivalPaths;
 }
 
 template<class T>
@@ -449,7 +443,7 @@ bool CUSTOMIR_MANAGER::IsDisplayIrOnline() const {
 
 CUSTOMIR_MANAGER::RivalSyncBatch CUSTOMIR_MANAGER::SyncRivals() {
 	RivalSyncBatch batch{};
-	sRivalPaths.clear();
+	mRivalPaths.clear();
 
 	if (!IsDisplayIrOnline()) {
 		ErrorLogAdd("CustomIR rival sync skipped: display IR offline\n");
@@ -503,7 +497,7 @@ CUSTOMIR_MANAGER::RivalSyncBatch CUSTOMIR_MANAGER::SyncRivals() {
 }
 
 bool CUSTOMIR_MANAGER::ApplyRivalSyncResults(RivalSyncBatch& sync) {
-	sRivalPaths.clear();
+	mRivalPaths.clear();
 	if (!sync.supported) return false;
 
 	cleanUpOldFutures(mDiscardedRivalSyncFutures);
@@ -528,7 +522,7 @@ bool CUSTOMIR_MANAGER::ApplyRivalSyncResults(RivalSyncBatch& sync) {
 		}
 
 		const std::filesystem::path rivalPath = rivalDirectory / std::to_string(task.id);
-		sRivalPaths.emplace_back(task.id, rivalPath);
+		mRivalPaths.emplace_back(task.id, rivalPath);
 		++count;
 		ErrorLogFmtAdd("CustomIR rival ready: %d (%s, scores=%zu)\n", task.id, task.name.c_str(), scores->size());
 	}

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -172,8 +172,7 @@ static uint64_t CustomIRRivalLastUpdateHint(const std::filesystem::path& rivalDi
 	const auto dbPath = rivalDirectory / std::format("{}.db", rivalId);
 
 	sqlite3* db = nullptr;
-	if(sqlite3_open_v2(std::format("file:{}?mode=ro", dbPath.generic_string()).c_str(), &db,
-					   SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, nullptr)
+	if(sqlite3_open_v2(dbPath.generic_string().c_str(), &db, SQLITE_OPEN_READONLY, nullptr)
 	   != SQLITE_OK)
 	{
 		return 0;

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -172,23 +172,30 @@ static uint64_t CustomIRRivalLastUpdateHint(const std::filesystem::path& rivalDi
 	const auto dbPath = rivalDirectory / std::format("{}.db", rivalId);
 
 	sqlite3* db = nullptr;
-	std::string uri = "file:" + dbPath.generic_string() + "?mode=ro";
-	if (sqlite3_open(uri.c_str(), &db) != SQLITE_OK) {
+	if(sqlite3_open_v2(std::format("file:{}?mode=ro", dbPath.generic_string()).c_str(), &db,
+					   SQLITE_OPEN_READONLY | SQLITE_OPEN_URI, nullptr)
+	   != SQLITE_OK)
+	{
 		return 0;
 	}
 
 	sqlite3_stmt* stmt = nullptr;
-	uint64_t lastUpdate = 0;
-	if (sqlite3_prepare_v2(db, "SELECT r_lastupdate FROM rival ORDER BY r_lastupdate DESC LIMIT 1", -1, &stmt, nullptr) == SQLITE_OK) {
-		if (sqlite3_step(stmt) == SQLITE_ROW) {
-			const sqlite3_int64 value = sqlite3_column_int64(stmt, 0);
-			if (value >= 0) {
-				lastUpdate = static_cast<uint64_t>(value);
-			}
-		}
-		sqlite3_finalize(stmt);
+	if(sqlite3_prepare_v2(db, "SELECT r_lastupdate FROM rival ORDER BY r_lastupdate DESC LIMIT 1", -1, &stmt, nullptr)
+	   != SQLITE_OK)
+	{
+		sqlite3_close(db);
+		return 0;
 	}
+
+	uint64_t lastUpdate = 0;
+	if(sqlite3_step(stmt) == SQLITE_ROW)
+		if(sqlite3_int64 const value = sqlite3_column_int64(stmt, 0); value >= 0)
+			lastUpdate = static_cast<uint64_t>(value);
+
+	sqlite3_finalize(stmt);
+
 	sqlite3_close(db);
+
 	return lastUpdate;
 }
 
@@ -336,11 +343,9 @@ std::optional<std::filesystem::path> CUSTOMIR_MANAGER::RivalPath(int rivalId) {
 }
 
 bool CUSTOMIR_MANAGER::CopyRivalIds(std::span<int> rivalsOut) {
-	std::ranges::fill(rivalsOut, 0);
-	if (sRivalPaths.empty() || rivalsOut.empty()) return false;
-	const std::size_t n = std::min(sRivalPaths.size(), rivalsOut.size());
-	for (std::size_t i = 0; i < n; ++i) {
-		rivalsOut[i] = sRivalPaths[i].first;
+	std::ranges::fill(rivalsOut, 0); // Fill the remainder if rivalsOut.size() < sRivalPaths.size()
+	for (auto [to, from] : std::views::zip(rivalsOut, sRivalPaths)) {
+		to = from.first;
 	}
 	return true;
 }
@@ -472,14 +477,12 @@ CUSTOMIR_MANAGER::RivalSyncBatch CUSTOMIR_MANAGER::SyncRivals() {
 	}
 
 	batch.supported = true;
-	batch.tasks.reserve(std::min(list.rivals.size(), openlr2::kMaxRivals));
+	batch.tasks.reserve(list.rivals.size());
 	for (const auto& entry : list.rivals) {
-		if (batch.tasks.size() >= openlr2::kMaxRivals) break;
 		if (entry.id < 1) continue;
 		const uint64_t lastUpdateHint = CustomIRRivalLastUpdateHint(rivalDirectory, entry.id);
 
 		batch.tasks.push_back(RivalSyncTask{
-			.id = entry.id,
 			.name = entry.name,
 			.result = std::async(std::launch::async, [ir, id = entry.id, lastUpdateHint]() -> std::optional<std::vector<openlr2::IRRivalScore>> {
 				std::vector<openlr2::IRRivalScore> scores;
@@ -492,6 +495,7 @@ CUSTOMIR_MANAGER::RivalSyncBatch CUSTOMIR_MANAGER::SyncRivals() {
 				}
 				return scores;
 			}),
+			.id = entry.id,
 		});
 	}
 
@@ -507,7 +511,6 @@ bool CUSTOMIR_MANAGER::ApplyRivalSyncResults(RivalSyncBatch& sync) {
 	const std::filesystem::path rivalDirectory = CustomIRRivalDirectory(sync.providerName);
 	int count = 0;
 	for (auto& task : sync.tasks) {
-		if (count >= static_cast<int>(openlr2::kMaxRivals)) break;
 		if (!task.result.valid()) continue;
 
 		// Soft skip: do not block on unfinished downloads; park like discarded result-IR futures.

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -2,6 +2,8 @@
 
 #include "LR2_customir_api.h"
 #include "LR2_songmanage.h"
+#include "En_fileutil.h"
+#include "filesystem.h"
 #include "structure.h"
 
 #include <algorithm>
@@ -9,6 +11,8 @@
 #include <chrono>
 #include <cstring>
 #include <filesystem>
+#include <format>
+#include <fstream>
 #include <future>
 #include <optional>
 #include <ranges>
@@ -17,7 +21,7 @@
 #include <utility>
 #include <vector>
 
-#include <DxLib.h>
+#include <sqlite3.h>
 
 #ifdef _WIN32
 #include <libloaderapi.h>
@@ -71,6 +75,8 @@ public:
 	openlr2::GetStatus RestoreCachedRank(const char* songHash, openlr2::IRRankResult& out);
 	openlr2::GetStatus GetGhost(const char* songHash, openlr2::GhostMode mode, int targetPlayerId, openlr2::IRGhostResult& out);
 	[[nodiscard]] std::string GetWebRankingUrl(const char* songHash);
+	openlr2::GetStatus GetRivals(openlr2::IRRivalListResult& out);
+	openlr2::GetStatus SyncRivalScores(int rivalId, uint64_t lastUpdateHint, std::vector<openlr2::IRRivalScore>& out);
 	[[nodiscard]] const std::string& Name() const { return mName; };
 	[[nodiscard]] bool DidLoginSuccessfully() const { return mDidLoginSuccessfully; };
 private:
@@ -148,9 +154,196 @@ std::string CustomIR::GetWebRankingUrl(const char* songHash) {
 	return mMethods.GetWebRankingUrl(songHash);
 }
 
+openlr2::GetStatus CustomIR::GetRivals(openlr2::IRRivalListResult& out) {
+	if (mMethods.GetRivals == nullptr) return openlr2::GetStatus::Fail;
+	return mMethods.GetRivals(out);
+}
+
+openlr2::GetStatus CustomIR::SyncRivalScores(int rivalId, uint64_t lastUpdateHint, std::vector<openlr2::IRRivalScore>& out) {
+	if (mMethods.SyncRivalScores == nullptr) return openlr2::GetStatus::Fail;
+	return mMethods.SyncRivalScores(rivalId, lastUpdateHint, out);
+}
+
+static std::filesystem::path CustomIRRivalDirectory(const std::string& providerName) {
+	return std::filesystem::path(fs::make_preferred("LR2files/CustomIRRival").data()) / providerName;
+}
+
+static uint64_t CustomIRRivalLastUpdateHint(const std::filesystem::path& rivalDirectory, int rivalId) {
+	const auto dbPath = rivalDirectory / std::format("{}.db", rivalId);
+
+	sqlite3* db = nullptr;
+	std::string uri = "file:" + dbPath.generic_string() + "?mode=ro";
+	if (sqlite3_open(uri.c_str(), &db) != SQLITE_OK) {
+		return 0;
+	}
+
+	sqlite3_stmt* stmt = nullptr;
+	uint64_t lastUpdate = 0;
+	if (sqlite3_prepare_v2(db, "SELECT r_lastupdate FROM rival ORDER BY r_lastupdate DESC LIMIT 1", -1, &stmt, nullptr) == SQLITE_OK) {
+		if (sqlite3_step(stmt) == SQLITE_ROW) {
+			const sqlite3_int64 value = sqlite3_column_int64(stmt, 0);
+			if (value >= 0) {
+				lastUpdate = static_cast<uint64_t>(value);
+			}
+		}
+		sqlite3_finalize(stmt);
+	}
+	sqlite3_close(db);
+	return lastUpdate;
+}
+
+static bool RivalExecSql(sqlite3* db, const char* sql) {
+	char* err = nullptr;
+	const int rc = sqlite3_exec(db, sql, nullptr, nullptr, &err);
+	if (rc != SQLITE_OK) {
+		if (err) {
+			ErrorLogFmtAdd("CustomIR rival db sql error: %s\n", err);
+			sqlite3_free(err);
+		}
+		return false;
+	}
+	return true;
+}
+
+static bool WriteCustomIRRivalDb(const std::filesystem::path& dbPath, const std::vector<openlr2::IRRivalScore>& scores) {
+	std::error_code ec;
+	std::filesystem::create_directories(dbPath.parent_path(), ec);
+
+	sqlite3* db = nullptr;
+	if (sqlite3_open(dbPath.string().c_str(), &db) != SQLITE_OK) {
+		ErrorLogFmtAdd("CustomIR rival db open failed: %s\n", dbPath.string().c_str());
+		return false;
+	}
+
+	const bool okSchema = RivalExecSql(
+		db,
+		"CREATE TABLE IF NOT EXISTS rival("
+		"hash TEXT primary key,"
+		"r_clear INTEGER,"
+		"r_totalnotes INTEGER,"
+		"r_maxcombo INTEGER,"
+		"r_perfect INTEGER,"
+		"r_great INTEGER,"
+		"r_good INTEGER,"
+		"r_bad INTEGER,"
+		"r_poor INTEGER,"
+		"r_minbp INTEGER,"
+		"r_option INTEGER,"
+		"r_lastupdate INGEGER)"
+	);
+	if (!okSchema || !RivalExecSql(db, "DELETE FROM rival") || !RivalExecSql(db, "BEGIN")) {
+		sqlite3_close(db);
+		return false;
+	}
+
+	sqlite3_stmt* stmt = nullptr;
+	const char* insertSql =
+		"INSERT OR REPLACE INTO rival "
+		"(hash,r_clear,r_totalnotes,r_maxcombo,r_perfect,r_great,r_good,r_bad,r_poor,r_minbp,r_option,r_lastupdate) "
+		"VALUES(?,?,?,?,?,?,?,?,?,?,?,?)";
+	if (sqlite3_prepare_v2(db, insertSql, -1, &stmt, nullptr) != SQLITE_OK) {
+		ErrorLogFmtAdd("CustomIR rival db prepare failed: %s\n", sqlite3_errmsg(db));
+		sqlite3_close(db);
+		return false;
+	}
+
+	for (const auto& score : scores) {
+		if (score.hash.empty()) {
+			continue;
+		}
+		sqlite3_bind_text(stmt, 1, score.hash.c_str(), -1, SQLITE_TRANSIENT);
+		sqlite3_bind_int(stmt, 2, score.clear);
+		sqlite3_bind_int(stmt, 3, score.notes);
+		sqlite3_bind_int(stmt, 4, score.combo);
+		sqlite3_bind_int(stmt, 5, score.pg);
+		sqlite3_bind_int(stmt, 6, score.gr);
+		sqlite3_bind_int(stmt, 7, score.gd);
+		sqlite3_bind_int(stmt, 8, score.bd);
+		sqlite3_bind_int(stmt, 9, score.pr);
+		sqlite3_bind_int(stmt, 10, score.minbp);
+		sqlite3_bind_int(stmt, 11, score.option);
+		sqlite3_bind_int64(stmt, 12, static_cast<sqlite3_int64>(score.lastupdate));
+		if (sqlite3_step(stmt) != SQLITE_DONE) {
+			ErrorLogFmtAdd("CustomIR rival db insert failed: %s\n", sqlite3_errmsg(db));
+			sqlite3_finalize(stmt);
+			sqlite3_close(db);
+			return false;
+		}
+		sqlite3_reset(stmt);
+	}
+
+	sqlite3_finalize(stmt);
+	if (!RivalExecSql(db, "COMMIT")) {
+		sqlite3_close(db);
+		return false;
+	}
+	sqlite3_close(db);
+	return true;
+}
+
+static bool WriteCustomIRRivalLr2folder(const std::filesystem::path& folderPath, int rivalId, const std::string& name) {
+	std::error_code ec;
+	std::filesystem::create_directories(folderPath.parent_path(), ec);
+
+	const std::string content = std::format(
+		"#COMMAND __RIVAL__\n"
+		"#MAXTRACKS {}\n"
+		"#CATEGORY ライバルフォルダ\n"
+		"#TITLE {}\n"
+		"#INFORMATION_A {}のプレイした曲を表示します\n"
+		"#INFORMAION_B\n",
+		rivalId,
+		name,
+		name
+	);
+	const std::string encoded = utf2ansi(content, 932);
+
+	std::ofstream out(folderPath, std::ios::binary);
+	if (!out) {
+		return false;
+	}
+	out.write(encoded.data(), static_cast<std::streamsize>(encoded.size()));
+	return static_cast<bool>(out);
+}
+
+static bool WriteCustomIRRivalArtifacts(
+	const std::filesystem::path& rivalDirectory,
+	int rivalId,
+	const std::string& name,
+	const std::vector<openlr2::IRRivalScore>& scores
+) {
+	const auto dbPath = rivalDirectory / std::format("{}.db", rivalId);
+	const auto folderPath = rivalDirectory / std::format("{}.lr2folder", rivalId);
+	if (!WriteCustomIRRivalDb(dbPath, scores)) {
+		return false;
+	}
+	if (!WriteCustomIRRivalLr2folder(folderPath, rivalId, name)) {
+		return false;
+	}
+	return true;
+}
+
 // All held std::future are automatically awaited on.
 // Can hang for up to 15 minutes if score sending fails time and time again...
 CUSTOMIR_MANAGER::~CUSTOMIR_MANAGER() = default;
+
+std::vector<std::pair<int, std::filesystem::path>> CUSTOMIR_MANAGER::sRivalPaths;
+
+std::optional<std::filesystem::path> CUSTOMIR_MANAGER::RivalPath(int rivalId) {
+	const auto it = std::ranges::find(sRivalPaths, rivalId, &std::pair<int, std::filesystem::path>::first);
+	if (it == sRivalPaths.end()) return std::nullopt;
+	return it->second;
+}
+
+bool CUSTOMIR_MANAGER::CopyRivalIds(std::span<int> rivalsOut) {
+	std::ranges::fill(rivalsOut, 0);
+	if (sRivalPaths.empty() || rivalsOut.empty()) return false;
+	const std::size_t n = std::min(sRivalPaths.size(), rivalsOut.size());
+	for (std::size_t i = 0; i < n; ++i) {
+		rivalsOut[i] = sRivalPaths[i].first;
+	}
+	return true;
+}
 
 template<class T>
 static void cleanUpOldFutures(std::vector<T>& futures) {
@@ -247,6 +440,98 @@ bool CUSTOMIR_MANAGER::IsDisplayIrOnline() const {
 	const auto irIt = std::ranges::find(mModules, mDisplayIr, &CustomIR::Name);
 	if (irIt == mModules.end()) { return false; }
 	return (*irIt)->DidLoginSuccessfully();
+}
+
+CUSTOMIR_MANAGER::RivalSyncBatch CUSTOMIR_MANAGER::SyncRivals() {
+	RivalSyncBatch batch{};
+	sRivalPaths.clear();
+
+	if (!IsDisplayIrOnline()) {
+		ErrorLogAdd("CustomIR rival sync skipped: display IR offline\n");
+		return batch;
+	}
+	const auto irIt = std::ranges::find(mModules, mDisplayIr, &CustomIR::Name);
+	if (irIt == mModules.end()) return batch;
+	auto ir = *irIt;
+	batch.providerName = ir->Name();
+	const std::filesystem::path rivalDirectory = CustomIRRivalDirectory(batch.providerName);
+	std::error_code ec;
+	std::filesystem::create_directories(rivalDirectory, ec);
+
+	openlr2::IRRivalListResult list{};
+	switch (ir->GetRivals(list)) {
+	case openlr2::GetStatus::Ok:
+		break;
+	case openlr2::GetStatus::Retry:
+		OverlayNotification("'%s' GetRivals retry ignored\n", ir->Name().c_str());
+		return batch;
+	case openlr2::GetStatus::Fail:
+	default:
+		OverlayNotification("'%s' GetRivals failed - falling back to legacy rival\n", ir->Name().c_str());
+		return batch;
+	}
+
+	batch.supported = true;
+	batch.tasks.reserve(std::min(list.rivals.size(), openlr2::kMaxRivals));
+	for (const auto& entry : list.rivals) {
+		if (batch.tasks.size() >= openlr2::kMaxRivals) break;
+		if (entry.id < 1) continue;
+		const uint64_t lastUpdateHint = CustomIRRivalLastUpdateHint(rivalDirectory, entry.id);
+
+		batch.tasks.push_back(RivalSyncTask{
+			.id = entry.id,
+			.name = entry.name,
+			.result = std::async(std::launch::async, [ir, id = entry.id, lastUpdateHint]() -> std::optional<std::vector<openlr2::IRRivalScore>> {
+				std::vector<openlr2::IRRivalScore> scores;
+				const auto syncStatus = ir->SyncRivalScores(id, lastUpdateHint, scores);
+				if (syncStatus != openlr2::GetStatus::Ok) {
+					ErrorLogFmtAdd("SyncRivalScores %s for id=%d\n",
+						syncStatus == openlr2::GetStatus::Retry ? "retry ignored" : "failed",
+						id);
+					return std::nullopt;
+				}
+				return scores;
+			}),
+		});
+	}
+
+	return batch;
+}
+
+bool CUSTOMIR_MANAGER::ApplyRivalSyncResults(RivalSyncBatch& sync) {
+	sRivalPaths.clear();
+	if (!sync.supported) return false;
+
+	cleanUpOldFutures(mDiscardedRivalSyncFutures);
+
+	const std::filesystem::path rivalDirectory = CustomIRRivalDirectory(sync.providerName);
+	int count = 0;
+	for (auto& task : sync.tasks) {
+		if (count >= static_cast<int>(openlr2::kMaxRivals)) break;
+		if (!task.result.valid()) continue;
+
+		// Soft skip: do not block on unfinished downloads; park like discarded result-IR futures.
+		if (task.result.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
+			mDiscardedRivalSyncFutures.push_back(std::move(task.result));
+			continue;
+		}
+
+		std::optional<std::vector<openlr2::IRRivalScore>> scores = task.result.get();
+		if (!scores) continue;
+
+		if (!WriteCustomIRRivalArtifacts(rivalDirectory, task.id, task.name, *scores)) {
+			ErrorLogFmtAdd("CustomIR rival write failed for id=%d\n", task.id);
+			continue;
+		}
+
+		const std::filesystem::path rivalPath = rivalDirectory / std::to_string(task.id);
+		sRivalPaths.emplace_back(task.id, rivalPath);
+		++count;
+		ErrorLogFmtAdd("CustomIR rival ready: %d (%s, scores=%zu)\n", task.id, task.name.c_str(), scores->size());
+	}
+
+	ErrorLogFmtAdd("CustomIR rival source active (%d rivals)\n", count);
+	return true;
 }
 
 std::string CUSTOMIR_MANAGER::GetWebRankingUrl(const char* songHash) const {

--- a/LR2/LR2_customir.h
+++ b/LR2/LR2_customir.h
@@ -6,7 +6,9 @@
 #include <future>
 #include <memory>
 #include <optional>
+#include <span>
 #include <string>
+#include <utility>
 #include <vector>
 
 struct RANKING;
@@ -44,10 +46,33 @@ public:
 	// \note Delegates to the display IR
 	// \retval nullopt - Fail
 	std::optional<openlr2::IRGhostResult> TryGetTargetInfo(const char* songmd5, int mode, int targetPlayerId);
+
+	struct RivalSyncTask {
+		int id{};
+		std::string name;
+		std::future<std::optional<std::vector<openlr2::IRRivalScore>>> result;
+	};
+	struct RivalSyncBatch {
+		std::string providerName;
+		bool supported{};
+		std::vector<RivalSyncTask> tasks;
+	};
+	// Caller: only when getRival. Returns async work; call ApplyRivalSyncResults after wait or soft skip.
+	RivalSyncBatch SyncRivals();
+	// Applies ready tasks only. Incomplete futures are parked (soft skip / no WinHTTP abort).
+	// Success writes LR2files/CustomIRRival/<provider>/ and records rival ids/paths on this manager
+	bool ApplyRivalSyncResults(RivalSyncBatch& sync);
+	// Set only after successful ApplyRivalSyncResults. Empty = not active for this rival; use legacy LR2files/Rival.
+	[[nodiscard]] static std::optional<std::filesystem::path> RivalPath(int rivalId);
+	// Copies CustomIR rival ids into rivalsOut (zero-filled first). Returns false if none active.
+	[[nodiscard]] static bool CopyRivalIds(std::span<int> rivalsOut);
+
 private:
+	static std::vector<std::pair<int, std::filesystem::path>> sRivalPaths;
 	std::vector<std::shared_ptr<CustomIR>> mModules;
 	std::vector<std::future<void>> mSendThreads;
 	std::vector<std::future<std::optional<openlr2::IRRankResult>>> mDiscardedResultIrFutures;
+	std::vector<std::future<std::optional<std::vector<openlr2::IRRivalScore>>>> mDiscardedRivalSyncFutures;
 	std::future<std::optional<openlr2::IRRankResult>> mResultIrFuture;
 	std::string mDisplayIr;
 };

--- a/LR2/LR2_customir.h
+++ b/LR2/LR2_customir.h
@@ -64,12 +64,12 @@ public:
 	// Success writes LR2files/CustomIRRival/<provider>/ and records rival ids/paths on this manager
 	bool ApplyRivalSyncResults(RivalSyncBatch& sync);
 	// Set only after successful ApplyRivalSyncResults. Empty = not active for this rival; use legacy LR2files/Rival.
-	[[nodiscard]] static std::optional<std::filesystem::path> RivalPath(int rivalId); // XXX: must not be 'static'
-	// Copies CustomIR rival ids into rivalsOut (zero-filled first). Returns false if none active.
-	[[nodiscard]] static bool CopyRivalIds(std::span<int> rivalsOut); // XXX: must not be 'static'
+	[[nodiscard]] std::optional<std::filesystem::path> RivalPath(int rivalId) const;
+	// Synced CustomIR rivals: (id, artifact stem under CustomIRRival/<provider>/). Empty if none active.
+	[[nodiscard]] std::span<const std::pair<int, std::filesystem::path>> RivalEntries() const;
 
 private:
-	static std::vector<std::pair<int, std::filesystem::path>> sRivalPaths; // XXX: must not be 'static'
+	std::vector<std::pair<int, std::filesystem::path>> mRivalPaths;
 	std::vector<std::shared_ptr<CustomIR>> mModules;
 	std::vector<std::future<void>> mSendThreads;
 	std::vector<std::future<std::optional<openlr2::IRRankResult>>> mDiscardedResultIrFutures;

--- a/LR2/LR2_customir.h
+++ b/LR2/LR2_customir.h
@@ -47,15 +47,16 @@ public:
 	// \retval nullopt - Fail
 	std::optional<openlr2::IRGhostResult> TryGetTargetInfo(const char* songmd5, int mode, int targetPlayerId);
 
+	// XXX: we should support fetching several IRs at once.
 	struct RivalSyncTask {
-		int id{};
 		std::string name;
 		std::future<std::optional<std::vector<openlr2::IRRivalScore>>> result;
+		int id{};
 	};
 	struct RivalSyncBatch {
 		std::string providerName;
-		bool supported{};
 		std::vector<RivalSyncTask> tasks;
+		bool supported{};
 	};
 	// Caller: only when getRival. Returns async work; call ApplyRivalSyncResults after wait or soft skip.
 	RivalSyncBatch SyncRivals();
@@ -63,12 +64,12 @@ public:
 	// Success writes LR2files/CustomIRRival/<provider>/ and records rival ids/paths on this manager
 	bool ApplyRivalSyncResults(RivalSyncBatch& sync);
 	// Set only after successful ApplyRivalSyncResults. Empty = not active for this rival; use legacy LR2files/Rival.
-	[[nodiscard]] static std::optional<std::filesystem::path> RivalPath(int rivalId);
+	[[nodiscard]] static std::optional<std::filesystem::path> RivalPath(int rivalId); // XXX: must not be 'static'
 	// Copies CustomIR rival ids into rivalsOut (zero-filled first). Returns false if none active.
-	[[nodiscard]] static bool CopyRivalIds(std::span<int> rivalsOut);
+	[[nodiscard]] static bool CopyRivalIds(std::span<int> rivalsOut); // XXX: must not be 'static'
 
 private:
-	static std::vector<std::pair<int, std::filesystem::path>> sRivalPaths;
+	static std::vector<std::pair<int, std::filesystem::path>> sRivalPaths; // XXX: must not be 'static'
 	std::vector<std::shared_ptr<CustomIR>> mModules;
 	std::vector<std::future<void>> mSendThreads;
 	std::vector<std::future<std::optional<openlr2::IRRankResult>>> mDiscardedResultIrFutures;

--- a/LR2/LR2_customir.h
+++ b/LR2/LR2_customir.h
@@ -47,21 +47,26 @@ public:
 	// \retval nullopt - Fail
 	std::optional<openlr2::IRGhostResult> TryGetTargetInfo(const char* songmd5, int mode, int targetPlayerId);
 
-	// XXX: we should support fetching several IRs at once.
 	struct RivalSyncTask {
 		std::string name;
 		std::future<std::optional<std::vector<openlr2::IRRivalScore>>> result;
 		int id{};
 	};
-	struct RivalSyncBatch {
+	struct RivalSyncProvider {
 		std::string providerName;
 		std::vector<RivalSyncTask> tasks;
-		bool supported{};
+		bool listOk{}; // GetRivals succeeded for this provider
 	};
-	// Caller: only when getRival. Returns async work; call ApplyRivalSyncResults after wait or soft skip.
+	struct RivalSyncBatch {
+		std::vector<RivalSyncProvider> providers;
+		[[nodiscard]] bool HasTasks() const;
+	};
+	// Caller: only when getRival. Syncs every logged-in CustomIR that supports rivals.
+	// Returns async work; call ApplyRivalSyncResults after wait or soft skip.
 	RivalSyncBatch SyncRivals();
 	// Applies ready tasks only. Incomplete futures are parked (soft skip / no WinHTTP abort).
-	// Success writes LR2files/CustomIRRival/<provider>/ and records rival ids/paths on this manager
+	// Writes LR2files/CustomIRRival/<provider>/ for every provider; mRivalPaths only for display IR.
+	// Returns true if the display IR GetRivals succeeded (active CustomIR rival folders).
 	bool ApplyRivalSyncResults(RivalSyncBatch& sync);
 	// Set only after successful ApplyRivalSyncResults. Empty = not active for this rival; use legacy LR2files/Rival.
 	[[nodiscard]] std::optional<std::filesystem::path> RivalPath(int rivalId) const;

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <array>
-#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -249,9 +248,6 @@ struct IRRivalInfo {
 	std::string name;
 };
 
-// Soft cap for GetRivals / SyncRivals. Raise this when callers (e.g. jukebox) support more.
-constexpr std::size_t kMaxRivals = 20;
-
 // One rival score row. Field names match legacy LR2IR XML / Stellaverse JSON.
 struct IRRivalScore {
 	std::string hash;
@@ -269,7 +265,6 @@ struct IRRivalScore {
 };
 
 struct IRRivalListResult {
-	// Capped by OpenLR2 at openlr2::kMaxRivals when syncing.
 	std::vector<IRRivalInfo> rivals;
 	uint64_t fetched_at{};
 };
@@ -305,6 +300,9 @@ struct MethodTable {
 	// This is called synchronously when F5 or the IR button is pressed in song-select.
 	// \retval "" - error or inapplicable.
 	std::string(OLR2_IR_API* GetWebRankingUrl)(char const* songHash) = nullptr;
+	// XXX: just some food for thought: should we introduce a `size_t MethodTableSize` here?
+	// '_trailing_field_to_increase_struct_size' is not cool, it's never too late to make things better.
+	//
 	// Called synchronously during startup rival sync (same window as legacy LR2IR_GetRivalInfo).
 	// nullptr = module does not support CustomIR rivals.
 	openlr2::GetStatus(OLR2_IR_API* GetRivals)(openlr2::IRRivalListResult& out) = nullptr;

--- a/LR2/LR2_customir_api.h
+++ b/LR2/LR2_customir_api.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -243,6 +244,36 @@ enum class GetStatus: int {
 	Fail,
 };
 
+struct IRRivalInfo {
+	int id{};
+	std::string name;
+};
+
+// Soft cap for GetRivals / SyncRivals. Raise this when callers (e.g. jukebox) support more.
+constexpr std::size_t kMaxRivals = 20;
+
+// One rival score row. Field names match legacy LR2IR XML / Stellaverse JSON.
+struct IRRivalScore {
+	std::string hash;
+	int clear{};
+	int notes{};
+	int combo{};
+	int pg{};
+	int gr{};
+	int gd{};
+	int bd{};
+	int pr{};
+	int minbp{};
+	int option{};
+	uint64_t lastupdate{};
+};
+
+struct IRRivalListResult {
+	// Capped by OpenLR2 at openlr2::kMaxRivals when syncing.
+	std::vector<IRRivalInfo> rivals;
+	uint64_t fetched_at{};
+};
+
 } // namespace openlr2
 
 struct MethodTable {
@@ -274,6 +305,14 @@ struct MethodTable {
 	// This is called synchronously when F5 or the IR button is pressed in song-select.
 	// \retval "" - error or inapplicable.
 	std::string(OLR2_IR_API* GetWebRankingUrl)(char const* songHash) = nullptr;
+	// Called synchronously during startup rival sync (same window as legacy LR2IR_GetRivalInfo).
+	// nullptr = module does not support CustomIR rivals.
+	openlr2::GetStatus(OLR2_IR_API* GetRivals)(openlr2::IRRivalListResult& out) = nullptr;
+	// Called per rival after GetRivals.
+	// lastUpdateHint: optional; OpenLR2 passes max r_lastupdate from its rival DB when available.
+	// The module may use it only to skip HTTP / read its private cache.
+	// On Ok: out is a complete snapshot of that rival's scores. OpenLR2 writes .db and .lr2folder.
+	openlr2::GetStatus(OLR2_IR_API* SyncRivalScores)(int rivalId, uint64_t lastUpdateHint, std::vector<openlr2::IRRivalScore>& out) = nullptr;
 	// Forward compatibility.
 	// This field will always be moved to the end of the struct when new fields are added.
 	// Thanks to this CustomIR module designed for newer game version won't write out-of-bounds memory when assigning fields of older MethodTable.

--- a/LR2/LR2_ir.cpp
+++ b/LR2/LR2_ir.cpp
@@ -670,7 +670,7 @@ int NETWORK::GetRanking(CSTR hash, char flagInit) {
 	return 1;
 }
 
-int NETWORK::GetRivalInfo(int rivalID) {
+int NETWORK::LR2IR_GetRivalInfo(int rivalID) {
 	CSTR pathXML;
 	cstrSprintf(&pathXML, fs::make_preferred("LR2files/Rival/%d.xml").data(), rivalID);
 	CSTR pathDB;
@@ -973,7 +973,7 @@ int NETWORK::LR2IR_Login(int isDirectPlay) {
 					ErrorLogFmtAdd("ライバル登録されています:%d\n", this->rivals[cur]); //TOFIX: 
 					this->rivals[cur] = csv.val[2+cur];
 					this->rivalcount++;
-					this->GetRivalInfo(this->rivals[cur]);
+					this->LR2IR_GetRivalInfo(this->rivals[cur]);
 					if (!this->getRival) break;
 				}
 			}

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -4,6 +4,7 @@
 #include "filesystem.h"
 #include "filesystem.h"
 #include <algorithm>
+#include <cassert>
 #include <cstring>
 #include <filesystem>
 #include <iterator>
@@ -2063,6 +2064,7 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 		isRival = 1;
 		SQL_Run("DETACH rivaldb", sql);
 		CSTR str;
+		// XXX: CUSTOMIR_MANAGER needs to be passed in as an argument
 		if (const auto rivalPath = CUSTOMIR_MANAGER::RivalPath(rivalID)) {
 			cstrSprintf(&str, "ATTACH \'file:%s?mode=ro\' AS rivaldb", std::filesystem::path{*rivalPath}.concat(".db").generic_string().c_str());
 		} else {
@@ -2844,6 +2846,7 @@ int LoadLR2CustomFolder(sqlite3 *sql, CONFIG_JUKEBOX *jb, CSTR scoreDBpath, char
 
 			for (int i = 0; i < 20; i++) {
 				if (jb->rival[i] < 1) break;
+				// XXX: CUSTOMIR_MANAGER needs to be passed in as an argument
 				if (const auto rivalPath = CUSTOMIR_MANAGER::RivalPath(jb->rival[i])) {
 					std::filesystem::path folderPath = *rivalPath;
 					folderPath += ".lr2folder";

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -2031,7 +2031,7 @@ int GetFolderDataFromPath(CSTR path, sqlite3 *sql) {
 }
 
 // TODO : rename variables
-int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *diffFilter, int *mode, uint sort, int rivalID, char flag) {
+int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *diffFilter, int *mode, uint sort, int rivalID, char flag, CUSTOMIR_MANAGER& customIR) {
 
 	sqlite3_stmt *pStmt;
 	int lastreadDiff{};
@@ -2064,8 +2064,7 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 		isRival = 1;
 		SQL_Run("DETACH rivaldb", sql);
 		CSTR str;
-		// XXX: CUSTOMIR_MANAGER needs to be passed in as an argument
-		if (const auto rivalPath = CUSTOMIR_MANAGER::RivalPath(rivalID)) {
+		if (const auto rivalPath = customIR.RivalPath(rivalID)) {
 			cstrSprintf(&str, "ATTACH \'file:%s?mode=ro\' AS rivaldb", std::filesystem::path{*rivalPath}.concat(".db").generic_string().c_str());
 		} else {
 			cstrSprintf(&str, fs::make_preferred("ATTACH \'LR2files/Rival/%d.db\' AS rivaldb").data(), rivalID);
@@ -2568,7 +2567,7 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 			}
 			ErrorLogFmtAdd("難度を変更します。　%d→%d\n", diffCycle, *diffFilter);
 			flag = 0;
-			return LoadFilteredBmsListFromDB(queryCpy, sql, ss, diffFilter, mode, sort, rivalID, flag);
+			return LoadFilteredBmsListFromDB(queryCpy, sql, ss, diffFilter, mode, sort, rivalID, flag, customIR);
 		}
 	}
 	else if (ss->unk5000 == 0) {
@@ -2633,7 +2632,7 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 				return -1;
 			}
 			ErrorLogFmtAdd("鍵盤数を変更します %d→%d\n", modeCycle, *mode);
-			return LoadFilteredBmsListFromDB(queryCpy, sql, ss, diffFilter, mode, sort, rivalID, flag);
+			return LoadFilteredBmsListFromDB(queryCpy, sql, ss, diffFilter, mode, sort, rivalID, flag, customIR);
 		}
 		return -1;
 	}
@@ -2681,7 +2680,7 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 }
 
 // LoadLR2CustomFolder
-int LoadLR2CustomFolder(sqlite3 *sql, CONFIG_JUKEBOX *jb, CSTR scoreDBpath, char flag_starter, char flag_direct) {
+int LoadLR2CustomFolder(sqlite3 *sql, CONFIG_JUKEBOX *jb, CSTR scoreDBpath, char flag_starter, char flag_direct, CUSTOMIR_MANAGER& customIR) {
 
 	sqlite3 *scoreDB, *tagDB;
 	char query[1024], query2[256];
@@ -2843,23 +2842,27 @@ int LoadLR2CustomFolder(sqlite3 *sql, CONFIG_JUKEBOX *jb, CSTR scoreDBpath, char
 
 		if (flag_starter == 0) {
 			SQL_Run(fs::make_preferred("DELETE FROM folder WHERE path LIKE \'LR2files/Rival/%\'").data(), sql);
+			SQL_Run(fs::make_preferred("DELETE FROM folder WHERE path LIKE \'LR2files/CustomIRRival/%\'").data(), sql);
 
-			for (int i = 0; i < 20; i++) {
-				if (jb->rival[i] < 1) break;
-				// XXX: CUSTOMIR_MANAGER needs to be passed in as an argument
-				if (const auto rivalPath = CUSTOMIR_MANAGER::RivalPath(jb->rival[i])) {
-					std::filesystem::path folderPath = *rivalPath;
+			const auto customRivals = customIR.RivalEntries();
+			if (!customRivals.empty()) {
+				for (const auto& [rivalId, rivalStem] : customRivals) {
+					if (rivalId < 1) continue;
+					std::filesystem::path folderPath = rivalStem;
 					folderPath += ".lr2folder";
-					char deleteQuery[1024];
-					sqlite3_snprintf(sizeof(deleteQuery), deleteQuery, "DELETE FROM folder WHERE path=\'%q\'", folderPath.string().c_str());
-					SQL_Run(deleteQuery, sql);
 					cstrSprintf(&jb->path[jb->numOfPath], "%s", folderPath.string().c_str());
-				} else {
-					cstrSprintf(&jb->path[jb->numOfPath], fs::make_preferred("LR2files/Rival/%d.lr2folder").data(), jb->rival[i]);
+					GetFolderDataFromPath(jb->path[jb->numOfPath], sql);
+					jb->numOfPath++;
+					folderAddCount++;
 				}
-				GetFolderDataFromPath(jb->path[jb->numOfPath], sql);
-				jb->numOfPath++;
-				folderAddCount++;
+			} else {
+				for (int i = 0; i < 20; i++) {
+					if (jb->rival[i] < 1) break;
+					cstrSprintf(&jb->path[jb->numOfPath], fs::make_preferred("LR2files/Rival/%d.lr2folder").data(), jb->rival[i]);
+					GetFolderDataFromPath(jb->path[jb->numOfPath], sql);
+					jb->numOfPath++;
+					folderAddCount++;
+				}
 			}
 
 			SQL_Run(fs::make_preferred("DELETE FROM folder WHERE path=\'LR2files/CustomFolder/newsong.lr2folder\'").data(), sql);

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -1,9 +1,11 @@
 ﻿#include "LR2_songmanage.h"
+#include "LR2_customir.h"
 #include "LR2_statlong.h"
 #include "filesystem.h"
 #include "filesystem.h"
 #include <algorithm>
 #include <cstring>
+#include <filesystem>
 #include <iterator>
 #include <ranges>
 #include <string>
@@ -2061,7 +2063,11 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 		isRival = 1;
 		SQL_Run("DETACH rivaldb", sql);
 		CSTR str;
-		cstrSprintf(&str, fs::make_preferred("ATTACH \'LR2files/Rival/%d.db\' AS rivaldb").data(), rivalID);
+		if (const auto rivalPath = CUSTOMIR_MANAGER::RivalPath(rivalID)) {
+			cstrSprintf(&str, "ATTACH \'file:%s?mode=ro\' AS rivaldb", std::filesystem::path{*rivalPath}.concat(".db").generic_string().c_str());
+		} else {
+			cstrSprintf(&str, fs::make_preferred("ATTACH \'LR2files/Rival/%d.db\' AS rivaldb").data(), rivalID);
+		}
 		SQL_Run(str, sql);
 		ss->rivalID = rivalID;
 		rivalID = 0;
@@ -2838,7 +2844,16 @@ int LoadLR2CustomFolder(sqlite3 *sql, CONFIG_JUKEBOX *jb, CSTR scoreDBpath, char
 
 			for (int i = 0; i < 20; i++) {
 				if (jb->rival[i] < 1) break;
-				cstrSprintf(&jb->path[jb->numOfPath], fs::make_preferred("LR2files/Rival/%d.lr2folder").data(), jb->rival[i]);
+				if (const auto rivalPath = CUSTOMIR_MANAGER::RivalPath(jb->rival[i])) {
+					std::filesystem::path folderPath = *rivalPath;
+					folderPath += ".lr2folder";
+					char deleteQuery[1024];
+					sqlite3_snprintf(sizeof(deleteQuery), deleteQuery, "DELETE FROM folder WHERE path=\'%q\'", folderPath.string().c_str());
+					SQL_Run(deleteQuery, sql);
+					cstrSprintf(&jb->path[jb->numOfPath], "%s", folderPath.string().c_str());
+				} else {
+					cstrSprintf(&jb->path[jb->numOfPath], fs::make_preferred("LR2files/Rival/%d.lr2folder").data(), jb->rival[i]);
+				}
 				GetFolderDataFromPath(jb->path[jb->numOfPath], sql);
 				jb->numOfPath++;
 				folderAddCount++;

--- a/LR2/LR2_songmanage.h
+++ b/LR2/LR2_songmanage.h
@@ -26,7 +26,7 @@ int ParseBMSMETA(BMSMETA * meta, CSTR filepath, char flag);
 int SearchSongsFromPath(CSTR root, sqlite3 * sql, CSTR path); //into DB
 int ReloadSongsByQuery(CSTR query, sqlite3 * sql, CONFIG_JUKEBOX * jb, ReloadProgress progress = ReloadProgress::None); //check reload condition and run
 int GetFolderDataFromPath(CSTR path, sqlite3 * sql);
-int LoadLR2CustomFolder(sqlite3 * sql, CONFIG_JUKEBOX * jb, CSTR scoreDBpath, char flag_starter, char flag_direct); //not coustomfolder only, but init DB and manage it
+int LoadLR2CustomFolder(sqlite3 * sql, CONFIG_JUKEBOX * jb, CSTR scoreDBpath, char flag_starter, char flag_direct, CUSTOMIR_MANAGER& customIR); //not coustomfolder only, but init DB and manage it
 
 int SetUndefinedDifficulty(sqlite3 * sql);
 
@@ -55,7 +55,7 @@ int LoadBmsListFromDB(CSTR query, sqlite3 * sql, SONGSELECT * ss, int * difficul
 
 int LoadFolderDataFromDB(CSTR query, SONGDATA * song, sqlite3 * sql, int difficulty, int key, int sort, int maxCount, CONFIG_SELECT * cfg_select, char flag);
 
-int LoadFilteredBmsListFromDB(CSTR query, sqlite3 * sql, SONGSELECT * ss, int * diffFilter, int * mode, uint sort, int rivalID, char flag);
+int LoadFilteredBmsListFromDB(CSTR query, sqlite3 * sql, SONGSELECT * ss, int * diffFilter, int * mode, uint sort, int rivalID, char flag, CUSTOMIR_MANAGER& customIR);
 
 namespace openlr2 {
 

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -585,9 +585,14 @@ int main(int argc, char** argv) {
 	gs.net.getRival = gs.config.network.getRival;
 	if (gs.net.getRival) {
 		auto rivalSync = gs.net.customIR.SyncRivals();
-		if (rivalSync.supported) {
+		if (rivalSync.HasTasks()) {
 			size_t i{};
-			while (!std::ranges::all_of(rivalSync.tasks, isFutureReady, &CUSTOMIR_MANAGER::RivalSyncTask::result)) {
+			const auto allTasksReady = [&] {
+				return std::ranges::all_of(rivalSync.providers, [&](const CUSTOMIR_MANAGER::RivalSyncProvider& provider) {
+					return std::ranges::all_of(provider.tasks, isFutureReady, &CUSTOMIR_MANAGER::RivalSyncTask::result);
+				});
+			};
+			while (!allTasksReady()) {
 				if (GetMouseInput()) {
 					printfDx("Skipped CustomIR rival sync.\n");
 					ScreenFlip();
@@ -596,16 +601,14 @@ int main(int argc, char** argv) {
 				}
 				if (loadingGrHandle > 0)
 					DrawExtendGraph(0, 0, resX, resY, loadingGrHandle, 0);
-				printfDx("Syncing CustomIR rivals");
-				// XXX: this syncs only one CustomIR, but it should sync every single one.
-				// We need this to later effortlessly be able to switch between several display IRs.
-				if (!rivalSync.providerName.empty()) {
-					printfDx(" (%s)", rivalSync.providerName.c_str());
-				}
-				printfDx(":\n");
+				printfDx("Syncing CustomIR rivals:\n");
 				printfDx("Hold left click to skip.\n");
-				for (auto& task : rivalSync.tasks) {
-					printfDx("%s (%d)%s\n", task.name.c_str(), task.id, isFutureReady(task.result) ? " - done!" : ellipsis(i, 3, 20).c_str());
+				for (const auto& provider : rivalSync.providers) {
+					if (provider.tasks.empty()) continue;
+					printfDx("[%s]\n", provider.providerName.c_str());
+					for (const auto& task : provider.tasks) {
+						printfDx("  %s (%d)%s\n", task.name.c_str(), task.id, isFutureReady(task.result) ? " - done!" : ellipsis(i, 3, 20).c_str());
+					}
 				}
 				ScreenFlip();
 				clsDx();

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -250,10 +250,6 @@ int main(int argc, char** argv) {
 #endif // NDEBUG
 #endif // _WIN32
 
-	// Enable URI filenames so file:...?mode=ro opens/attaches fail on missing files instead of creating them.
-	// XXX: just use SQLITE_OPEN_URI on the database we end up calling ATTACH on
-	sqlite3_config(SQLITE_CONFIG_URI, 1);
-
 	if constexpr (!is_linux()) {
 		if (!IsWindowsVersionAbove1903()) {
 			MessageBoxA(nullptr,
@@ -641,9 +637,12 @@ int main(int argc, char** argv) {
 
 	memcpy(gs.config.jukebox.rival, gs.net.rivals, 4 * 20);
 	sqlite3* sql3;
-	sqlite3_open(gs.is_starter
+	sqlite3_open_v2(gs.is_starter
 			? fs::make_preferred("LR2files/Database.db" ).data()
-			: fs::make_preferred("LR2files/Database/song.db").data(), &sql3);
+			: fs::make_preferred("LR2files/Database/song.db").data(),
+			&sql3,
+			SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_URI,
+			nullptr);
 	LoadLR2CustomFolder(sql3, &gs.config.jukebox, pathScoreDB, gs.is_starter, gs.cmd_directplay, gs.net.customIR);
 	if (gs.cmd_directplay == false) {
 		if (loadingGrHandle > 0) {

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -636,15 +636,12 @@ int main(int argc, char** argv) {
 		}
 	}
 
-	// Prefer CustomIR-owned rival ids when present; otherwise legacy NETWORK::rivals (LR2IR).
-	if (!gs.net.customIR.CopyRivalIds(gs.config.jukebox.rival)) {
-		memcpy(gs.config.jukebox.rival, gs.net.rivals, sizeof(gs.config.jukebox.rival));
-	}
+	memcpy(gs.config.jukebox.rival, gs.net.rivals, 4 * 20);
 	sqlite3* sql3;
 	sqlite3_open(gs.is_starter
 			? fs::make_preferred("LR2files/Database.db" ).data()
 			: fs::make_preferred("LR2files/Database/song.db").data(), &sql3);
-	LoadLR2CustomFolder(sql3, &gs.config.jukebox, pathScoreDB, gs.is_starter, gs.cmd_directplay);
+	LoadLR2CustomFolder(sql3, &gs.config.jukebox, pathScoreDB, gs.is_starter, gs.cmd_directplay, gs.net.customIR);
 	if (gs.cmd_directplay == false) {
 		if (loadingGrHandle > 0) {
 			DrawExtendGraph(0, 0, resX, resY, loadingGrHandle, 0);
@@ -1113,7 +1110,7 @@ int main(int argc, char** argv) {
 								gs.sSelect.stack_rivalID[gs.sSelect.cur] = 0;
 								gs.sSelect.stack_searchTitle[gs.sSelect.cur] = "検索語句を入力";
 								gs.sSelect.directory = "ROOT";
-								LoadFilteredBmsListFromDB(gs.sSelect.stack_query[gs.sSelect.cur], sql3, &gs.sSelect, &gs.config.select.difficulty, &gs.config.select.key, gs.config.select.sort, 0, 0);
+								LoadFilteredBmsListFromDB(gs.sSelect.stack_query[gs.sSelect.cur], sql3, &gs.sSelect, &gs.config.select.difficulty, &gs.config.select.key, gs.config.select.sort, 0, 0, gs.net.customIR);
 								SwapBmsList(&gs.sSelect);
 							}
 							if (gs.rec.recMode == 4) {

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -250,6 +250,9 @@ int main(int argc, char** argv) {
 #endif // NDEBUG
 #endif // _WIN32
 
+	// Enable URI filenames so file:...?mode=ro opens/attaches fail on missing files instead of creating them.
+	sqlite3_config(SQLITE_CONFIG_URI, 1);
+
 	if constexpr (!is_linux()) {
 		if (!IsWindowsVersionAbove1903()) {
 			MessageBoxA(nullptr,
@@ -578,11 +581,47 @@ int main(int argc, char** argv) {
 		}
 	}
 
+	gs.net.getRival = gs.config.network.getRival;
+	if (gs.net.getRival && gs.net.customIR.IsDisplayIrOnline()) {
+		auto rivalSync = gs.net.customIR.SyncRivals();
+		if (rivalSync.supported) {
+			size_t i{};
+			while (!std::ranges::all_of(rivalSync.tasks, isFutureReady, &CUSTOMIR_MANAGER::RivalSyncTask::result)) {
+				// Soft skip only (legacy LR2IR): leave the wait loop; do not abort module HTTP.
+				if (GetMouseInput()) {
+					printfDx("Skipped CustomIR rival sync.\n");
+					ScreenFlip();
+					clsDx();
+					break;
+				}
+				if (loadingGrHandle > 0)
+					DrawExtendGraph(0, 0, resX, resY, loadingGrHandle, 0);
+				printfDx("Syncing CustomIR rivals");
+				if (!rivalSync.providerName.empty()) {
+					printfDx(" (%s)", rivalSync.providerName.c_str());
+				}
+				printfDx(":\n");
+				printfDx("Hold left click to skip.\n");
+				for (auto& task : rivalSync.tasks) {
+					printfDx("%s (%d)%s\n", task.name.c_str(), task.id, isFutureReady(task.result) ? " - done!" : ellipsis(i, 3, 20).c_str());
+				}
+				ScreenFlip();
+				clsDx();
+				std::this_thread::sleep_for(std::chrono::milliseconds(10));
+				++i;
+			}
+		}
+		if (gs.net.customIR.ApplyRivalSyncResults(rivalSync)) {
+			ErrorLogAdd("Using CustomIR rival folders\n");
+		} else {
+			ErrorLogAdd("CustomIR rival sync failed\n");
+		}
+	}
+
 	if (gs.is_starter == 0 && gs.cmd_nosave == 0) {
 		gs.net.IR_pass = gs.config.player.pass;
 		gs.net.IR_name = gs.config.player.id;
 		gs.net.IR_passMD5 = MD5str(gs.config.player.pass);
-		gs.net.getRival = gs.config.network.getRival;
 		gs.net.IR_ID = gs.gameplay.playerstat.irid;
 		gs.net.rankingData.myID = gs.net.IR_ID;
 		if (gs.config.network.lr2ir == 1) {
@@ -594,7 +633,10 @@ int main(int argc, char** argv) {
 		}
 	}
 
-	memcpy(gs.config.jukebox.rival, gs.net.rivals, 4 * 20);
+	// Prefer CustomIR-owned rival ids when present; otherwise legacy NETWORK::rivals (LR2IR).
+	if (!gs.net.customIR.CopyRivalIds(gs.config.jukebox.rival)) {
+		memcpy(gs.config.jukebox.rival, gs.net.rivals, sizeof(gs.config.jukebox.rival));
+	}
 	sqlite3* sql3;
 	sqlite3_open(gs.is_starter
 			? fs::make_preferred("LR2files/Database.db" ).data()

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -251,6 +251,7 @@ int main(int argc, char** argv) {
 #endif // _WIN32
 
 	// Enable URI filenames so file:...?mode=ro opens/attaches fail on missing files instead of creating them.
+	// XXX: just use SQLITE_OPEN_URI on the database we end up calling ATTACH on
 	sqlite3_config(SQLITE_CONFIG_URI, 1);
 
 	if constexpr (!is_linux()) {
@@ -582,12 +583,11 @@ int main(int argc, char** argv) {
 	}
 
 	gs.net.getRival = gs.config.network.getRival;
-	if (gs.net.getRival && gs.net.customIR.IsDisplayIrOnline()) {
+	if (gs.net.getRival) {
 		auto rivalSync = gs.net.customIR.SyncRivals();
 		if (rivalSync.supported) {
 			size_t i{};
 			while (!std::ranges::all_of(rivalSync.tasks, isFutureReady, &CUSTOMIR_MANAGER::RivalSyncTask::result)) {
-				// Soft skip only (legacy LR2IR): leave the wait loop; do not abort module HTTP.
 				if (GetMouseInput()) {
 					printfDx("Skipped CustomIR rival sync.\n");
 					ScreenFlip();
@@ -597,6 +597,8 @@ int main(int argc, char** argv) {
 				if (loadingGrHandle > 0)
 					DrawExtendGraph(0, 0, resX, resY, loadingGrHandle, 0);
 				printfDx("Syncing CustomIR rivals");
+				// XXX: this syncs only one CustomIR, but it should sync every single one.
+				// We need this to later effortlessly be able to switch between several display IRs.
 				if (!rivalSync.providerName.empty()) {
 					printfDx(" (%s)", rivalSync.providerName.c_str());
 				}
@@ -607,6 +609,7 @@ int main(int argc, char** argv) {
 				}
 				ScreenFlip();
 				clsDx();
+				ClsDrawScreen();
 				std::this_thread::sleep_for(std::chrono::milliseconds(10));
 				++i;
 			}

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1540,7 +1540,7 @@ void CheckNewSong(glb_dbgame *glb) {
 			flag = SearchCourseFromDB(glb->pSql, &glb->pGame->sSelect, glb->pGame->sSelect.filterKey, 2);
 		}
 		else if (glb->pGame->sSelect.curQuery[i].findStrPos("FROM song") > 0) {
-			flag = LoadFilteredBmsListFromDB(glb->pGame->sSelect.curQuery[i], glb->pSql, &glb->pGame->sSelect, &glb->pGame->sSelect.filterDifficulty, &glb->pGame->sSelect.filterKey, glb->pGame->sSelect.filterSort, glb->pGame->sSelect.searchMax, glb->pGame->sSelect.unk4fc4[i]);
+			flag = LoadFilteredBmsListFromDB(glb->pGame->sSelect.curQuery[i], glb->pSql, &glb->pGame->sSelect, &glb->pGame->sSelect.filterDifficulty, &glb->pGame->sSelect.filterKey, glb->pGame->sSelect.filterSort, glb->pGame->sSelect.searchMax, glb->pGame->sSelect.unk4fc4[i], glb->pGame->net.customIR);
 		}
 		else {
 			flag = LoadBmsListFromDB(glb->pGame->sSelect.curQuery[i], glb->pSql, &glb->pGame->sSelect, &glb->pGame->sSelect.filterDifficulty, &glb->pGame->sSelect.filterKey, glb->pGame->sSelect.filterSort, glb->pGame->sSelect.searchMax);

--- a/LR2/Scene11_Po4select.cpp
+++ b/LR2/Scene11_Po4select.cpp
@@ -252,7 +252,7 @@ int ProcI_PO4Select(game *g, sqlite3 *sql) { //not tested
 					g->sSelect.stack_searchTitle[g->sSelect.cur] = "検索語句を入力";
 					g->sSelect.directory = "ROOT";
 					int t = g->po4cur_song + 2;
-					LoadFilteredBmsListFromDB(g->sSelect.stack_query[g->sSelect.cur], sql, &g->sSelect, &t, &g->config.select.key, 1, 0, 0);
+					LoadFilteredBmsListFromDB(g->sSelect.stack_query[g->sSelect.cur], sql, &g->sSelect, &t, &g->config.select.key, 1, 0, 0, g->net.customIR);
 					SwapBmsList(&g->sSelect);
 					SetTransColor(0, 255, 0);
 

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1585,7 +1585,7 @@ struct NETWORK {
 	void WaitForRankingHandle();
 	int GetRanking(CSTR hash, char flagInit);
 
-	int GetRivalInfo(int ID_rival);
+	int LR2IR_GetRivalInfo(int ID_rival);
 
 	int LR2IR_GetTargetInfo(int mode, CSTR songmd5, CSTR * oStr1, CSTR * oStr2, int * oDigit1, int * oDigit2, int * oDigit3, int * oDigit4, int * oUnk, int * oExscore);
 	bool GetTargetInfo(int mode, CSTR songmd5, CSTR * oStr1, CSTR * oStr2, int * oDigit1, int * oDigit2, int * oDigit3, int * oDigit4, int * oUnk, int * oExscore);


### PR DESCRIPTION
This feature will carry out the work of allowing the existing RIVAL folder to be used via Custom IR.

While it follows the legacy logic of the existing LR2IR as is, unlike the previous logic which retrieved data in XML format, anyone implementing a Custom IR can choose to create it in either XML or JSON format. This is highly similar to the existing GetResultRank logic.

~~I have added sqlite3.c to ExampleIR.cpp. Since the actual rival folder reads from the DB, the actual example now requires sqlite3.c as well.~~