### PR TITLE
Fix play config restore when leaving replay before it starts

### DIFF
--- a/LR2/LR2_replay.cpp
+++ b/LR2/LR2_replay.cpp
@@ -734,8 +734,8 @@ int ReplayDataToInput(ReplayData *data, game *g, AUDIO *aud, gameplay *gp, input
 
 int SetReplayConfig(REPLAY *re, game *g, AUDIO *aud, gameplay *gp, inputStructure *in, Timer *T) {
 	
-	re->cfg = g->config.play;
-	re->aud = aud->param;
+	re->playConfigBackupBeforeWatchingReplay = g->config.play;
+	re->audioParamBackupBeforeWatchingReplay = aud->param;
 
 	while (re->count < re->max && re->data[re->count].timing == 0) {
 		ReplayDataToInput(&re->data[re->count], g, aud, gp, in, T);

--- a/LR2/LR2_replay.cpp
+++ b/LR2/LR2_replay.cpp
@@ -734,8 +734,8 @@ int ReplayDataToInput(ReplayData *data, game *g, AUDIO *aud, gameplay *gp, input
 
 int SetReplayConfig(REPLAY *re, game *g, AUDIO *aud, gameplay *gp, inputStructure *in, Timer *T) {
 	
-	memcpy(&re->cfg, &g->config.play, sizeof(CONFIG_PLAY));
-	memcpy(&re->aud, &aud->param, sizeof(AUDIO_PARAM));
+	re->cfg = g->config.play;
+	re->aud = aud->param;
 
 	while (re->count < re->max && re->data[re->count].timing == 0) {
 		ReplayDataToInput(&re->data[re->count], g, aud, gp, in, T);

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -424,7 +424,7 @@ int main(int argc, char** argv) {
 	gs.config.select.titleflash = gs.config.jukebox.titleflash;
 	if (gs.config.play.bga == 3) gs.config.play.bga = 1;
 	if (gs.config.select.disableDifficultyFilter) gs.config.select.ignoreDifficultyAll = false;
-	memcpy(&gs.sSelect.filter, &gs.config.select, sizeof(CONFIG_SELECT));
+	gs.sSelect.filter = gs.config.select;
 	{
 		CSTR newPath;
 		std::error_code ec; // ignore errors
@@ -1525,7 +1525,7 @@ int main(int argc, char** argv) {
 					if (gs.net.rankingData.showRanking == 0) {
 						if (gs.sSelect.stack_query[gs.sSelect.cur].findStrPos("__RIVAL__") >= 0) {
 							gs.net.rankingData.target_ID = gs.sSelect.stack_rivalID[gs.sSelect.cur];
-							memcpy(&gs.gameplay.targetCfg, &gs.config.play, sizeof(CONFIG_PLAY)); // need check
+							gs.gameplay.targetCfg = gs.config.play; // TODO: GOMazk: need check
 							if (gs.config.play.battle == OPTION_BATTLE_GBATTLE && gs.sSelect.bmsList[gs.sSelect.cur_song].keymode < 8) gs.gameplay.ghostBattle = 1;
 							gs.config.play.battle = OPTION_BATTLE_OFF;
 						}
@@ -1534,7 +1534,7 @@ int main(int argc, char** argv) {
 						}
 					}
 					else {
-						memcpy(&gs.gameplay.targetCfg, &gs.config.play, sizeof(CONFIG_PLAY)); // need check
+						gs.gameplay.targetCfg = gs.config.play; // TODO: GOMazk: need check
 						if (gs.config.play.battle == OPTION_BATTLE_GBATTLE && gs.sSelect.bmsList[gs.sSelect.cur_song].keymode < 8) gs.gameplay.ghostBattle = 1;
 						gs.config.play.battle = OPTION_BATTLE_OFF;
 						gs.net.rankingData.target_ID = gs.net.rankingData.ranking[gs.sSelect.cur_song].id;
@@ -1665,10 +1665,10 @@ int main(int argc, char** argv) {
 
 					ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 					if (gs.net.rankingData.target_ID != 0) {
-						memcpy(&gs.config.play, &gs.gameplay.targetCfg, sizeof(CONFIG_PLAY));
+						gs.config.play = gs.gameplay.targetCfg;
 					}
 					if (gs.gameplay.replay.status == 2) {
-						memcpy(&gs.config.play, &gs.gameplay.replay.cfg, sizeof(CONFIG_PLAY));
+						gs.config.play = gs.gameplay.replay.cfg;
 						ReleaseReplayBuffer(&gs.gameplay.replay);
 						gs.audio.param.eq_gain[0] = gs.gameplay.replay.aud.eq_gain[0];
 						gs.audio.param.eq_gain[1] = gs.gameplay.replay.aud.eq_gain[1];

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -1665,33 +1665,50 @@ int main(int argc, char** argv) {
 
 					ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 					if (gs.net.rankingData.target_ID != 0) {
-						gs.config.play = gs.gameplay.playConfigBackupBeforeTargetSomething;
+						if(auto& backup = gs.gameplay.playConfigBackupBeforeTargetSomething)
+						{
+							gs.config.play = *backup;
+							backup.reset();
+						} else {
+							ErrorLogAdd("BUG: playConfigBackupBeforeTargetSomething is not filled but was supposed to");
+						}
 					}
 					if (gs.gameplay.replay.status == 2) {
-						gs.config.play = gs.gameplay.replay.playConfigBackupBeforeWatchingReplay;
-						ReleaseReplayBuffer(&gs.gameplay.replay);
-						gs.audio.param.eq_gain[0] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.eq_gain[0];
-						gs.audio.param.eq_gain[1] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.eq_gain[1];
-						gs.audio.param.eq_gain[3] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.eq_gain[3];
-						gs.audio.param.eq_gain[4] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.eq_gain[4];
-						gs.audio.param.eq_gain[2] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.eq_gain[2];
-						gs.audio.param.eq_gain[6] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.eq_gain[6];
-						gs.audio.param.eq_on = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.eq_on;
-						gs.audio.param.eq_gain[5] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.eq_gain[5];
-						for (int i = 0; i < 3; i++) {
-							gs.audio.param.fxParam[i][PLAYER_1] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.fxParam[i][PLAYER_1];
-							gs.audio.param.fxParam[i][PLAYER_2] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.fxParam[i][PLAYER_2];
-							gs.audio.param.fxChannel[i] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.fxChannel[i];
-							gs.audio.param.fxType[i] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.fxType[i];
-							gs.audio.param.fx_on[i] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.fx_on[i];
+						if(auto& backup = gs.gameplay.replay.playConfigBackupBeforeWatchingReplay) {
+							gs.config.play = *backup;
+							backup.reset();
+						} else {
+							ErrorLogAdd("BUG: playConfigBackupBeforeWatchingReplay is not filled but was supposed to");
 						}
-						gs.audio.param.pitch_on = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.pitch_on;
-						gs.audio.param.pitch_type = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.pitch_type;
-						gs.audio.param.volume_BGM = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.volume_BGM;
-						gs.audio.param.pitch_amount = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.pitch_amount;
-						gs.audio.param.volume_key = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.volume_key;
-						gs.audio.param.fx_volume_on = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.fx_volume_on;
-						gs.audio.param.volume_master = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.volume_master;
+						ReleaseReplayBuffer(&gs.gameplay.replay);
+						if(auto& backup = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay)
+						{
+							gs.audio.param.eq_gain[0] = backup->eq_gain[0];
+							gs.audio.param.eq_gain[1] = backup->eq_gain[1];
+							gs.audio.param.eq_gain[3] = backup->eq_gain[3];
+							gs.audio.param.eq_gain[4] = backup->eq_gain[4];
+							gs.audio.param.eq_gain[2] = backup->eq_gain[2];
+							gs.audio.param.eq_gain[6] = backup->eq_gain[6];
+							gs.audio.param.eq_on = backup->eq_on;
+							gs.audio.param.eq_gain[5] = backup->eq_gain[5];
+							for (int i = 0; i < 3; i++) {
+								gs.audio.param.fxParam[i][PLAYER_1] = backup->fxParam[i][PLAYER_1];
+								gs.audio.param.fxParam[i][PLAYER_2] = backup->fxParam[i][PLAYER_2];
+								gs.audio.param.fxChannel[i] = backup->fxChannel[i];
+								gs.audio.param.fxType[i] = backup->fxType[i];
+								gs.audio.param.fx_on[i] = backup->fx_on[i];
+							}
+							gs.audio.param.pitch_on = backup->pitch_on;
+							gs.audio.param.pitch_type = backup->pitch_type;
+							gs.audio.param.volume_BGM = backup->volume_BGM;
+							gs.audio.param.pitch_amount = backup->pitch_amount;
+							gs.audio.param.volume_key = backup->volume_key;
+							gs.audio.param.fx_volume_on = backup->fx_volume_on;
+							gs.audio.param.volume_master = backup->volume_master;
+							backup.reset();
+						} else {
+							ErrorLogAdd("BUG: audioParamBackupBeforeWatchingReplay is not filled but was supposed to");
+						}
 						ApplySoundFX(&gs.audio, 1, gs.config.sound.disableDSP);
 					}
 					else if (gs.gameplay.replay.status == 1) {

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -978,12 +978,6 @@ int main(int argc, char** argv) {
 
 			switch (gs.procSelecter) {
 				case SCENE_SELECT:
-					if (gs.gameplay.replay.status == 2) {
-						memcpy(&gs.config.play, &gs.gameplay.replay.cfg, sizeof(CONFIG_PLAY));
-					}
-					if (gs.net.rankingData.target_ID != 0) {
-						memcpy(&gs.config.play, &gs.gameplay.targetCfg, sizeof(CONFIG_PLAY));
-					}
 					gs.gameplay.ghostBattle = 0;
 					ReadKeyConfig(&gs, (!gs.config.select.control)
 							? fs::make_preferred("LR2files/Config/keyconfig.xml" ).data()
@@ -1670,7 +1664,11 @@ int main(int argc, char** argv) {
 					}
 
 					ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
+					if (gs.net.rankingData.target_ID != 0) {
+						memcpy(&gs.config.play, &gs.gameplay.targetCfg, sizeof(CONFIG_PLAY));
+					}
 					if (gs.gameplay.replay.status == 2) {
+						memcpy(&gs.config.play, &gs.gameplay.replay.cfg, sizeof(CONFIG_PLAY));
 						ReleaseReplayBuffer(&gs.gameplay.replay);
 						gs.audio.param.eq_gain[0] = gs.gameplay.replay.aud.eq_gain[0];
 						gs.audio.param.eq_gain[1] = gs.gameplay.replay.aud.eq_gain[1];

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -1525,7 +1525,7 @@ int main(int argc, char** argv) {
 					if (gs.net.rankingData.showRanking == 0) {
 						if (gs.sSelect.stack_query[gs.sSelect.cur].findStrPos("__RIVAL__") >= 0) {
 							gs.net.rankingData.target_ID = gs.sSelect.stack_rivalID[gs.sSelect.cur];
-							gs.gameplay.targetCfg = gs.config.play; // TODO: GOMazk: need check
+							gs.gameplay.playConfigBackupBeforeTargetSomething = gs.config.play; // TODO: GOMazk: need check
 							if (gs.config.play.battle == OPTION_BATTLE_GBATTLE && gs.sSelect.bmsList[gs.sSelect.cur_song].keymode < 8) gs.gameplay.ghostBattle = 1;
 							gs.config.play.battle = OPTION_BATTLE_OFF;
 						}
@@ -1534,7 +1534,7 @@ int main(int argc, char** argv) {
 						}
 					}
 					else {
-						gs.gameplay.targetCfg = gs.config.play; // TODO: GOMazk: need check
+						gs.gameplay.playConfigBackupBeforeTargetSomething = gs.config.play; // TODO: GOMazk: need check
 						if (gs.config.play.battle == OPTION_BATTLE_GBATTLE && gs.sSelect.bmsList[gs.sSelect.cur_song].keymode < 8) gs.gameplay.ghostBattle = 1;
 						gs.config.play.battle = OPTION_BATTLE_OFF;
 						gs.net.rankingData.target_ID = gs.net.rankingData.ranking[gs.sSelect.cur_song].id;
@@ -1665,33 +1665,33 @@ int main(int argc, char** argv) {
 
 					ReadKeyConfig(&gs, fs::make_preferred("LR2files/Config/keyconfig.xml").data());
 					if (gs.net.rankingData.target_ID != 0) {
-						gs.config.play = gs.gameplay.targetCfg;
+						gs.config.play = gs.gameplay.playConfigBackupBeforeTargetSomething;
 					}
 					if (gs.gameplay.replay.status == 2) {
-						gs.config.play = gs.gameplay.replay.cfg;
+						gs.config.play = gs.gameplay.replay.playConfigBackupBeforeWatchingReplay;
 						ReleaseReplayBuffer(&gs.gameplay.replay);
-						gs.audio.param.eq_gain[0] = gs.gameplay.replay.aud.eq_gain[0];
-						gs.audio.param.eq_gain[1] = gs.gameplay.replay.aud.eq_gain[1];
-						gs.audio.param.eq_gain[3] = gs.gameplay.replay.aud.eq_gain[3];
-						gs.audio.param.eq_gain[4] = gs.gameplay.replay.aud.eq_gain[4];
-						gs.audio.param.eq_gain[2] = gs.gameplay.replay.aud.eq_gain[2];
-						gs.audio.param.eq_gain[6] = gs.gameplay.replay.aud.eq_gain[6];
-						gs.audio.param.eq_on = gs.gameplay.replay.aud.eq_on;
-						gs.audio.param.eq_gain[5] = gs.gameplay.replay.aud.eq_gain[5];
+						gs.audio.param.eq_gain[0] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.eq_gain[0];
+						gs.audio.param.eq_gain[1] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.eq_gain[1];
+						gs.audio.param.eq_gain[3] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.eq_gain[3];
+						gs.audio.param.eq_gain[4] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.eq_gain[4];
+						gs.audio.param.eq_gain[2] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.eq_gain[2];
+						gs.audio.param.eq_gain[6] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.eq_gain[6];
+						gs.audio.param.eq_on = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.eq_on;
+						gs.audio.param.eq_gain[5] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.eq_gain[5];
 						for (int i = 0; i < 3; i++) {
-							gs.audio.param.fxParam[i][PLAYER_1] = gs.gameplay.replay.aud.fxParam[i][PLAYER_1];
-							gs.audio.param.fxParam[i][PLAYER_2] = gs.gameplay.replay.aud.fxParam[i][PLAYER_2];
-							gs.audio.param.fxChannel[i] = gs.gameplay.replay.aud.fxChannel[i];
-							gs.audio.param.fxType[i] = gs.gameplay.replay.aud.fxType[i];
-							gs.audio.param.fx_on[i] = gs.gameplay.replay.aud.fx_on[i];
+							gs.audio.param.fxParam[i][PLAYER_1] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.fxParam[i][PLAYER_1];
+							gs.audio.param.fxParam[i][PLAYER_2] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.fxParam[i][PLAYER_2];
+							gs.audio.param.fxChannel[i] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.fxChannel[i];
+							gs.audio.param.fxType[i] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.fxType[i];
+							gs.audio.param.fx_on[i] = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.fx_on[i];
 						}
-						gs.audio.param.pitch_on = gs.gameplay.replay.aud.pitch_on;
-						gs.audio.param.pitch_type = gs.gameplay.replay.aud.pitch_type;
-						gs.audio.param.volume_BGM = gs.gameplay.replay.aud.volume_BGM;
-						gs.audio.param.pitch_amount = gs.gameplay.replay.aud.pitch_amount;
-						gs.audio.param.volume_key = gs.gameplay.replay.aud.volume_key;
-						gs.audio.param.fx_volume_on = gs.gameplay.replay.aud.fx_volume_on;
-						gs.audio.param.volume_master = gs.gameplay.replay.aud.volume_master;
+						gs.audio.param.pitch_on = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.pitch_on;
+						gs.audio.param.pitch_type = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.pitch_type;
+						gs.audio.param.volume_BGM = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.volume_BGM;
+						gs.audio.param.pitch_amount = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.pitch_amount;
+						gs.audio.param.volume_key = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.volume_key;
+						gs.audio.param.fx_volume_on = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.fx_volume_on;
+						gs.audio.param.volume_master = gs.gameplay.replay.audioParamBackupBeforeWatchingReplay.volume_master;
 						ApplySoundFX(&gs.audio, 1, gs.config.sound.disableDSP);
 					}
 					else if (gs.gameplay.replay.status == 1) {

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -2816,9 +2816,7 @@ int CreateRandomCourse(game *g, sqlite3 *sql, char playing) {
 			break;
 	}
 
-	CONFIG_COURSE tCfg;
-
-	memcpy(&tCfg, &g->config.course, sizeof(CONFIG_COURSE));
+	CONFIG_COURSE tCfg = g->config.course;
 
 	if (WriteRandomCourse(sql, &g->sSelect.course, &g->sSelect, tCfg, key) == 1) {
 		g->sSelect.is_coursemaking_done = 1;

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1260,8 +1260,8 @@ struct REPLAY {
 	int max{};
 	int count{};
 	int status{}; /* 0:off 1:recording 2:playing */
-	struct CONFIG_PLAY cfg;
-	struct AUDIO_PARAM aud;
+	CONFIG_PLAY playConfigBackupBeforeWatchingReplay;
+	AUDIO_PARAM audioParamBackupBeforeWatchingReplay;
 };
 
 struct EXTENDEDPLAYERSTATS {
@@ -1471,7 +1471,7 @@ struct gameplay {
 	int bpmChangedRealtime; /* timer142 */
 	int bpmChangedBmstime; /* bpm change timing */
 	char ghostBattle;
-	struct CONFIG_PLAY targetCfg; /* //1p_speed ~ struct */
+	CONFIG_PLAY playConfigBackupBeforeTargetSomething;
 	int delayDetectedCount;
 	int delayCheckCount;
 	char isCourse; 

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1260,8 +1260,8 @@ struct REPLAY {
 	int max{};
 	int count{};
 	int status{}; /* 0:off 1:recording 2:playing */
-	CONFIG_PLAY playConfigBackupBeforeWatchingReplay;
-	AUDIO_PARAM audioParamBackupBeforeWatchingReplay;
+	std::optional<CONFIG_PLAY> playConfigBackupBeforeWatchingReplay;
+	std::optional<AUDIO_PARAM> audioParamBackupBeforeWatchingReplay;
 };
 
 struct EXTENDEDPLAYERSTATS {
@@ -1471,7 +1471,7 @@ struct gameplay {
 	int bpmChangedRealtime; /* timer142 */
 	int bpmChangedBmstime; /* bpm change timing */
 	char ghostBattle;
-	CONFIG_PLAY playConfigBackupBeforeTargetSomething;
+	std::optional<CONFIG_PLAY> playConfigBackupBeforeTargetSomething;
 	int delayDetectedCount;
 	int delayCheckCount;
 	char isCourse; 

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1088,7 +1088,6 @@ struct AUDIO_PARAM {
 	int volume_key{};
 	int volume_BGM{};
 	int volume_master{};
-	double unk4e0[5]{};
 	double stagePitch[5]{};
 	double stageBgmVolume[5]{};
 	double stageKeyVolume[5]{};


### PR DESCRIPTION
Fixes https://github.com/GOMazk/OpenLR2/issues/246 "Launching and
quitting watching replay before letting play start resets play config".
See commit messages for juicy details.