### PR TITLE
 fix(main): don't load courses when entering skin customize (LR2 bug) 

### DIFF
--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -2034,7 +2034,7 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 	int bmsobj_stageFirst{};
 	double oldSpeedMultiplier{};
 		
-	char mapAdded[2][10] = { 0, };
+	char mapAdded[2][10]{};
 	double prevStageTime = -1.0;
 	double meaLength{};
 
@@ -3010,8 +3010,8 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 			double t_realTiming = 0.0;
 			double t_bmsTiming = 0.0;
 			double t_renderTiming = 0.0;
-			bool mapAdded[2][10] = { 0, };
-			int addNoteCount[2] = { 0, };
+			bool mapAdded[2][10]{};
+			int addNoteCount[2]{};
 
 			for (int i = 0; i < gp->bmsobj.count; i++) {
 				if (l_realTiming < gp->bmsobj.notes[i].realTiming) {

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -1452,7 +1452,7 @@ int main(int argc, char** argv) {
 					}
 					gs.gameplay.courseStageNow = 0;
 					gs.gameplay.courseType = -1;
-					if (gs.sSelect.bmsList[gs.sSelect.cur_song].coursePlayable == 1) {
+					if (gs.procSelecter != SCENE_SKINSELECT && gs.sSelect.bmsList[gs.sSelect.cur_song].coursePlayable == 1) {
 						SONGDATA sd;
 						gs.gameplay.isCourse = 1;
 						gs.gameplay.courseStageCount = gs.sSelect.bmsList[gs.sSelect.cur_song].courseStageCount;


### PR DESCRIPTION
Fixes https://github.com/GOMazk/OpenLR2/issues/213 "Skin customize plays
course chart instead of sample when opened in course list".