### PR TITLE
fix: calculate money score on a wider type (u64) (LR2 bug)

### DIFF
--- a/LR2/LR2_ghost.cpp
+++ b/LR2/LR2_ghost.cpp
@@ -675,7 +675,7 @@ int PLAYSCORE::SetScore(PLAYERSTATUS *pstat, char flagExpect) {
 		pstat->judgecount[4] = this->judgeExpect[4];
 		pstat->judgecount[5] = this->judgeExpect[5];
 		pstat->exscore = this->exscore;
-		pstat->score = ((pstat->judgecount[3] + (pstat->judgecount[4] + pstat->judgecount[5] * 2) * 2) * 50000) / this->totalnotes;
+		pstat->score = ((pstat->judgecount[3] + (pstat->judgecount[4] + pstat->judgecount[5] * 2) * 2) * 50000ULL) / this->totalnotes;
 		pstat->now_combo = this->totalnotes;
 		pstat->rate = (double)((pstat->exscore * 100) / (double)(this->totalnotes * 2));
 		return 1;
@@ -687,7 +687,7 @@ int PLAYSCORE::SetScore(PLAYERSTATUS *pstat, char flagExpect) {
 	pstat->judgecount[4] = this->judge[4];
 	pstat->judgecount[5] = this->judge[5];
 	pstat->exscore = this->rate;
-	pstat->score = ((pstat->judgecount[3] + (pstat->judgecount[4] + pstat->judgecount[5] * 2) * 2) * 50000) / this->totalnotes;
+	pstat->score = ((pstat->judgecount[3] + (pstat->judgecount[4] + pstat->judgecount[5] * 2) * 2) * 50000ULL) / this->totalnotes;
 	pstat->now_combo = this->nownote;
 	pstat->rate = (double)((pstat->exscore * 100) / (double)(this->totalnotes * 2));
 	return 1;

--- a/LR2/LR2_replay.cpp
+++ b/LR2/LR2_replay.cpp
@@ -393,7 +393,7 @@ int REPLAY_ApplyJudgeNote(gameplay *gp, Timer *T, game *g, uint judge, int playe
 	}
 
 	if (gp->player[player].totalnotes > 0) {
-		gp->player[player].score = (gp->player[player].judgecount[3] + (gp->player[player].judgecount[4] + gp->player[player].judgecount[5] * 2) * 2) * 50000 / gp->player[player].totalnotes;
+		gp->player[player].score = (gp->player[player].judgecount[3] + (gp->player[player].judgecount[4] + gp->player[player].judgecount[5] * 2) * 2) * 50000ULL / gp->player[player].totalnotes;
 	}
 	gp->player[player].exscore = gp->player[player].judgecount[4] + gp->player[player].judgecount[5] * 2;
 

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -256,7 +256,7 @@ void LoadIRDerivedRecord(sqlite3* sql, SONGDATA& sd) {
 			int rseed = sqlite3_column_int(stmt, 15);
 			int complete = sqlite3_column_int(stmt, 16);
 
-			int stat_score = (good + great * 2 + perfect * 4) * 50000 / totalnotes;
+			int stat_score = (good + great * 2 + perfect * 4) * 50000ULL / totalnotes;
 			int stat_exscore = perfect * 2 + great;
 			if (!minbp) {
 				minbp = bad + poor;
@@ -1110,7 +1110,7 @@ int GetSongData(CSTR songMD5, SONGDATA *song, sqlite3 *sql, SONGSELECT *ss) {
 					song->mybest.total_notes = sqlite3_column_int(stmt, 26);
 
 				if (song->mybest.total_notes > 0)
-					song->mybest.stat_score = (song->mybest.stat_good + song->mybest.stat_great * 2 + song->mybest.stat_pgreat * 4) * 50000 / song->mybest.total_notes;
+					song->mybest.stat_score = (song->mybest.stat_good + song->mybest.stat_great * 2 + song->mybest.stat_pgreat * 4) * 50000ULL / song->mybest.total_notes;
 
 				if (song->mybest.minbp == 0 && song->mybest.clear != 5)
 					song->mybest.minbp = -1;
@@ -1746,7 +1746,7 @@ int SearchCourseFromDB(sqlite3 *sql, SONGSELECT *ss, int keys, int multistagemod
 		if (isSameScoreHash(&song.mybest, &ss->playerPassMD5, &song.hash, &str)) {
 			song.mybest.stat_exscore = song.mybest.stat_great + song.mybest.stat_pgreat * 2;
 			if (song.mybest.total_notes > 0) {
-				song.mybest.stat_score = (song.mybest.stat_good + song.mybest.stat_exscore) * 2 * 50000 / song.mybest.total_notes;
+				song.mybest.stat_score = (song.mybest.stat_good + song.mybest.stat_exscore) * 2 * 50000ULL / song.mybest.total_notes;
 			}
 			if (song.mybest.minbp == 0 && song.mybest.clear != 5) song.mybest.minbp = -1;
 		}
@@ -2319,7 +2319,7 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 							song.rivalRecord.op_best = sqlite3_column_int(pStmt, 63);
 							song.rivalRecord.stat_exscore = song.rivalRecord.stat_great + song.rivalRecord.stat_pgreat * 2;
 							if (0 < song.rivalRecord.total_notes) {
-								song.rivalRecord.stat_score = ((song.rivalRecord.stat_good + song.rivalRecord.stat_exscore * 2) * 50000) / song.rivalRecord.total_notes;
+								song.rivalRecord.stat_score = ((song.rivalRecord.stat_good + song.rivalRecord.stat_exscore * 2) * 50000ULL) / song.rivalRecord.total_notes;
 								song.rivalRecord.rate = (song.rivalRecord.stat_exscore * 50) / song.rivalRecord.total_notes;
 								song.rivalRecord.rank = (song.rivalRecord.stat_exscore * 9) / (song.rivalRecord.total_notes * 2);
 								if (song.rivalRecord.rank < 9) {
@@ -2337,7 +2337,7 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 						if (isSameScoreHash(&song.mybest, &ss->playerPassMD5, &song.hash, &bestHash)) {
 							song.mybest.stat_exscore = song.mybest.stat_great + song.mybest.stat_pgreat * 2;
 							if (song.mybest.total_notes > 0) {
-								song.mybest.stat_score = ((song.mybest.stat_good + song.mybest.stat_exscore * 2) * 50000) /	song.mybest.total_notes;
+								song.mybest.stat_score = ((song.mybest.stat_good + song.mybest.stat_exscore * 2) * 50000ULL) /	song.mybest.total_notes;
 							}
 							if ((song.mybest.minbp == 0) && (song.mybest.clear != 5)) {
 								song.mybest.minbp = -1;

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -173,7 +173,7 @@ int ApplyJudgeNote(int judge, game *g, int _player, int lane, Timer *T, char isR
 	}
 
 	if (player.totalnotes > 0) {
-		player.score = (player.judgecount[3] + (player.judgecount[4] + player.judgecount[5] * 2) * 2) * 50000 / player.totalnotes;
+		player.score = (player.judgecount[3] + (player.judgecount[4] + player.judgecount[5] * 2) * 2) * 50000ULL / player.totalnotes;
 	}
 	player.exscore = player.judgecount[4] + player.judgecount[5] * 2;
 


### PR DESCRIPTION
Fixes money score not being displayed in some cases, not even as a bunch of zeroes.

Reproduce by playing a chart or a course with at least 10'000 notes and getting some decent accuracy.