### PR TITLE
fix(result): fix typo in GAS gauge switch condition blocking it

### DIFF
--- a/LR2/Scene05_Result.cpp
+++ b/LR2/Scene05_Result.cpp
@@ -226,7 +226,7 @@ static bool fWaitHiScoreUpdateInput = false;
 int ProcI_Result(game *g) {
 
 	auto switch_gauge_display = [](gameplay& gameplay, int buttonVal, PLAYERSTATUS& player) {
-		if (buttonVal == 1 && player.gaugeType != OPTION_GAUGE_PATTACK) {
+		if (buttonVal == 1 && player.gaugeType != OPTION_GAUGE_GATTACK) {
 			int& gauge = player.gaugeType;
 			if (gameplay.courseType != 2) [[likely]] {
 				switch (gauge) {


### PR DESCRIPTION
Fixes: 1ed630fb02e3 ("refactor: use OPTION_GAUGE enum for missing hardcoded value")