### PR TITLE
Dynamic skinnable panels

### DIFF
--- a/LR2/En_timer.cpp
+++ b/LR2/En_timer.cpp
@@ -82,10 +82,8 @@ double GetTimeWrap(void) {
 }
 
 int InitTimer(Timer *T) {
-	//GetTimeWrap() call seems replaced by compiler
-	T->clock[0] = -1.0;
-	for (int i = 0; i < 499; i++) {
-		T->clock[i + 1] = T->clock[i];
+	for (int i = 0; i < TIMER_MAX; i++) {
+		T->clock[i] = -1.;
 	}
 
 	T->scratch = GetTimeWrap();
@@ -112,7 +110,7 @@ int CalcFPS(Timer *t){
 }
 
 double GetTimeLapse(uint timerID, Timer *T) {
-	if (500 < timerID) return -1.0;
+	if (timerID >= TIMER_MAX) return -1.0;
 	if (timerID == 140) return T->Rhythm;
 
 	if (T->clock[timerID] == -1.0) return -1.0;

--- a/LR2/LR2_panels.cpp
+++ b/LR2/LR2_panels.cpp
@@ -1,18 +1,35 @@
 #include "LR2_panels.h"
+#include "LR2_skindraw.h"
+#include "En_timer.h"
 #include <DxLib.h>
 #include <ranges>
 #include <optional>
 #include <algorithm>
 
-static auto is_pointer_legit = []<typename T>(const T* ptr, const std::vector<T>& arr) {
+static auto is_ptr_legit = []<typename T>(const T* ptr, const std::vector<T>& arr) {
 	if (ptr < arr.data()) return false;
 	if (ptr >= arr.data() + arr.size()) return false;
 	if ((reinterpret_cast<uintptr_t>(ptr) - reinterpret_cast<uintptr_t>(arr.data())) % sizeof(T) != 0) return false;
 	return true;
 };
 
-size_t PanelManager::GetIdx(Panel* ptr) {
-	if (is_pointer_legit(ptr, mPanels)) return ptr - mPanels.data();
+static auto is_idx_legit = []<typename T>(size_t idx, const std::vector<T>&arr) {
+	if (idx >= arr.size()) return false;
+	return true;
+};
+
+void PanelManager::Panel::Open() {
+	mIsActive = true;
+	mTimer = GetTimeWrap();
+}
+
+void PanelManager::Panel::Close() {
+	mIsActive = false;
+	mTimer = -1.;
+}
+
+size_t PanelManager::GetIdx(const Panel* ptr) {
+	if (is_ptr_legit(ptr, mPanels)) return ptr - mPanels.data();
 	return 0;
 }
 
@@ -33,6 +50,9 @@ bool PanelManager::IterateMaster(bool plus) {
 	auto next = get_next(mCurrentMaster, mPanels, plus);
 	while (next->mMaster) next = get_next(mCurrentMaster, mPanels, plus);
 	if (next == mCurrentMaster) return false;
+	mCurrentMaster->Close();
+	mCurrentPanel->Close();
+	next->Open();
 	mCurrentMaster = next;
 	mCurrentPanel = mCurrentMaster;
 	return true;
@@ -42,6 +62,7 @@ bool PanelManager::IterateSlave(bool plus) {
 	if (mCurrentMaster->mSlaves.empty()) return false;
 	if (mCurrentPanel == mCurrentMaster) {
 		mCurrentPanel = const_cast<Panel*>(mCurrentMaster->mSlaves[0]);
+		mCurrentPanel->Open();
 		return true;
 	}
 	auto get_next = []<typename T>(T* now, std::vector<const T*>&arr, bool plus) {
@@ -57,12 +78,14 @@ bool PanelManager::IterateSlave(bool plus) {
 		return next;
 	};
 	auto next = get_next(mCurrentPanel, mCurrentMaster->mSlaves, plus);
+	mCurrentPanel->Close();
 	if (next == mCurrentPanel) {
 		mCurrentPanel = mCurrentMaster;
 	}
 	else {
 		mCurrentPanel = const_cast<Panel*>(next);
 	}
+	mCurrentPanel->Open();
 	return true;
 }
 
@@ -93,14 +116,30 @@ bool PanelManager::Toggle() {
 }
 
 bool PanelManager::Open() {
-	if (mCurrentMaster == nullptr) return false;
+	if (mCurrentMaster == nullptr || mCurrentPanel == nullptr) return false;
 	mIsActive = true;
+	mCurrentMaster->Open();
+	mCurrentPanel->Open();
 	return true;
 }
 
 bool PanelManager::Close() {
 	mIsActive = false;
+	if (mCurrentMaster) mCurrentMaster->Close();
+	if (mCurrentPanel) mCurrentPanel->Close();
 	return true;
+}
+
+bool PanelManager::IsPanelActive(size_t id) {
+	id -= 10;
+	if (!is_idx_legit(id, mPanels)) return false;
+	return mPanels[id].mIsActive;
+}
+
+double PanelManager::GetTimer(size_t id) {
+	id -= 10;
+	if (!is_idx_legit(id, mPanels)) return -1.;
+	return mPanels[id].mTimer;
 }
 
 bool PanelManager::AddPanel(const SRCstruct& src) {
@@ -113,8 +152,7 @@ bool PanelManager::AddPanel(const SRCstruct& src) {
 		std::optional<size_t> ret = {};
 		if (src.op1) {
 			size_t masterIdx = src.op1 - 10;
-			if (masterIdx > 49) return ret;
-			if (masterIdx >= mPanels.size()) return ret;
+			if (!is_idx_legit(masterIdx, mPanels)) return ret;
 			if (mPanels[masterIdx].mMaster) return ret;
 			return ret = masterIdx;
 		}
@@ -136,10 +174,19 @@ bool PanelManager::AddPanel(const SRCstruct& src) {
 	return true;
 }
 
+bool PanelManager::BindButton(SRCstruct* src) {
+	size_t idx = src->op3 - 10;
+	if (!is_idx_legit(idx, mPanels)) return false;
+	auto& panel = mPanels[idx];
+	if (panel.mMaster) src->op3 = GetIdx(panel.mMaster) + 10;
+	mPanels[idx].mBoundButtons.push_back(src);
+	return true;
+}
+
 PanelManager::Panel::Panel(Panel&& other) noexcept {
 	std::swap(mMaster, other.mMaster);
 	std::swap(mSlaves, other.mSlaves);
-	std::swap(mButtonSlaves, other.mButtonSlaves);
+	std::swap(mBoundButtons, other.mBoundButtons);
 	std::swap(mSRC, other.mSRC);
 	std::swap(mDST, other.mDST);
 	std::swap(mTimer, other.mTimer);
@@ -157,4 +204,29 @@ PanelManager::Panel::~Panel() {
 DSTstruct* PanelManager::GetLastDST() {
 	if (mIsIgnoreDST) return nullptr;
 	return &mPanels.back().mDST;
+}
+
+void PanelManager::Draw(DrawingBuf* drb) {
+	auto AddDrawingBuffer_Panel = [&](const SRCstruct& src, const DSTstruct& dst, double timer) {
+		if (dst.dstCount <= 0 || dst.dataSize <= 0) return;
+		double timeLapse = timer >= 0. ? GetTimeWrap() - timer : -1.;
+		DSTdraw tDstd = SetDSTdrawByTime(dst, timeLapse);
+
+		if (tDstd.time != -1 && src.inArray < src.graphcount && src.inArray > -1) {
+			AddDrawingBuffer(drb, src.grHandles[src.inArray], &tDstd);
+		}
+	};
+	for (const auto& panel : mPanels) {
+		AddDrawingBuffer_Panel(panel.mSRC, panel.mDST, panel.mMaster ? panel.mMaster->mTimer : panel.mTimer);
+	}
+}
+
+int PanelManager::CheckInput(const SRCstruct* src, const inputStructure* input) {
+	if (mCurrentPanel == nullptr) return 0; 
+	if (!mCurrentPanel->mIsActive) return 0;
+	auto it = std::ranges::find(mCurrentPanel->mBoundButtons, src);
+	if (it == mCurrentPanel->mBoundButtons.end()) return 0;
+	auto idx = std::distance(mCurrentPanel->mBoundButtons.begin(), it);
+	if (idx > 7) return 0;
+	return input->p1_buttonInput[idx] | input->p2_buttonInput[idx];
 }

--- a/LR2/LR2_panels.cpp
+++ b/LR2/LR2_panels.cpp
@@ -1,0 +1,160 @@
+#include "LR2_panels.h"
+#include <DxLib.h>
+#include <ranges>
+#include <optional>
+#include <algorithm>
+
+static auto is_pointer_legit = []<typename T>(const T* ptr, const std::vector<T>& arr) {
+	if (ptr < arr.data()) return false;
+	if (ptr >= arr.data() + arr.size()) return false;
+	if ((reinterpret_cast<uintptr_t>(ptr) - reinterpret_cast<uintptr_t>(arr.data())) % sizeof(T) != 0) return false;
+	return true;
+};
+
+size_t PanelManager::GetIdx(Panel* ptr) {
+	if (is_pointer_legit(ptr, mPanels)) return ptr - mPanels.data();
+	return 0;
+}
+
+bool PanelManager::IterateMaster(bool plus) {
+	if (mPanels.empty()) return false;
+	auto get_next = []<typename T>(T* now, std::vector<T>&arr, bool plus) {
+		auto iterate_plus = [&](T* now) {
+			if (now == arr.data() + arr.size() - 1) return &arr[0];
+			return now + 1;
+		};
+		auto iterate_minus = [&](T* now) {
+			if (now == arr.data()) return arr.data() + arr.size() - 1;
+			return now - 1;
+		};
+		auto next = plus ? iterate_plus(now) : iterate_minus(now);
+		return next;
+	};
+	auto next = get_next(mCurrentMaster, mPanels, plus);
+	while (next->mMaster) next = get_next(mCurrentMaster, mPanels, plus);
+	if (next == mCurrentMaster) return false;
+	mCurrentMaster = next;
+	mCurrentPanel = mCurrentMaster;
+	return true;
+}
+
+bool PanelManager::IterateSlave(bool plus) {
+	if (mCurrentMaster->mSlaves.empty()) return false;
+	if (mCurrentPanel == mCurrentMaster) {
+		mCurrentPanel = const_cast<Panel*>(mCurrentMaster->mSlaves[0]);
+		return true;
+	}
+	auto get_next = []<typename T>(T* now, std::vector<const T*>&arr, bool plus) {
+		auto iterate_plus = [&](T* now) {
+			if (now == *(arr.data() + arr.size() - 1)) return arr[0];
+			return *(std::ranges::find(arr, now) + 1);
+		};
+		auto iterate_minus = [&](T* now) {
+			if (now == *arr.data()) return *(arr.data() + arr.size() - 1);
+			return *(std::ranges::find(arr, now) - 1);
+		};
+		auto next = plus ? iterate_plus(now) : iterate_minus(now);
+		return next;
+	};
+	auto next = get_next(mCurrentPanel, mCurrentMaster->mSlaves, plus);
+	if (next == mCurrentPanel) {
+		mCurrentPanel = mCurrentMaster;
+	}
+	else {
+		mCurrentPanel = const_cast<Panel*>(next);
+	}
+	return true;
+}
+
+bool PanelManager::NextPanel() {
+	return IterateMaster(true);
+}
+
+bool PanelManager::PrevPanel() {
+	return IterateMaster(false);
+}
+
+bool PanelManager::NextSubPanel() {
+	return IterateSlave(true);
+}
+
+bool PanelManager::PrevSubPanel() {
+	return IterateSlave(false);
+}
+
+bool PanelManager::Toggle() {
+	if (!mIsActive) {
+		return Open();
+	}
+	else {
+		Close();
+		return false;
+	}
+}
+
+bool PanelManager::Open() {
+	if (mCurrentMaster == nullptr) return false;
+	mIsActive = true;
+	return true;
+}
+
+bool PanelManager::Close() {
+	mIsActive = false;
+	return true;
+}
+
+bool PanelManager::AddPanel(const SRCstruct& src) {
+	auto fail = [&]() {
+		mIsIgnoreDST = true;
+		return false;
+	};
+	if (mPanels.size() == CUSTOM_PANELS_MAX) return fail();
+	auto masterIdx = [&]() {
+		std::optional<size_t> ret = {};
+		if (src.op1) {
+			size_t masterIdx = src.op1 - 10;
+			if (masterIdx > 49) return ret;
+			if (masterIdx >= mPanels.size()) return ret;
+			if (mPanels[masterIdx].mMaster) return ret;
+			return ret = masterIdx;
+		}
+		return ret;
+	}();
+	if (src.op1 && !masterIdx) return fail();
+	auto& panel = mPanels.emplace_back();
+	panel.mSRC = src;
+	if (masterIdx) {
+		auto& master = mPanels[*masterIdx];
+		panel.mMaster = &master;
+		master.mSlaves.push_back(&panel);
+	}
+	if (mPanels.size() == 1) {
+		mCurrentMaster = &panel;
+		mCurrentPanel = &panel;
+	}
+	mIsIgnoreDST = false;
+	return true;
+}
+
+PanelManager::Panel::Panel(Panel&& other) noexcept {
+	std::swap(mMaster, other.mMaster);
+	std::swap(mSlaves, other.mSlaves);
+	std::swap(mButtonSlaves, other.mButtonSlaves);
+	std::swap(mSRC, other.mSRC);
+	std::swap(mDST, other.mDST);
+	std::swap(mTimer, other.mTimer);
+	std::swap(mIsActive, other.mIsActive);
+}
+
+PanelManager::Panel::~Panel() {
+	for (int i = 0; i < mSRC.graphcount; i++) {
+		DeleteGraph(mSRC.grHandles[i]);
+	}
+	free(mSRC.grHandles);
+	free(mDST.draw);
+}
+
+DSTstruct* PanelManager::GetLastDST() {
+	if (mIsIgnoreDST) return nullptr;
+	return &mPanels.back().mDST;
+}

--- a/LR2/LR2_panels.cpp
+++ b/LR2/LR2_panels.cpp
@@ -222,7 +222,7 @@ void PanelManager::Draw(DrawingBuf* drb) {
 	}
 }
 
-int PanelManager::CheckInput(const SRCstruct* src, const inputStructure* input) {
+int PanelManager::CheckButton(const SRCstruct* src, const inputStructure* input) {
 	if (mCurrentPanel == nullptr) return 0; 
 	if (!mCurrentPanel->mIsActive) return 0;
 	auto it = std::ranges::find(mCurrentPanel->mBoundButtons, src);

--- a/LR2/LR2_panels.cpp
+++ b/LR2/LR2_panels.cpp
@@ -21,17 +21,23 @@ static auto is_idx_legit = []<typename T>(size_t idx, const std::vector<T>&arr) 
 
 void PanelManager::Panel::Open() {
 	mIsActive = true;
-	mTimer = GetTimeWrap();
+	*mTimerOpen = GetTimeWrap();
+	*mTimerClose = -1.;
 }
 
 void PanelManager::Panel::Close() {
 	mIsActive = false;
-	mTimer = -1.;
+	*mTimerOpen = -1.;
+	*mTimerClose = GetTimeWrap();
 }
 
 size_t PanelManager::GetIdx(const Panel* ptr) {
 	if (is_ptr_legit(ptr, mPanels)) return ptr - mPanels.data();
 	return 0;
+}
+
+Timer* PanelManager::GetTimersPtr() {
+	return mTimers;
 }
 
 bool PanelManager::IterateMaster(bool plus) {
@@ -137,12 +143,6 @@ bool PanelManager::IsPanelActive(size_t id) {
 	return mPanels[id].mIsActive;
 }
 
-double PanelManager::GetTimer(size_t id) {
-	id -= 10;
-	if (!is_idx_legit(id, mPanels)) return -1.;
-	return mPanels[id].mTimer;
-}
-
 bool PanelManager::AddPanel(const SRCstruct& src) {
 	auto fail = [&]() {
 		mIsIgnoreDST = true;
@@ -160,8 +160,11 @@ bool PanelManager::AddPanel(const SRCstruct& src) {
 		return ret;
 	}();
 	if (src.op1 && !masterIdx) return fail();
+	size_t panelIdx = mPanels.size();
 	auto& panel = mPanels.emplace_back();
 	panel.mSRC = src;
+	panel.mTimerOpen = &mTimers->clock[500 + panelIdx];
+	panel.mTimerClose = &mTimers->clock[500 + CUSTOM_PANELS_MAX + panelIdx];
 	if (masterIdx) {
 		auto& master = mPanels[*masterIdx];
 		panel.mMaster = &master;
@@ -190,7 +193,8 @@ PanelManager::Panel::Panel(Panel&& other) noexcept {
 	std::swap(mBoundButtons, other.mBoundButtons);
 	std::swap(mSRC, other.mSRC);
 	std::swap(mDST, other.mDST);
-	std::swap(mTimer, other.mTimer);
+	std::swap(mTimerOpen, other.mTimerOpen);
+	std::swap(mTimerClose, other.mTimerClose);
 	std::swap(mIsActive, other.mIsActive);
 }
 
@@ -218,7 +222,7 @@ void PanelManager::Draw(DrawingBuf* drb) {
 		}
 	};
 	for (const auto& panel : mPanels) {
-		AddDrawingBuffer_Panel(panel.mSRC, panel.mDST, panel.mMaster ? panel.mMaster->mTimer : panel.mTimer);
+		AddDrawingBuffer_Panel(panel.mSRC, panel.mDST, panel.mMaster ? *panel.mMaster->mTimerOpen : *panel.mTimerOpen);
 	}
 }
 

--- a/LR2/LR2_panels.cpp
+++ b/LR2/LR2_panels.cpp
@@ -1,6 +1,7 @@
 #include "LR2_panels.h"
 #include "LR2_skindraw.h"
 #include "En_timer.h"
+#include "En_audio.h"
 #include <DxLib.h>
 #include <ranges>
 #include <optional>
@@ -226,7 +227,33 @@ int PanelManager::CheckInput(const SRCstruct* src, const inputStructure* input) 
 	if (!mCurrentPanel->mIsActive) return 0;
 	auto it = std::ranges::find(mCurrentPanel->mBoundButtons, src);
 	if (it == mCurrentPanel->mBoundButtons.end()) return 0;
-	auto idx = std::distance(mCurrentPanel->mBoundButtons.begin(), it);
+	auto idx = std::distance(mCurrentPanel->mBoundButtons.begin(), it) + 1;
 	if (idx > 7) return 0;
 	return input->p1_buttonInput[idx] | input->p2_buttonInput[idx];
+}
+
+bool PanelManager::RunSelectorInput(const inputStructure* input, AUDIO* audio) {
+	auto button = [&](size_t idx) {
+		return input->p1_buttonInput[idx] | input->p2_buttonInput[idx];
+	};
+	auto play = [&](SOUNDDATA* sound) {
+		PlaySound(audio, sound, audio->chnKey, -1);
+	};
+	if (!mIsActive) {
+		if ((button(12) == 1 || button(12) == 2) && button(13) == 1) {
+			if (Open()) {
+				play(&audio->sysSound.panel_open);
+				return true;
+			}
+		}
+	}
+	else {
+		if (button(13) == 0 && button(12) == 1 && Close()) play(&audio->sysSound.panel_close);
+		if (button(12) == 0 && button(13) == 1 && NextPanel()) play(&audio->sysSound.difficulty);
+		if (button(13) == 2 && button(12) == 1 && PrevPanel()) play(&audio->sysSound.difficulty);
+		if (button(10) == 1 && PrevSubPanel()) play(&audio->sysSound.scratch);
+		if (button(11) == 1 && NextSubPanel()) play(&audio->sysSound.scratch);
+		return true;
+	}
+	return false;
 }

--- a/LR2/LR2_panels.cpp
+++ b/LR2/LR2_panels.cpp
@@ -143,26 +143,21 @@ bool PanelManager::IsPanelActive(size_t id) {
 	return mPanels[id].mIsActive;
 }
 
-bool PanelManager::AddPanel(const SRCstruct& src) {
-	auto fail = [&]() {
-		mIsIgnoreDST = true;
-		return false;
-	};
-	if (mPanels.size() == CUSTOM_PANELS_MAX) return fail();
+bool PanelManager::AddPanel(const CSVbuf& csv) {
+	if (mPanels.size() == CUSTOM_PANELS_MAX) return false;
 	auto masterIdx = [&]() {
 		std::optional<size_t> ret = {};
-		if (src.op1) {
-			size_t masterIdx = src.op1 - 10;
+		if (csv.val[1]) {
+			size_t masterIdx = csv.val[1] - 10;
 			if (!is_idx_legit(masterIdx, mPanels)) return ret;
 			if (mPanels[masterIdx].mMaster) return ret;
 			return ret = masterIdx;
 		}
 		return ret;
 	}();
-	if (src.op1 && !masterIdx) return fail();
+	if (csv.val[1] && !masterIdx) return false;
 	size_t panelIdx = mPanels.size();
 	auto& panel = mPanels.emplace_back();
-	panel.mSRC = src;
 	panel.mTimerOpen = &mTimers->clock[500 + panelIdx];
 	panel.mTimerClose = &mTimers->clock[500 + CUSTOM_PANELS_MAX + panelIdx];
 	if (masterIdx) {
@@ -170,11 +165,11 @@ bool PanelManager::AddPanel(const SRCstruct& src) {
 		panel.mMaster = &master;
 		master.mSlaves.push_back(&panel);
 	}
+	panel.mIsSelectable = csv.val[2] > 0;
 	if (mPanels.size() == 1) {
 		mCurrentMaster = &panel;
 		mCurrentPanel = &panel;
 	}
-	mIsIgnoreDST = false;
 	return true;
 }
 
@@ -185,45 +180,6 @@ bool PanelManager::BindButton(SRCstruct* src) {
 	if (panel.mMaster) src->op3 = GetIdx(panel.mMaster) + 10;
 	mPanels[idx].mBoundButtons.push_back(src);
 	return true;
-}
-
-PanelManager::Panel::Panel(Panel&& other) noexcept {
-	std::swap(mMaster, other.mMaster);
-	std::swap(mSlaves, other.mSlaves);
-	std::swap(mBoundButtons, other.mBoundButtons);
-	std::swap(mSRC, other.mSRC);
-	std::swap(mDST, other.mDST);
-	std::swap(mTimerOpen, other.mTimerOpen);
-	std::swap(mTimerClose, other.mTimerClose);
-	std::swap(mIsActive, other.mIsActive);
-}
-
-PanelManager::Panel::~Panel() {
-	for (int i = 0; i < mSRC.graphcount; i++) {
-		DeleteGraph(mSRC.grHandles[i]);
-	}
-	free(mSRC.grHandles);
-	free(mDST.draw);
-}
-
-DSTstruct* PanelManager::GetLastDST() {
-	if (mIsIgnoreDST) return nullptr;
-	return &mPanels.back().mDST;
-}
-
-void PanelManager::Draw(DrawingBuf* drb) {
-	auto AddDrawingBuffer_Panel = [&](const SRCstruct& src, const DSTstruct& dst, double timer) {
-		if (dst.dstCount <= 0 || dst.dataSize <= 0) return;
-		double timeLapse = timer >= 0. ? GetTimeWrap() - timer : -1.;
-		DSTdraw tDstd = SetDSTdrawByTime(dst, timeLapse);
-
-		if (tDstd.time != -1 && src.inArray < src.graphcount && src.inArray > -1) {
-			AddDrawingBuffer(drb, src.grHandles[src.inArray], &tDstd);
-		}
-	};
-	for (const auto& panel : mPanels) {
-		AddDrawingBuffer_Panel(panel.mSRC, panel.mDST, panel.mMaster ? *panel.mMaster->mTimerOpen : *panel.mTimerOpen);
-	}
 }
 
 int PanelManager::CheckButton(const SRCstruct* src, const inputStructure* input) {

--- a/LR2/LR2_panels.h
+++ b/LR2/LR2_panels.h
@@ -5,66 +5,10 @@
 constexpr size_t CUSTOM_PANELS_MAX = 50;
 
 struct inputStructure;
-struct DrawingBuf;
 struct AUDIO;
 struct Timer;
-
-struct DSTdraw { /* 80bytes,4*0x14 */
-	float x{ 0 };
-	float y{ 0 };
-	float w{ 0 };
-	float h{ 0 };
-	int sortID{ 0 };
-	int time{ -1 };
-	int acc{ 0 };
-	int blend{ 0 };
-	int filter{ 0 };
-	int a{ 0 };
-	int r{ 0 };
-	int g{ 0 };
-	int b{ 0 };
-	float angle{ 0 };
-	int center{ 0 };
-	int grHandle{ -1 };
-	int fontHandle{ -1 };
-	int subHandle{ -1 };
-	int align{ 0 };
-	char isDrawBackbox{ 0 };
-};
-
-struct DSTstruct { /* 44bytes.4*0x0b */
-	int n; /* (NULL) on file */
-	int opt1; /* dst_option */
-	int opt2; /* and dst_option */
-	int opt3; /* and dst_option */
-	int opt4; /* scratch */
-	int opt5;
-	int timer;
-	struct DSTdraw* draw;
-	int dataSize;
-	int loop;
-	int dstCount;
-};
-
-struct SRCstruct { /* 68bytes,4*0x11 */
-	int n; /* (NULL) in file */
-	int* grHandles; /* =fontHandle */
-	int graphcount;
-	int cycle; /* =font */
-	int op1;
-	int op2;
-	int op3;
-	int op4;
-	int op5;
-	int count;
-	int timer;
-	int fontHandle;
-	int align;
-	int st;
-	int inArray;
-	int sx;
-	int sy;
-};
+struct SRCstruct;
+struct CSVbuf;
 
 class PanelManager {
 private:
@@ -73,21 +17,13 @@ private:
 		const Panel* mMaster = nullptr;
 		std::vector<const Panel*> mSlaves;
 		std::vector<const SRCstruct*> mBoundButtons;
-		SRCstruct mSRC{};
-		DSTstruct mDST{};
 		double* mTimerOpen = nullptr;
 		double* mTimerClose = nullptr;
 		bool mIsActive = false;
+		bool mIsSelectable = false;
 
 		void Open();
 		void Close();
-
-		Panel() = default;
-		Panel(const Panel&) = delete;
-		Panel& operator=(const Panel&) = delete;
-		Panel& operator=(Panel&&) = delete;
-		Panel(Panel&&) noexcept;
-		~Panel();
 	};
 	size_t GetIdx(const Panel* ptr);
 	std::vector<Panel> mPanels;
@@ -95,7 +31,6 @@ private:
 	Panel* mCurrentMaster = nullptr;
 	Panel* mCurrentPanel = nullptr;
 	bool mIsActive = false;
-	bool mIsIgnoreDST = true;
 
 	bool IterateMaster(bool plus);
 	bool IterateSlave(bool plus);
@@ -115,10 +50,8 @@ public:
 	// Range 500-549 for open timers, 550-599 for close timers.
 	Timer* GetTimersPtr();
 
-	bool AddPanel(const SRCstruct& src);
+	bool AddPanel(const CSVbuf& csv);
 	bool BindButton(SRCstruct* src);
-	DSTstruct* GetLastDST();
-	void Draw(DrawingBuf* drb);
 	int CheckButton(const SRCstruct* src, const inputStructure* input);
 	bool RunSelectorInput(const inputStructure* input, AUDIO* audio);
 

--- a/LR2/LR2_panels.h
+++ b/LR2/LR2_panels.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <vector>
+
+constexpr size_t CUSTOM_PANELS_MAX = 50;
+
+struct DSTdraw { /* 80bytes,4*0x14 */
+	float x{ 0 };
+	float y{ 0 };
+	float w{ 0 };
+	float h{ 0 };
+	int sortID{ 0 };
+	int time{ -1 };
+	int acc{ 0 };
+	int blend{ 0 };
+	int filter{ 0 };
+	int a{ 0 };
+	int r{ 0 };
+	int g{ 0 };
+	int b{ 0 };
+	float angle{ 0 };
+	int center{ 0 };
+	int grHandle{ -1 };
+	int fontHandle{ -1 };
+	int subHandle{ -1 };
+	int align{ 0 };
+	char isDrawBackbox{ 0 };
+};
+
+struct DSTstruct { /* 44bytes.4*0x0b */
+	int n; /* (NULL) on file */
+	int opt1; /* dst_option */
+	int opt2; /* and dst_option */
+	int opt3; /* and dst_option */
+	int opt4; /* scratch */
+	int opt5;
+	int timer;
+	struct DSTdraw* draw;
+	int dataSize;
+	int loop;
+	int dstCount;
+};
+
+struct SRCstruct { /* 68bytes,4*0x11 */
+	int n; /* (NULL) in file */
+	int* grHandles; /* =fontHandle */
+	int graphcount;
+	int cycle; /* =font */
+	int op1;
+	int op2;
+	int op3;
+	int op4;
+	int op5;
+	int count;
+	int timer;
+	int fontHandle;
+	int align;
+	int st;
+	int inArray;
+	int sx;
+	int sy;
+};
+
+class PanelManager {
+private:
+	class Panel {
+	public:
+		const Panel* mMaster = nullptr;
+		std::vector<const Panel*> mSlaves;
+		std::vector<const DSTstruct*> mButtonSlaves;
+		SRCstruct mSRC{};
+		DSTstruct mDST{};
+		double mTimer = 0.;
+		bool mIsActive = false;
+
+		Panel() = default;
+		Panel(const Panel&) = delete;
+		Panel& operator=(const Panel&) = delete;
+		Panel& operator=(Panel&&) = delete;
+		Panel(Panel&&) noexcept;
+		~Panel();
+	};
+	size_t GetIdx(Panel* ptr);
+	std::vector<Panel> mPanels;
+	Panel* mCurrentMaster = nullptr;
+	Panel* mCurrentPanel = nullptr;
+	bool mIsActive = false;
+	bool mIsIgnoreDST = true;
+
+	bool IterateMaster(bool plus);
+	bool IterateSlave(bool plus);
+public:
+	bool NextPanel();
+	bool PrevPanel();
+	bool NextSubPanel();
+	bool PrevSubPanel();
+	bool Toggle();
+	bool Open();
+	bool Close();
+
+	bool IsPanelOpen(size_t id); // 'panel' param in 10-59 range
+	double GetTimer(size_t id); // 'timer' param in 500-549 range
+
+	bool AddPanel(const SRCstruct& src);
+	DSTstruct* GetLastDST();
+	void Draw();
+	void ProcessInput();
+};

--- a/LR2/LR2_panels.h
+++ b/LR2/LR2_panels.h
@@ -4,6 +4,9 @@
 
 constexpr size_t CUSTOM_PANELS_MAX = 50;
 
+struct inputStructure;
+struct DrawingBuf;
+
 struct DSTdraw { /* 80bytes,4*0x14 */
 	float x{ 0 };
 	float y{ 0 };
@@ -67,11 +70,14 @@ private:
 	public:
 		const Panel* mMaster = nullptr;
 		std::vector<const Panel*> mSlaves;
-		std::vector<const DSTstruct*> mButtonSlaves;
+		std::vector<const SRCstruct*> mBoundButtons;
 		SRCstruct mSRC{};
 		DSTstruct mDST{};
-		double mTimer = 0.;
+		double mTimer = -1.;
 		bool mIsActive = false;
+
+		void Open();
+		void Close();
 
 		Panel() = default;
 		Panel(const Panel&) = delete;
@@ -80,7 +86,7 @@ private:
 		Panel(Panel&&) noexcept;
 		~Panel();
 	};
-	size_t GetIdx(Panel* ptr);
+	size_t GetIdx(const Panel* ptr);
 	std::vector<Panel> mPanels;
 	Panel* mCurrentMaster = nullptr;
 	Panel* mCurrentPanel = nullptr;
@@ -98,11 +104,12 @@ public:
 	bool Open();
 	bool Close();
 
-	bool IsPanelOpen(size_t id); // 'panel' param in 10-59 range
+	bool IsPanelActive(size_t id); // 'panel' param in 10-59 range
 	double GetTimer(size_t id); // 'timer' param in 500-549 range
 
 	bool AddPanel(const SRCstruct& src);
+	bool BindButton(SRCstruct* src);
 	DSTstruct* GetLastDST();
-	void Draw();
-	void ProcessInput();
+	void Draw(DrawingBuf* drb);
+	int CheckInput(const SRCstruct* src, const inputStructure* input);
 };

--- a/LR2/LR2_panels.h
+++ b/LR2/LR2_panels.h
@@ -7,6 +7,7 @@ constexpr size_t CUSTOM_PANELS_MAX = 50;
 struct inputStructure;
 struct DrawingBuf;
 struct AUDIO;
+struct Timer;
 
 struct DSTdraw { /* 80bytes,4*0x14 */
 	float x{ 0 };
@@ -74,7 +75,8 @@ private:
 		std::vector<const SRCstruct*> mBoundButtons;
 		SRCstruct mSRC{};
 		DSTstruct mDST{};
-		double mTimer = -1.;
+		double* mTimerOpen = nullptr;
+		double* mTimerClose = nullptr;
 		bool mIsActive = false;
 
 		void Open();
@@ -89,6 +91,7 @@ private:
 	};
 	size_t GetIdx(const Panel* ptr);
 	std::vector<Panel> mPanels;
+	Timer* mTimers = nullptr;
 	Panel* mCurrentMaster = nullptr;
 	Panel* mCurrentPanel = nullptr;
 	bool mIsActive = false;
@@ -106,7 +109,11 @@ public:
 	bool Close();
 
 	bool IsPanelActive(size_t id); // 'panel' param in 10-59 range
-	double GetTimer(size_t id); // 'timer' param in 500-549 range
+	// PanelManager controls the timers its panels use internally,
+	// but uses global timer struct to hold them, so they can be
+	// accessed from the rest of the code normally.
+	// Range 500-549 for open timers, 550-599 for close timers.
+	Timer* GetTimersPtr();
 
 	bool AddPanel(const SRCstruct& src);
 	bool BindButton(SRCstruct* src);
@@ -114,4 +121,7 @@ public:
 	void Draw(DrawingBuf* drb);
 	int CheckButton(const SRCstruct* src, const inputStructure* input);
 	bool RunSelectorInput(const inputStructure* input, AUDIO* audio);
+
+	PanelManager() = default;
+	PanelManager(Timer* timers) : mTimers(timers) {};
 };

--- a/LR2/LR2_panels.h
+++ b/LR2/LR2_panels.h
@@ -6,6 +6,7 @@ constexpr size_t CUSTOM_PANELS_MAX = 50;
 
 struct inputStructure;
 struct DrawingBuf;
+struct AUDIO;
 
 struct DSTdraw { /* 80bytes,4*0x14 */
 	float x{ 0 };
@@ -112,4 +113,5 @@ public:
 	DSTstruct* GetLastDST();
 	void Draw(DrawingBuf* drb);
 	int CheckInput(const SRCstruct* src, const inputStructure* input);
+	bool RunSelectorInput(const inputStructure* input, AUDIO* audio);
 };

--- a/LR2/LR2_panels.h
+++ b/LR2/LR2_panels.h
@@ -112,6 +112,6 @@ public:
 	bool BindButton(SRCstruct* src);
 	DSTstruct* GetLastDST();
 	void Draw(DrawingBuf* drb);
-	int CheckInput(const SRCstruct* src, const inputStructure* input);
+	int CheckButton(const SRCstruct* src, const inputStructure* input);
 	bool RunSelectorInput(const inputStructure* input, AUDIO* audio);
 };

--- a/LR2/LR2_skindraw.cpp
+++ b/LR2/LR2_skindraw.cpp
@@ -69,7 +69,7 @@ DSTdraw DSTDbyTime(DSTdraw *dstd1, DSTdraw *dstd2, double t1, double t2, double 
 	return ret;
 }
 
-DSTdraw SetDSTdrawByTime(DSTstruct dst, double time) {
+DSTdraw SetDSTdrawByTime(const DSTstruct& dst, double time) {
 	int tStart, tEnd;
 	int t = time, t2;
 	DSTdraw oBuf{};

--- a/LR2/LR2_skindraw.h
+++ b/LR2/LR2_skindraw.h
@@ -9,7 +9,7 @@ int ReallocDrawingBuffer(DrawingBuf * drb);
 
 //calc draw position
 DSTdraw DSTDbyTime(DSTdraw * dstd1, DSTdraw * dstd2, double t1, double t2, double tO);
-DSTdraw SetDSTdrawByTime(DSTstruct dst, double time);
+DSTdraw SetDSTdrawByTime(const DSTstruct& dst, double time);
 
 //skinobj into DrawingBuf
 int GetSRCcycleNow(SRCstruct src, double time);

--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -1085,6 +1085,11 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						if (sk->otherObject[1].srcSize > 0 && (sk->otherObject[1].dst[sk->otherObject[1].srcSize - 1].dstCount < 1 || sk->otherObject[1].dst[sk->otherObject[1].srcSize - 1].dataSize < 1)) {
 							ErrorLogFmtAdd("スキン読み込みエラー %d行目\n%s\n(この行のエラーではありません)ひとつ前の#SRC_BUTTONに対応した#DST_BUTTONが存在しないか、登録に失敗したようです\n", line, fBuf.body);
 						}
+						if (csv.val[13] > 9) {
+							if (!sk->panelMan.BindButton(&sk->otherObject[1].src[sk->otherObject[1].srcSize])) {
+								ErrorLogFmtAdd("#SRC_BUTTON at line %d has invalid 'panel' param.\n", line);
+							}
+						}
 						sk->otherObject[1].srcSize++;
 						break;
 					}

--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -180,7 +180,7 @@ static int ReadSRC_BAR_TITLE(SRCstruct *src, CSVbuf *csv, skstruct *sk){
 
 
 // InitSkin
-int InitSkin(skstruct *sk, int /*unused*/, char font) {
+int InitSkin(skstruct *sk, int /*unused*/, char font, Timer* timers) {
 	SetTransColor(0, 255, 0);
 	sk->startinput_start = 0;
 	sk->startinput_rank = 0;
@@ -420,7 +420,7 @@ int InitSkin(skstruct *sk, int /*unused*/, char font) {
 		InitDST(&sk->dst_EVENT_LOADINGBG[i]);
 	}
 
-	sk->panelMan = {};
+	sk->panelMan = { timers ? timers : sk->panelMan.GetTimersPtr() }; // Forgive me Father, for I have sinned.
 
 	return 1;
 }

--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -149,7 +149,7 @@ static int ReadSRC(SRCstruct *src, CSVbuf *csv, skstruct *sk){
 				src->grHandles[i + csv->val[7]*j] = DerivationGraph(blockX*i + csv->val[3], blockY*j + csv->val[4], blockX, blockY, sk->GrHandle[csv->val[2]]);
 			}
 			else {
-				src->grHandles[i + csv->val[7]*j] =	sk->GrHandle[csv->val[2]];
+				src->grHandles[i + csv->val[7]*j] =	sk->GrHandle[csv->val[2]]; // TOFIX: Handle sharing GG.
 			}
 		}
 	}
@@ -419,6 +419,9 @@ int InitSkin(skstruct *sk, int /*unused*/, char font) {
 	for (int i = 0; i < 5; i++) {
 		InitDST(&sk->dst_EVENT_LOADINGBG[i]);
 	}
+
+	sk->panelMan = {};
+
 	return 1;
 }
 
@@ -1827,6 +1830,31 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 					}
 					case "#HORIZONTAL"_hash:{
 						sk->horizontal = 1;
+						break;
+					}
+					case "#SRC_PANEL"_hash: {
+						SplitCSV(fBuf, &csv, ",");
+						SRCstruct src{};
+						InitSRC(&src);
+						ReadSRC(&src, &csv, sk);
+						if (!sk->panelMan.AddPanel(src)) {
+							for (int i = 0; i < src.graphcount; i++) {
+								DeleteGraph(src.grHandles[i]);
+							}
+							free(src.grHandles);
+							ErrorLogFmtAdd("#SRC_PANEL at line %d ignored: Tried to exceed 50 panels or to use invalid 'panel' param.\n", line);
+						}
+						break;
+					}
+					case "#DST_PANEL"_hash: {
+						SplitCSV(fBuf, &csv, ",");
+						DSTstruct* dst = sk->panelMan.GetLastDST();
+						if (!dst) {
+							ErrorLogFmtAdd("#DST_PANEL at line %d ignored: Has no bound #SRC_PANEL.\n", line);
+							break;
+						}
+						if (dst->dstCount == 0) InitDST(dst);
+						ReadDST(dst, &csv, tSkin_num, line);
 						break;
 					}
 					}

--- a/LR2/LR2_skinload.cpp
+++ b/LR2/LR2_skinload.cpp
@@ -1837,29 +1837,11 @@ int ReadSkin(skstruct *sk,CSTR FilePath, int unused, int skin_num, SkinUser* sku
 						sk->horizontal = 1;
 						break;
 					}
-					case "#SRC_PANEL"_hash: {
+					case "#PANEL"_hash: {
 						SplitCSV(fBuf, &csv, ",");
-						SRCstruct src{};
-						InitSRC(&src);
-						ReadSRC(&src, &csv, sk);
-						if (!sk->panelMan.AddPanel(src)) {
-							for (int i = 0; i < src.graphcount; i++) {
-								DeleteGraph(src.grHandles[i]);
-							}
-							free(src.grHandles);
-							ErrorLogFmtAdd("#SRC_PANEL at line %d ignored: Tried to exceed 50 panels or to use invalid 'panel' param.\n", line);
+						if (!sk->panelMan.AddPanel(csv)) {
+							ErrorLogFmtAdd("#PANEL at line %d ignored: Tried to exceed 50 panels or to use invalid 'panel' param.\n", line);
 						}
-						break;
-					}
-					case "#DST_PANEL"_hash: {
-						SplitCSV(fBuf, &csv, ",");
-						DSTstruct* dst = sk->panelMan.GetLastDST();
-						if (!dst) {
-							ErrorLogFmtAdd("#DST_PANEL at line %d ignored: Has no bound #SRC_PANEL.\n", line);
-							break;
-						}
-						if (dst->dstCount == 0) InitDST(dst);
-						ReadDST(dst, &csv, tSkin_num, line);
 						break;
 					}
 					}

--- a/LR2/LR2_skinload.h
+++ b/LR2/LR2_skinload.h
@@ -16,7 +16,7 @@ int InitSRC(SRCstruct * src);
 int InitDST(DSTstruct * dst);
 
 //skin / scene
-int InitSkin(skstruct * sk, int p5, char font);
+int InitSkin(skstruct * sk, int p5, char font, Timer* timers = nullptr);
 bool CheckIndexRange(int index, int min, int max, int line, char * str);
 int ExpandSkinObjectMax(SkinObject * so, int add);
 int FlipSide_Timer(int * n);

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -4199,7 +4199,7 @@ int ButtonByInput(skstruct* sk, SRCstruct *src, DSTstruct *dst, Timer *T, inputS
 	if (GetTimeLapse(dst->timer, T) == -1.0) return 0;
 
 	ret = 0;
-	int customPanelInput = sk->panelMan.CheckInput(src, input);
+	int customPanelInput = sk->panelMan.CheckButton(src, input);
 	if (customPanelInput) {
 		if (src->op2 != 1 || customPanelInput != 1) ret = 1;
 		else if (min < max) {

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -4199,8 +4199,7 @@ int ButtonByInput(skstruct* sk, SRCstruct *src, DSTstruct *dst, Timer *T, inputS
 	if (GetTimeLapse(dst->timer, T) == -1.0) return 0;
 
 	ret = 0;
-	int customPanelInput = sk->panelMan.CheckButton(src, input);
-	if (customPanelInput) {
+	if (int customPanelInput = sk->panelMan.CheckButton(src, input)) {
 		if (src->op2 != 1 || customPanelInput != 1) ret = 1;
 		else if (min < max) {
 			src->op4 == 2 ? (*target)-- : (*target)++;
@@ -4208,10 +4207,14 @@ int ButtonByInput(skstruct* sk, SRCstruct *src, DSTstruct *dst, Timer *T, inputS
 		}
 	}
 	else {
+		bool isPanelActive = src->op3 == 0 ? true :
+			src->op3 < 10 ?
+			src->op3 == panel :
+			sk->panelMan.IsPanelActive(src->op3);
 		dstd = SetDSTdrawByTime(*dst, GetTimeLapse(dst->timer, T));
 		mouse = MouseOnDSTD(&dstd, &input->mouse_oldX, &input->mouse_oldY);
 		if ( (mouse == 1 && src->op4 == 0) || (mouse != 0 && src->op4 == 1) ) { // right side or plusonly
-			if (src->op2 != 1 || input->mouse_buttonL != 1 || (src->op3 != panel && src->op3 != 0)) {
+			if (src->op2 != 1 || input->mouse_buttonL != 1 || !isPanelActive) {
 				ret = 1;
 			}
 			else {
@@ -4220,7 +4223,7 @@ int ButtonByInput(skstruct* sk, SRCstruct *src, DSTstruct *dst, Timer *T, inputS
 			}
 		}
 		else if ( (mouse == 2 && src->op4 == 0) || (mouse != 0 && src->op4 == 2) ) { // left side or plusonly(-)
-			if (src->op2 != 1 || input->mouse_buttonL != 1 || (src->op3 != panel && src->op3 != 0)) {
+			if (src->op2 != 1 || input->mouse_buttonL != 1 || !isPanelActive) {
 				ret = 1;
 			}
 			else {

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -2962,7 +2962,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 			case 7:
 			case 8:
 				iTmp = (g->sSelect.panel == op);
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 1, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 1, g->sSelect.panel);
 				if (isClickSuccess == 2	&& g->sSelect.course.isMakingCourse != 1) {
 					if (g->sSelect.panel == op) {
 						g->sSelect.panel = -1;
@@ -2991,7 +2991,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 			//SongSelect Option
 			case 10:
 				iTmp = g->config.select.difficulty;
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, iTmp, iTmp, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, iTmp, iTmp, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					filterChanged = 1;
 					g->sSelect.is_clicked_filter = 1;
@@ -3002,7 +3002,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 
 			case 11:
 				iTmp = g->config.select.key;
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, iTmp, iTmp, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, iTmp, iTmp, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					filterChanged = 1;
 					g->sSelect.is_clicked_filter = 1;
@@ -3013,7 +3013,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 
 			case 12:
 				iTmp = g->config.select.sort;
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, iTmp, iTmp, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, iTmp, iTmp, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					filterChanged = 1;
 					g->sSelect.is_clicked_filter = 1;
@@ -3024,7 +3024,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 
 			//Buttons
 			case 13:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 0, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 0, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					if (g->procSelecter == 2) {
 						g->sSelect.is_clicked_keyconfig = 1;
@@ -3033,7 +3033,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 14:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 0, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 0, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					if (g->procSelecter == 2) {
 						g->sSelect.is_clicked_skinselect = 1;
@@ -3042,7 +3042,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 15:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 0, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 0, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					if (g->procSelecter == 2) {
 						if (g->sSelect.bmsList[g->sSelect.cur_song].keymode > 0 || g->sSelect.bmsList[g->sSelect.cur_song].folderType == 9) {
@@ -3054,7 +3054,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 16:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 0, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 0, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					if (g->procSelecter == 2) {
 						if (g->sSelect.bmsList[g->sSelect.cur_song].keymode > 0 || g->sSelect.bmsList[g->sSelect.cur_song].folderType == 9) {
@@ -3066,7 +3066,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 17:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 0, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 0, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					if (g->procSelecter == 2) {
 						ShowReadmes(g);
@@ -3080,7 +3080,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 18:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 0, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 0, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					if (g->procSelecter == 2) {
 						PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
@@ -3090,7 +3090,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 19:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 0, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 0, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					if (g->procSelecter == 2 && g->sSelect.bmsList[g->sSelect.cur_song].keymode > 0) {
 						g->gameplay.replay.status = 2;
@@ -3102,7 +3102,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 			
 			//Option FX
 			case 20:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.fxType[0], 0, 7, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.fxType[0], 0, 7, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					InitFxParam(g, 0);
 					if (GetTimeLapse(41, T) > 0.0 && g->gameplay.replay.status == 1) {
@@ -3113,7 +3113,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 21:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.fxType[1], 0, 7, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.fxType[1], 0, 7, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					InitFxParam(g, 1);
 					if (GetTimeLapse(41, T) > 0.0 && g->gameplay.replay.status == 1) {
@@ -3124,7 +3124,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 22:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.fxType[2], 0, 7, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.fxType[2], 0, 7, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					InitFxParam(g, 2);
 					if (GetTimeLapse(41, T) > 0.0 && g->gameplay.replay.status == 1) {
@@ -3135,7 +3135,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 23:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.fx_on[0], 0, 1, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.fx_on[0], 0, 1, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					ApplySoundFX(&g->audio, 1, g->config.sound.disableDSP);
 					if (GetTimeLapse(41, T) > 0.0 && g->gameplay.replay.status == 1) {
@@ -3146,7 +3146,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 24:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.fx_on[1], 0, 1, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.fx_on[1], 0, 1, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					ApplySoundFX(&g->audio, 1, g->config.sound.disableDSP);
 					if (GetTimeLapse(41, T) > 0.0 && g->gameplay.replay.status == 1) {
@@ -3157,7 +3157,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 25:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.fx_on[2], 0, 1, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.fx_on[2], 0, 1, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					ApplySoundFX(&g->audio, 1, g->config.sound.disableDSP);
 					if (GetTimeLapse(41, T) > 0.0 && g->gameplay.replay.status == 1) {
@@ -3168,7 +3168,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 26:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.fxChannel[0], 0, 2, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.fxChannel[0], 0, 2, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					ApplySoundFX(&g->audio, 1, g->config.sound.disableDSP);
 					if (GetTimeLapse(41, T) > 0.0 && g->gameplay.replay.status == 1) {
@@ -3179,7 +3179,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 27:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.fxChannel[1], 0, 2, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.fxChannel[1], 0, 2, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					ApplySoundFX(&g->audio, 1, g->config.sound.disableDSP);
 					if (GetTimeLapse(41, T) > 0.0 && g->gameplay.replay.status == 1) {
@@ -3190,7 +3190,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 28:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.fxChannel[2], 0, 2, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.fxChannel[2], 0, 2, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					ApplySoundFX(&g->audio, 1, g->config.sound.disableDSP);
 					if (GetTimeLapse(41, T) > 0.0 && g->gameplay.replay.status == 1) {
@@ -3201,7 +3201,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 29:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.eq_on, 0, 1, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.eq_on, 0, 1, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					ApplySoundFX(&g->audio, 1, g->config.sound.disableDSP);
 					if (GetTimeLapse(41, T) > 0.0 && g->gameplay.replay.status == 1) {
@@ -3212,14 +3212,14 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 30:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.eq_preset, 0, 5, g->sSelect.panel); //EQ_PRESET is not implemented yet
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.eq_preset, 0, 5, g->sSelect.panel); //EQ_PRESET is not implemented yet
 				if (isClickSuccess == 2) {
 					ApplySoundFX(&g->audio, 1, g->config.sound.disableDSP);
 				}
 				break;
 
 			case 31:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.fx_volume_on, 0, 1, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.fx_volume_on, 0, 1, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					ApplySoundFX(&g->audio, 1, g->config.sound.disableDSP);
 					if (GetTimeLapse(41, T) > 0.0 && g->gameplay.replay.status == 1) {
@@ -3230,7 +3230,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 32:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.pitch_on, 0, 1, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.pitch_on, 0, 1, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					ApplySoundFX(&g->audio, 1, g->config.sound.disableDSP);
 					if (GetTimeLapse(41, T) > 0.0 && g->gameplay.replay.status == 1) {
@@ -3241,7 +3241,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 33:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.pitch_type, 0, 2, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->audio.param.pitch_type, 0, 2, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					ApplySoundFX(&g->audio, 1, g->config.sound.disableDSP);
 					if (GetTimeLapse(41, T) > 0.0 && g->gameplay.replay.status == 1) {
@@ -3254,8 +3254,8 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 			//Option Play
 			case 40:
 				isClickSuccess = g->procSelecter == 4 || g->procSelecter == 5 || g->procSelecter == 13 ?
-					ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->gameplay.player[PLAYER_1].gaugeType, OPTION_GAUGE_GROOVE, OPTION_GAUGE_END, g->sSelect.panel) :
-					ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.gaugeType[PLAYER_1], OPTION_GAUGE_GROOVE, OPTION_GAUGE_END, g->sSelect.panel);
+					ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->gameplay.player[PLAYER_1].gaugeType, OPTION_GAUGE_GROOVE, OPTION_GAUGE_END, g->sSelect.panel) :
+					ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.gaugeType[PLAYER_1], OPTION_GAUGE_GROOVE, OPTION_GAUGE_END, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetObjectStrings_SongSelect(g);
@@ -3265,8 +3265,8 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 			case 41:
 				if (g->config.play.battle == OPTION_BATTLE_BATTLE) {
 					isClickSuccess = g->procSelecter == 4 || g->procSelecter == 5 || g->procSelecter == 13 ?
-						ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->gameplay.player[PLAYER_2].gaugeType, OPTION_GAUGE_GROOVE, OPTION_GAUGE_END, g->sSelect.panel) :
-						ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.gaugeType[PLAYER_2], OPTION_GAUGE_GROOVE, OPTION_GAUGE_END, g->sSelect.panel);
+						ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->gameplay.player[PLAYER_2].gaugeType, OPTION_GAUGE_GROOVE, OPTION_GAUGE_END, g->sSelect.panel) :
+						ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.gaugeType[PLAYER_2], OPTION_GAUGE_GROOVE, OPTION_GAUGE_END, g->sSelect.panel);
 					if (isClickSuccess == 2) {
 						PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 						SetObjectStrings_SongSelect(g);
@@ -3276,7 +3276,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 42:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.random[PLAYER_1], OPTION_RANDOM_OFF, OPTION_RANDOM_END, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.random[PLAYER_1], OPTION_RANDOM_OFF, OPTION_RANDOM_END, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetObjectStrings_SongSelect(g);
@@ -3284,7 +3284,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 43:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.random[PLAYER_2], OPTION_RANDOM_OFF, OPTION_RANDOM_END, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.random[PLAYER_2], OPTION_RANDOM_OFF, OPTION_RANDOM_END, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetObjectStrings_SongSelect(g);
@@ -3292,7 +3292,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 44:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.assist[PLAYER_1], 0, 1, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.assist[PLAYER_1], 0, 1, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetObjectStrings_SongSelect(g);
@@ -3300,7 +3300,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 45:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.assist[PLAYER_2], 0, 1, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.assist[PLAYER_2], 0, 1, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetObjectStrings_SongSelect(g);
@@ -3308,7 +3308,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break; 
 				
 			case 46:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.lanecover[PLAYER_1], 0, 1, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.lanecover[PLAYER_1], 0, 1, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					g->config.play.lanecover[PLAYER_2] = g->config.play.lanecover[PLAYER_1];
@@ -3317,7 +3317,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 			
 			case 50:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.m_HIDSUD[PLAYER_1], 0, 3, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.m_HIDSUD[PLAYER_1], 0, 3, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetObjectStrings_SongSelect(g);
@@ -3325,7 +3325,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 51:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.m_HIDSUD[PLAYER_2], 0, 3, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.m_HIDSUD[PLAYER_2], 0, 3, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetObjectStrings_SongSelect(g);
@@ -3334,7 +3334,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 
 			case 54:
 				iTmp = (int)g->config.play.dpFlip;
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 1, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 1, g->sSelect.panel);
 				g->config.play.dpFlip = (iTmp > 0);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
@@ -3343,7 +3343,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 55:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.hsfix, OPTION_HSFIX_OFF, OPTION_HSFIX_END, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.hsfix, OPTION_HSFIX_OFF, OPTION_HSFIX_END, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetObjectStrings_SongSelect(g);
@@ -3351,7 +3351,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 56:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.battle, OPTION_BATTLE_OFF, OPTION_BATTLE_END, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.battle, OPTION_BATTLE_OFF, OPTION_BATTLE_END, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetObjectStrings_SongSelect(g);
@@ -3360,7 +3360,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 
 			case 57:
 				iTmp = 1;
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 2, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 2, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 				}
@@ -3370,7 +3370,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 			case 58:
 				iTmp = 1;
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 2, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 2, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 				}
@@ -3381,7 +3381,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 
 			case 70:
 				iTmp = (int)g->config.play.scoreGraph;
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 1, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 1, g->sSelect.panel);
 				g->config.play.scoreGraph = (iTmp > 0);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
@@ -3390,7 +3390,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 71:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.play_ghost, 0, 3, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.play_ghost, 0, 3, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetObjectStrings_SongSelect(g);
@@ -3398,7 +3398,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 72:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.bga, 0, 2, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.bga, 0, 2, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetObjectStrings_SongSelect(g);
@@ -3406,7 +3406,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 73:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.bgasize, 0, 1, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.bgasize, 0, 1, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetObjectStrings_SongSelect(g);
@@ -3414,7 +3414,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 74:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.judgetiming, -199, 199, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.judgetiming, -199, 199, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetObjectStrings_SongSelect(g);
@@ -3422,7 +3422,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 75:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.autojudge, 0, 2, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.autojudge, 0, 2, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetObjectStrings_SongSelect(g);
@@ -3430,7 +3430,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 76:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.target_percent, 50, 100, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.target_percent, 50, 100, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetObjectStrings_SongSelect(g);
@@ -3438,7 +3438,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 77:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.p1_target, 0, 8, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.p1_target, 0, 8, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetTarget(g);
@@ -3448,7 +3448,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 
 			//Option etc
 			case 80:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.system.screenmode, 0, 2, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.system.screenmode, 0, 2, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					g->is_clicked_screenModeChange = 1;
@@ -3457,7 +3457,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 81:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.system.highcolor, 0, 1, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.system.highcolor, 0, 1, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetObjectStrings_SongSelect(g);
@@ -3465,7 +3465,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 82:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.system.vsync, 0, 1, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.system.vsync, 0, 1, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetWaitVSyncFlag(g->config.system.vsync);
@@ -3474,7 +3474,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 83:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.replay, 0, 4, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.play.replay, 0, 4, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetObjectStrings_SongSelect(g);
@@ -3482,7 +3482,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 90:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->sSelect.bmsList[g->sSelect.cur_song].favorite, 0, 2, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->sSelect.bmsList[g->sSelect.cur_song].favorite, 0, 2, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					g->sSelect.is_tag_edited = 1;
@@ -3498,7 +3498,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 			case 95:
 			case 96:
 				iTmp = g->config.select.difficulty;
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, iTmp, iTmp, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, iTmp, iTmp, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					g->sSelect.is_clicked_filter = 1;
 					g->sSelect.filter_clicked = 0;
@@ -3559,7 +3559,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 			case 138:
 			case 139:
 				iTmp = (g->KeyInput.config_button_inMap == op - 100);
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 1, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 1, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					g->KeyInput.config_button_inMap = op - 100;
@@ -3577,7 +3577,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 140:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->KeyInput.config_button, 0, 22, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->KeyInput.config_button, 0, 22, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					g->KeyInput.config_button_inMap  = ConfigButtonToKeyID7(g->KeyInput.config_button);
@@ -3586,7 +3586,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 141:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->KeyInput.config_button, 0, 11, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->KeyInput.config_button, 0, 11, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					g->KeyInput.config_button_inMap = ConfigButtonToKeyID9(g->KeyInput.config_button);
@@ -3595,7 +3595,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 142:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->KeyInput.config_button, 0, 18, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->KeyInput.config_button, 0, 18, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					g->KeyInput.config_button_inMap = ConfigButtonToKeyID5(g->KeyInput.config_button);
@@ -3604,7 +3604,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 143:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->KeyInput.config_keymode, 0, 2, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->KeyInput.config_keymode, 0, 2, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					g->KeyInput.config_button_inMap = 0;
@@ -3635,7 +3635,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 			case 157: 
 				//TOFIX : keyconfig slot is 10 but clickable button is only 8??
 				iTmp = (g->KeyInput.config_key == op - 150);
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 1, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 1, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					g->KeyInput.config_key = op - 150;
@@ -3663,7 +3663,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 			case 187:
 			case 188: {
 				iTmp = (g->skinData.select == op - 170);
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 1, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 1, g->sSelect.panel);
 				if(isClickSuccess == 2){
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					g->skinData.select = op - 170;
@@ -3718,7 +3718,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 
 			case 190: {
 				iTmp = (g->KeyInput.config_key == op - 150);
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, -1, 1, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, -1, 1, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					if (iTmp == 1) SkinPreviewNext(&g->skinData, (SKINTYPE)g->skinData.select);
@@ -3775,7 +3775,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 			}
 			case 191:
 				iTmp = (g->KeyInput.config_key == op - 150);
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 5, (g->sSelect).panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 5, (g->sSelect).panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SelectSkin(&g->skinData, g->config.skin.skinFilePath + g->skinData.select);
@@ -3791,7 +3791,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 			case 207:
 			case 208:
 			case 209:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 0, (g->sSelect).panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 0, (g->sSelect).panel);
 				if (isClickSuccess == 2) {
 					if (g->procSelecter == 2) {
 						ShowReadme(g,sk->helpfilePath[op-200]);
@@ -3805,7 +3805,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 210:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 0, (g->sSelect).panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 0, (g->sSelect).panel);
 				if (isClickSuccess == 2) {
 					if (g->procSelecter == 2) {
 						g->sSelect.is_buttonIRpage = 1;
@@ -3825,7 +3825,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 			case 229: {
 				int customIDThis = op - 220;
 				SkinCustom &customThis = g->skinData.Data[g->skinData.previewID].customs[g->skinData.previewCustomID + customIDThis];
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &customThis.dst_op_selected, customThis.dst_op_start, customThis.dst_op_start + customThis.dst_op_count -1, (g->sSelect).panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &customThis.dst_op_selected, customThis.dst_op_start, customThis.dst_op_start + customThis.dst_op_count -1, (g->sSelect).panel);
 				if (isClickSuccess == 2) {
 					SetObjectString(100 + customIDThis, customThis.title, g->txtStruct.objectStr);
 					SetObjectString(110 + customIDThis, customThis.op_label[customThis.dst_op_selected - customThis.dst_op_start], g->txtStruct.objectStr);
@@ -3859,7 +3859,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 			}
 
 			case 230:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, -1, 1, (g->sSelect).panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, -1, 1, (g->sSelect).panel);
 				if (isClickSuccess == 2) {
 					if (g->sSelect.course.count > 0 && g->sSelect.course.isMakingCourse == 1) {
 						ResetTimeLapse(17, &g->timer1);
@@ -3882,7 +3882,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 231:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, -1, 1, (g->sSelect).panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, -1, 1, (g->sSelect).panel);
 				if (isClickSuccess == 2) {
 					if (g->sSelect.course.isMakingCourse == 1) {
 						ResetTimeLapse(17, &g->timer1);
@@ -3905,7 +3905,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 			//case 232 doesn't exist
 			case 233:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, -1, 1, (g->sSelect).panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, -1, 1, (g->sSelect).panel);
 				if (isClickSuccess == 2) {
 					if (g->sSelect.bmsList[g->sSelect.cur_song].folderType == 8) {
 						g->sSelect.course.isDeletingCourse = 1;
@@ -3924,10 +3924,10 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 			case 248:
 				if (g->sSelect.bmsList[g->sSelect.cur_song].courseIR == 1 || g->sSelect.bmsList[g->sSelect.cur_song].courseType != 1) {
 					iTmp = g->sSelect.bmsList[g->sSelect.cur_song].courseKeys[op - 240];
-					isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, iTmp, iTmp, g->sSelect.panel);
+					isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, iTmp, iTmp, g->sSelect.panel);
 				}
 				else {
-					isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->sSelect.bmsList[g->sSelect.cur_song].courseKeys[op-240], 0, 5, g->sSelect.panel);
+					isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->sSelect.bmsList[g->sSelect.cur_song].courseKeys[op-240], 0, 5, g->sSelect.panel);
 					if (isClickSuccess == 2) {
 						PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 						g->sSelect.course.isCourseCreated = 1;
@@ -3940,10 +3940,10 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 			case 253:
 				if (g->sSelect.bmsList[g->sSelect.cur_song].courseIR == 1) {
 					iTmp = 1;
-					isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, iTmp, iTmp, g->sSelect.panel);
+					isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, iTmp, iTmp, g->sSelect.panel);
 				}
 				else {
-					isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->sSelect.bmsList[g->sSelect.cur_song].courseIR, 0, 1, g->sSelect.panel);
+					isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->sSelect.bmsList[g->sSelect.cur_song].courseIR, 0, 1, g->sSelect.panel);
 					if (isClickSuccess == 2) {
 						PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 						g->sSelect.course.isCourseCreated = 1;
@@ -3952,7 +3952,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 260:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.course.optimumlevel_7, 0, 99, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.course.optimumlevel_7, 0, 99, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					if (g->procSelecter == 2) {
 						PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
@@ -3961,7 +3961,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				}
 				break;
 			case 261:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.course.maxlevel, 0, 99, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.course.maxlevel, 0, 99, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					if (g->procSelecter == 2) {
 						PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
@@ -3970,7 +3970,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				}
 				break;
 			case 262:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.course.minlevel, 0, 99, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.course.minlevel, 0, 99, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					if (g->procSelecter == 2) {
 						PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
@@ -3979,7 +3979,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				}
 				break;
 			case 263:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.course.bpmrange, 0, 99, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.course.bpmrange, 0, 99, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					if (g->procSelecter == 2) {
 						PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
@@ -3989,7 +3989,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 			case 264:
 				iTmp = g->config.course.maxbpm / 10;
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 99, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 99, g->sSelect.panel);
 				g->config.course.maxbpm = iTmp * 10;
 				if (isClickSuccess == 2) {
 					if (g->procSelecter == 2) {
@@ -4000,7 +4000,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 			case 265:
 				iTmp = g->config.course.minbpm / 10;
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 99, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &iTmp, 0, 99, g->sSelect.panel);
 				g->config.course.minbpm = iTmp * 10;
 				if (isClickSuccess == 2) {
 					if (g->procSelecter == 2) {
@@ -4010,7 +4010,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				}
 				break;
 			case 266:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.course.stage, 0, 5, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.course.stage, 0, 5, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					if (g->procSelecter == 2) {
 						PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
@@ -4020,7 +4020,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 
 			case 268:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.course.defaultconnection, 0, 5, (g->sSelect).panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.course.defaultconnection, 0, 5, (g->sSelect).panel);
 				if (isClickSuccess == 2) {
 					if (g->procSelecter == 2) {
 						PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
@@ -4029,7 +4029,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				}
 				break;
 			case 400:
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.system.fullscreenfilter, 0, 2, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &g->config.system.fullscreenfilter, 0, 2, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					SetFullScreenScalingMode(g->config.system.fullscreenfilter, g->config.system.fullscreenfitstretch ? 1 : 0);
@@ -4038,7 +4038,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag) {
 				break;
 			case 401: {
 				int tmp = g->config.system.fullscreenfitstretch ? 1 : 0;
-				isClickSuccess = ButtonByInput(&sk->drBuf, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &tmp, 0, 1, g->sSelect.panel);
+				isClickSuccess = ButtonByInput(sk, &sk->otherObject[1].src[i], &sk->otherObject[1].dst[i], T, &g->KeyInput, &tmp, 0, 1, g->sSelect.panel);
 				if (isClickSuccess == 2) {
 					PlaySound(&g->audio, &g->audio.sysSound.option_change, g->audio.chnKey, -1);
 					g->config.system.fullscreenfitstretch = !g->config.system.fullscreenfitstretch;
@@ -4191,7 +4191,7 @@ int SliderByTime(DrawingBuf */*drb*/, SRCstruct *src, DSTstruct *dst, Timer *T, 
 	return 1;
 }
 
-int ButtonByInput(DrawingBuf */*drb*/, SRCstruct *src, DSTstruct *dst, Timer *T, inputStructure *input, int *target, int min, int max, int panel) { //return 1:just clicked 2:changed 0:not changed
+int ButtonByInput(skstruct* sk, SRCstruct *src, DSTstruct *dst, Timer *T, inputStructure *input, int *target, int min, int max, int panel) { //return 1:just clicked 2:changed 0:not changed
 	DSTdraw dstd;
 	int mouse, ret;
 	
@@ -4199,24 +4199,34 @@ int ButtonByInput(DrawingBuf */*drb*/, SRCstruct *src, DSTstruct *dst, Timer *T,
 	if (GetTimeLapse(dst->timer, T) == -1.0) return 0;
 
 	ret = 0;
-	dstd = SetDSTdrawByTime(*dst, GetTimeLapse(dst->timer, T));
-	mouse = MouseOnDSTD(&dstd, &input->mouse_oldX, &input->mouse_oldY);
-	if ( (mouse == 1 && src->op4 == 0) || (mouse != 0 && src->op4 == 1) ) { // right side or plusonly
-		if (src->op2 != 1 || input->mouse_buttonL != 1 || (src->op3 != panel && src->op3 != 0)) {
-			ret = 1;
-	}
-		else {
-			if (min < max) (*target)++;
+	int customPanelInput = sk->panelMan.CheckInput(src, input);
+	if (customPanelInput) {
+		if (src->op2 != 1 || customPanelInput != 1) ret = 1;
+		else if (min < max) {
+			src->op4 == 2 ? (*target)-- : (*target)++;
 			ret = 2;
 		}
 	}
-	else if ( (mouse == 2 && src->op4 == 0) || (mouse != 0 && src->op4 == 2) ) { // left side or plusonly(-)
-		if (src->op2 != 1 || input->mouse_buttonL != 1 || (src->op3 != panel && src->op3 != 0)) {
-			ret = 1;
+	else {
+		dstd = SetDSTdrawByTime(*dst, GetTimeLapse(dst->timer, T));
+		mouse = MouseOnDSTD(&dstd, &input->mouse_oldX, &input->mouse_oldY);
+		if ( (mouse == 1 && src->op4 == 0) || (mouse != 0 && src->op4 == 1) ) { // right side or plusonly
+			if (src->op2 != 1 || input->mouse_buttonL != 1 || (src->op3 != panel && src->op3 != 0)) {
+				ret = 1;
+			}
+			else {
+				if (min < max) (*target)++;
+				ret = 2;
+			}
 		}
-		else {
-			if (min < max) (*target)--;
-			ret = 2;
+		else if ( (mouse == 2 && src->op4 == 0) || (mouse != 0 && src->op4 == 2) ) { // left side or plusonly(-)
+			if (src->op2 != 1 || input->mouse_buttonL != 1 || (src->op3 != panel && src->op3 != 0)) {
+				ret = 1;
+			}
+			else {
+				if (min < max) (*target)--;
+				ret = 2;
+			}
 		}
 	}
 

--- a/LR2/LR2_skinobject.h
+++ b/LR2/LR2_skinobject.h
@@ -17,7 +17,7 @@ int SetObjectValue_Button(game *g, skstruct *sk, Timer *T, char flag);
 int MouseOnDSTD(DSTdraw * dstd, int * x, int * y);
 int MouseOnObject(DSTstruct * dst, Timer * T, int * x, int * y);
 int SliderByTime(DrawingBuf * drb, SRCstruct * src, DSTstruct * dst, Timer * T, int min, int max, int * value, inputStructure * input, int objectID);
-int ButtonByInput(DrawingBuf * drb, SRCstruct * src, DSTstruct * dst, Timer * T, inputStructure * input, int * target, int min, int max, int panel);
+int ButtonByInput(skstruct* sk, SRCstruct * src, DSTstruct * dst, Timer * T, inputStructure * input, int * target, int min, int max, int panel);
 
 //text input
 int Proc_Text(game *g, sqlite3 *sql, char flag);

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -697,7 +697,7 @@ int main(int argc, char** argv) {
 	gs.gameplay.courseStageNow = 0;
 	gs.gameplay.timetick = GetTimeWrap();
 	gs.gameplay.flag_threadDoingProcGame = 0;
-	InitSkin(&gs.skstruct, 0, 0);
+	InitSkin(&gs.skstruct, 0, 0, &gs.timer1);
 	gs.skstruct.fontname.assign(&gs.config.skin.fontname);
 	for (int i = 0; i < SLOTS; i++) gs.gameplay.keysound->load = 0;
 	for (int i = 0; i < 200; i++) gs.skstruct2.caption[i].fillzero();
@@ -721,7 +721,7 @@ int main(int argc, char** argv) {
 		return -1;
 	}
 	gs.skstruct2.drBuf.disableImageFont = gs.config.skin.disableImageFont;
-	InitSkin(&gs.skstruct2, 0, 0);
+	InitSkin(&gs.skstruct2, 0, 0, &gs.timer2);
 	gs.skstruct2.fontname.assign(&gs.config.skin.fontname);
 
 	gs.sSelect.toRoot = 1;

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -2007,7 +2007,6 @@ int main(int argc, char** argv) {
 				}
 			}
 		}
-		gs.skstruct.panelMan.Draw(&gs.skstruct.drBuf);
 		for (int i = 0; i < gs.skstruct.drBuf.count; i++) {
 			int quake_x = 0, quake_y = 0;
 			if (((gs.procPhase == 1) && (gs.procSelecter == 4)) && (0 < gs.config.play.m_earthquake)) {

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -2007,6 +2007,7 @@ int main(int argc, char** argv) {
 				}
 			}
 		}
+		gs.skstruct.panelMan.Draw(&gs.skstruct.drBuf);
 		for (int i = 0; i < gs.skstruct.drBuf.count; i++) {
 			int quake_x = 0, quake_y = 0;
 			if (((gs.procPhase == 1) && (gs.procSelecter == 4)) && (0 < gs.config.play.m_earthquake)) {

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1945,6 +1945,16 @@ void SubProcI_Select(game *g, sqlite3 *sql) {
 		if (GetTimeLapse(175, &g->timer1) != -1.0) return;
 		if (GetTimeLapse(176, &g->timer1) != -1.0) return;
 
+		if (g->skstruct.panelMan.RunSelectorInput(&g->KeyInput, &g->audio)) {
+			if (g->sSelect.panel >= 0) {
+				ResetTimeLapse(20 + g->sSelect.panel, &g->timer1);
+				SetTimeLapse(30 + g->sSelect.panel, &g->timer1);
+				g->sSelect.panel = -1;
+				PlaySound(&g->audio, &g->audio.sysSound.panel_close, g->audio.chnKey, -1);
+			}
+			return;
+		}
+
 		if (g->KeyInput.inputID[KEY_INPUT_F8] == 1) {
 			if (g->sSelect.stack_query[g->sSelect.cur].findStrPos("parent") != -1) {
 				SetBmsFilter(g, sql);

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -27,6 +27,7 @@
 #define SINGLESLOTS 3844
 #define SLOTS SINGLESLOTS*10
 //36*36*5(6480) -> 62*62*10(38440)
+constexpr size_t TIMER_MAX = 600;
 
 
 struct sqlite3;
@@ -1465,7 +1466,7 @@ struct SkinCustom {
 };
 
 struct Timer {
-	double clock[500];
+	double clock[TIMER_MAX];
 	double scratch; /* //for graphic */
 	double gameTick; /* //game tick */
 	double vSyncTick; /* //VSync */

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -27,8 +27,7 @@
 #define SINGLESLOTS 3844
 #define SLOTS SINGLESLOTS*10
 //36*36*5(6480) -> 62*62*10(38440)
-constexpr size_t TIMER_MAX = 600;
-
+constexpr size_t TIMER_MAX = 500 + CUSTOM_PANELS_MAX * 2;
 
 struct sqlite3;
 struct game;
@@ -672,6 +671,28 @@ struct CSVbuf {
 	int val[30]{};
 	CSTR str[30]{};
 };
+struct DSTdraw { /* 80bytes,4*0x14 */
+	float x{0};
+	float y{0};
+	float w{0};
+	float h{0};
+	int sortID{0};
+	int time{-1};
+	int acc{0};
+	int blend{0};
+	int filter{0};
+	int a{0};
+	int r{0};
+	int g{0};
+	int b{0};
+	float angle{0};
+	int center{0};
+	int grHandle{-1};
+	int fontHandle{-1};
+	int subHandle{-1};
+	int align{0};
+	char isDrawBackbox{0};
+};
 
 struct DrawingBuf {
 	struct DSTdraw * dstd;
@@ -684,6 +705,20 @@ struct DrawingBuf {
 	char isDisabled;
 	char unkFE;
 	char unkFF;
+};
+
+struct DSTstruct { /* 44bytes.4*0x0b */
+	int n; /* (NULL) on file */
+	int opt1; /* dst_option */
+	int opt2; /* and dst_option */
+	int opt3; /* and dst_option */
+	int opt4; /* scratch */
+	int opt5;
+	int timer;
+	struct DSTdraw * draw;
+	int dataSize;
+	int loop;
+	int dstCount;
 };
 
 struct FontChar {
@@ -845,6 +880,26 @@ struct ImageFont {
 	char filepath[260]{};
 	std::vector<FontImage> images; /* est.array size 1000 */
 	std::unordered_map<char32_t, FontChar> chars;
+};
+
+struct SRCstruct { /* 68bytes,4*0x11 */
+	int n; /* (NULL) in file */
+	int * grHandles; /* =fontHandle */
+	int graphcount;
+	int cycle; /* =font */
+	int op1;
+	int op2;
+	int op3;
+	int op4;
+	int op5;
+	int count;
+	int timer;
+	int fontHandle;
+	int align;
+	int st;
+	int inArray;
+	int sx;
+	int sy;
 };
 
 struct SkinObject {

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -11,6 +11,7 @@
 
 #include "strclass.h"
 #include "LR2_customir.h"
+#include "LR2_panels.h"
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -670,28 +671,6 @@ struct CSVbuf {
 	int val[30]{};
 	CSTR str[30]{};
 };
-struct DSTdraw { /* 80bytes,4*0x14 */
-	float x{0};
-	float y{0};
-	float w{0};
-	float h{0};
-	int sortID{0};
-	int time{-1};
-	int acc{0};
-	int blend{0};
-	int filter{0};
-	int a{0};
-	int r{0};
-	int g{0};
-	int b{0};
-	float angle{0};
-	int center{0};
-	int grHandle{-1};
-	int fontHandle{-1};
-	int subHandle{-1};
-	int align{0};
-	char isDrawBackbox{0};
-};
 
 struct DrawingBuf {
 	struct DSTdraw * dstd;
@@ -704,20 +683,6 @@ struct DrawingBuf {
 	char isDisabled;
 	char unkFE;
 	char unkFF;
-};
-
-struct DSTstruct { /* 44bytes.4*0x0b */
-	int n; /* (NULL) on file */
-	int opt1; /* dst_option */
-	int opt2; /* and dst_option */
-	int opt3; /* and dst_option */
-	int opt4; /* scratch */
-	int opt5;
-	int timer;
-	struct DSTdraw * draw;
-	int dataSize;
-	int loop;
-	int dstCount;
 };
 
 struct FontChar {
@@ -881,26 +846,6 @@ struct ImageFont {
 	std::unordered_map<char32_t, FontChar> chars;
 };
 
-struct SRCstruct { /* 68bytes,4*0x11 */
-	int n; /* (NULL) in file */
-	int * grHandles; /* =fontHandle */
-	int graphcount;
-	int cycle; /* =font */
-	int op1;
-	int op2;
-	int op3;
-	int op4;
-	int op5;
-	int count;
-	int timer;
-	int fontHandle;
-	int align;
-	int st;
-	int inArray;
-	int sx;
-	int sy;
-};
-
 struct SkinObject {
 	int srcSize;
 	int dstSize;
@@ -1012,6 +957,7 @@ struct skstruct {
 	int event_FADEOUT[10]{};
 	struct DSTstruct dst_EVENT_LOADINGBG[5]{};
 	int horizontal{};
+	PanelManager panelMan;
 };
 
 struct MYRANKING {

--- a/vcxproj/OpenLR2.vcxproj
+++ b/vcxproj/OpenLR2.vcxproj
@@ -49,6 +49,7 @@
     <ClInclude Include="..\LR2\LR2_ghost.h" />
     <ClInclude Include="..\LR2\LR2_ir.h" />
     <ClInclude Include="..\LR2\LR2_makemp3.h" />
+    <ClInclude Include="..\LR2\LR2_panels.h" />
     <ClInclude Include="..\LR2\LR2_replay.h" />
     <ClInclude Include="..\LR2\LR2_skindraw.h" />
     <ClInclude Include="..\LR2\LR2_skinload.h" />
@@ -93,6 +94,7 @@
     <ClCompile Include="..\LR2\LR2_ghost.cpp" />
     <ClCompile Include="..\LR2\LR2_ir.cpp" />
     <ClCompile Include="..\LR2\LR2_makemp3.cpp" />
+    <ClCompile Include="..\LR2\LR2_panels.cpp" />
     <ClCompile Include="..\LR2\LR2_replay.cpp" />
     <ClCompile Include="..\LR2\LR2_skindraw.cpp" />
     <ClCompile Include="..\LR2\LR2_skinload.cpp" />

--- a/vcxproj/OpenLR2.vcxproj.filters
+++ b/vcxproj/OpenLR2.vcxproj.filters
@@ -156,6 +156,9 @@
     <ClInclude Include="..\LR2\En_audio.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\LR2\LR2_panels.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\LR2\En_audio.cpp">
@@ -273,6 +276,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\LR2\strclass.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\LR2\LR2_panels.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
WHY:

Assume you want a new feature - you code basic elements for it like `SRC_BUTTON`, some accessors for `SRC_NUMBER`, etc.
Now, you have made 50 new buttons and numbers. Unfortunately, there are only that many pixels on the screen, and that many button binds available, so UI flow must be extended, as you can't cram everything into the scene root. It makes most sense to have basically sub-scenes (panels), which will be able to store those elements. Much like `START` panel in select scene, which allows to draw a bunch of logically connected buttons in a single place, and alter what keybinds are gonna be doing.

HOW:

Adds `#PANEL` skinnable element. It's a non-rendering element, which has parameters 'master' and 'selectable'. 'master' parameter is a panel index which this panel will be assigned to as a sub-panel (slave). Indexes are assigned to panels in the order of their definition, in the range of 10-59. Panels will also have their own timers in the range of 500-599, where 500-549 is open timers, and 550-599 is close timers. Slave panels are not allowed to have slave panels themselves; only master panel ('master' parameter set to 0) index can be used as `master` param. Other skin elements can be bound to the panel through its panel and timer indexes, just like with existing panels.

Custom panel view can be opened by pressing `SELECT` while holding `START` (or the other way around, will see). This brings up the first master panel as well as its slave panels. You don't need to hold `SELECT` for the panel to stay open, so you can close it by pressing `START`. You can change which sub-panel (current master panel and its slaves) is active using scratch. This impacts which panel will be using button input on keys 1-7. Keys 1-7 are naively bound to first seven #SRC_BUTTON which use that panel's index as `panel` param. Panel can have more than 7 buttons, but anything past 7 will only be operable with the mouse. You can switch to next master panel by pressing `SELECT`, and previous by pressing `START` while holding `SELECT`. `#SRC_BUTTON` will likely be extended with new values for `type` param to have on-screen controls for custom panel flow.

USE CASE:

It allows us to only code new primitive skin elements, without having to worry about their GUI, leaving those things to skinners discretion, as well as have nice LR2-like flow to new features. For example, a panel to control unrandomizer could be made, with a sub-panel to select arrangement, and another sub-panel to control its toggles. There could be another panel to use other features of OpenLR2 like GAS, maybe some additional settings for GAS could be introduced too, and i'm sure there will be other gameplay features requiring GUI in the future. Settings menu could be expanded to control CustomIR with sub-sections to change more settings (there are a lot of settings currently not exposed at runtime which make sense to expose). Select and result scene could use a per-column judgement stats panel, which the game tracks the data for already, but lacks GUI. And anything else, really, anything at all. I believe this could be a future-proof solution for all our GUI needs.

Currently this is very early WIP, a draft PR is made already so contributors could follow the progress and make their input as it goes, so the development flow isn't based exclusively on my ideas, and before it grows too big for someone else to properly follow and impact.