### PR TITLE
fix: move screen mode config option to openlr2-config.xml

### DIFF
--- a/LR2/LR2_configsave.cpp
+++ b/LR2/LR2_configsave.cpp
@@ -1,5 +1,6 @@
 ﻿#include "LR2_configsave.h"
 #include "En_xml.h"
+#include <algorithm>
 #include <filesystem>
 #include <iterator>
 
@@ -156,7 +157,7 @@ int WriteConfigXml(game *g, const char *filename){
 	fputs("<config>\n", pFile);
 
 	fputs("\t<system>\n", pFile);
-	WriteXML_Tab2Int(pFile, "screenmode", (g->config).system.screenmode);
+	WriteXML_Tab2Int(pFile, "screenmode", (g->config).system.oldConfigScreenMode);
 	WriteXML_Tab2Int(pFile, "vsync", (g->config).system.vsync);
 	WriteXML_Tab2Int(pFile, "directdraw", (g->config).system.directdraw);
 	WriteXML_Tab2Int(pFile, "highcolor", (g->config).system.highcolor);
@@ -563,8 +564,6 @@ int WriteConfigXml(game *g, const char *filename){
 }
 
 int WriteOpenLr2ConfigXml(game *g, const char *filename){
-	char buf[256];
-
 	FILE *pFile = fopen(filename, "w");
 	if (pFile == nullptr) return 0;
 
@@ -575,6 +574,7 @@ int WriteOpenLr2ConfigXml(game *g, const char *filename){
 	WriteXML_Tab2Int(pFile, "resolution", (g->config).system.resolution);
 	WriteXML_Tab2Int(pFile, "fullscreenfilter", (g->config).system.fullscreenfilter);
 	WriteXML_Tab2BoolAsInt(pFile, "fullscreenfitstretch", (g->config).system.fullscreenfitstretch);
+	WriteXML_Tab2Int(pFile, "screenmode", (g->config).system.screenmode);
 	fputs("\t</system>\n", pFile);
 
 	fputs("\t<play>\n", pFile);
@@ -947,8 +947,10 @@ int ReadConfig(game* g, const char* filepath) {
 		return 0;
 	}
 
-	ReadXml_Int("config", "system", "screenmode", 0, &g->config.system.screenmode, hXml);
-	if ((unsigned)g->config.system.screenmode > 2) g->config.system.screenmode = 1;
+	ReadXml_Int("config", "system", "screenmode", 0, &g->config.system.oldConfigScreenMode, hXml);
+	// LR2 crashes on out-of-range values, and we may have written OpenLR2-specific '2' before
+	if (g->config.system.oldConfigScreenMode < 0 || g->config.system.oldConfigScreenMode > 1)
+		g->config.system.oldConfigScreenMode = 0;
 	ReadXml_Int("config", "system", "vsync", 0, &g->config.system.vsync, hXml);
 	ReadXml_Int("config", "system", "directdraw", 0, &g->config.system.directdraw, hXml);
 	ReadXml_Int("config", "system", "maindisplay", 0, &g->config.system.maindisplay, hXml);
@@ -1149,12 +1151,20 @@ int ReadOpenLr2Config(game* g, const char* filepath) {
 		delete(hXml);
 		return 0;
 	}
+
 	ReadXml_Int("config", "system", "resolution", 0, &g->config.system.resolution, hXml);
 	ReadXml_Int("config", "system", "fullscreenfilter", 0, &g->config.system.fullscreenfilter, hXml);
 	ReadXml_PositiveIntAsBool("config", "system", "fullscreenfitstretch", false, &g->config.system.fullscreenfitstretch, hXml);
+	ReadXml_Int("config", "system", "screenmode", 0, &g->config.system.screenmode, hXml);
+	if (g->config.system.screenmode < 0 || g->config.system.screenmode > 2)
+		g->config.system.screenmode = 0; // out-of-range
+
 	ReadXml_PositiveIntAsBool("config", "play", "gaugeautoshift", false, &g->config.play.m_gas, hXml);
+
 	ReadXml_Str("config", "skin", "courseresult", "", &g->config.skin.skinFilePath[15], hXml);
+
 	ReadXml_Str("config", "network", "display_ir", "", &g->config.network.displayIr, hXml);
+
 	delete(hXml);
 	return 1;
 }

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -169,13 +169,9 @@ static void MoveWindowToDisplay(int targetDisplayIndex, int sourceDisplayIndex) 
 	SetWindowPosition(targetX + wx - sourceX, targetY + wy - sourceY);
 }
 
-// Applies the configured screen mode.
-//   0 = desktop fullscreen (exclusive, bypasses the DWM -> lower input latency)
-//   1 = windowed
-//   2 = borderless fullscreen (virtual; composited by the DWM)
-// DxLib picks exclusive vs borderless through SetFullScreenResolutionMode;
-// ChangeWindowMode only toggles windowed(1)/fullscreen(0).
 static void ApplyScreenMode(int screenmode) {
+	// DxLib picks exclusive vs borderless through SetFullScreenResolutionMode;
+	// ChangeWindowMode only toggles windowed(1)/fullscreen(0).
 	switch (screenmode) {
 		case 0: {
 			const int displayInfoIndex = FindMonitorThatContainsWindowCenter();

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -504,6 +504,9 @@ struct CONFIG_SOUND {
 
 struct CONFIG_SYSTEM {
 	int fullscreenfilter{};
+	// 0 = desktop fullscreen (exclusive, bypasses the DWM)
+	// 1 = windowed
+	// 2 = borderless fullscreen (virtual, composited by the DWM)
 	int screenmode{};
 	int vsync{};
 	int directdraw{};
@@ -527,6 +530,7 @@ struct CONFIG_SYSTEM {
 	int resolution{};   // 0=SD 640x480, 1=HD 1280x720, 2=FHD 1920x1080
 	unsigned int coreCount = 0;
 	bool fullscreenfitstretch{};
+	int oldConfigScreenMode{}; // We use our own \ref screenmode now
 };
 
 struct CONFIG_TOOLS {


### PR DESCRIPTION
Setting SCREEN MODE to "BORDERLESS" causes issues if you then start vanilla LR2.
So move this option to our own config file.
Mentioned here [1].

Also add clamping to never use invalid values.
Note that the way it's implemented will end up resetting 'screenmode' on the first launch of updated OpenLR2.

Fixes https://github.com/GOMazk/OpenLR2/issues/220 "Move screen mode config option to openlr2-config.xml".

[1] https://github.com/GOMazk/OpenLR2/pull/156#issuecomment-4820202780

---

FYI @Unengine @SayakaIsBaka