### PR TITLE
feat(songselect): add support for beatoraja preview files

### DIFF
--- a/LR2/En_fileutil.cpp
+++ b/LR2/En_fileutil.cpp
@@ -380,6 +380,8 @@ bool IsMediaFile(CSTR str) {
 		str.lower();
 		if (str.isSame(".mp3")) return true;
 		if (str.isSame(".wav")) return true;
+		if (str.isSame(".ogg")) return true;
+		if (str.isSame(".flac")) return true;
 		if (str.isSame(".avi")) return true;
 	}
 	return false;
@@ -391,6 +393,8 @@ bool IsSndFile(CSTR str) {
 		str.lower();
 		if (str.isSame(".mp3")) return true;
 		if (str.isSame(".wav")) return true;
+		if (str.isSame(".ogg")) return true;
+		if (str.isSame(".flac")) return true;
 	}
 	return false;
 }

--- a/LR2/LR2_configsave.cpp
+++ b/LR2/LR2_configsave.cpp
@@ -577,6 +577,11 @@ int WriteOpenLr2ConfigXml(game *g, const char *filename){
 	WriteXML_Tab2Int(pFile, "screenmode", (g->config).system.screenmode);
 	fputs("\t</system>\n", pFile);
 
+    fputs("\t<select>\n", pFile);
+    WriteXML_Tab2BoolAsInt(pFile, "ignorepreviewfiles", (g->config).select.ignorePreviewFiles);
+    WriteXML_Tab2Int(pFile, "previewdelay", (g->config).select.previewDelay);
+    fputs("\t</select>\n", pFile);
+
 	fputs("\t<play>\n", pFile);
 	WriteXML_Tab2BoolAsInt(pFile, "gaugeautoshift", (g->config).play.m_gas);
 	fputs("\t</play>\n", pFile);
@@ -1158,6 +1163,9 @@ int ReadOpenLr2Config(game* g, const char* filepath) {
 	ReadXml_Int("config", "system", "screenmode", 0, &g->config.system.screenmode, hXml);
 	if (g->config.system.screenmode < 0 || g->config.system.screenmode > 2)
 		g->config.system.screenmode = 0; // out-of-range
+
+    ReadXml_PositiveIntAsBool("config", "select", "ignorepreviewfiles", false, &g->config.select.ignorePreviewFiles, hXml);
+    ReadXml_Int("config", "select", "previewdelay", 500, &g->config.select.previewDelay, hXml);
 
 	ReadXml_PositiveIntAsBool("config", "play", "gaugeautoshift", false, &g->config.play.m_gas, hXml);
 

--- a/LR2/LR2_configsave.cpp
+++ b/LR2/LR2_configsave.cpp
@@ -577,10 +577,10 @@ int WriteOpenLr2ConfigXml(game *g, const char *filename){
 	WriteXML_Tab2Int(pFile, "screenmode", (g->config).system.screenmode);
 	fputs("\t</system>\n", pFile);
 
-    fputs("\t<select>\n", pFile);
-    WriteXML_Tab2BoolAsInt(pFile, "ignorepreviewfiles", (g->config).select.ignorePreviewFiles);
-    WriteXML_Tab2Int(pFile, "previewdelay", (g->config).select.previewDelay);
-    fputs("\t</select>\n", pFile);
+	fputs("\t<select>\n", pFile);
+	WriteXML_Tab2BoolAsInt(pFile, "ignorepreviewfiles", (g->config).select.ignorePreviewFiles);
+	WriteXML_Tab2Int(pFile, "previewdelay", (g->config).select.previewDelay);
+	fputs("\t</select>\n", pFile);
 
 	fputs("\t<play>\n", pFile);
 	WriteXML_Tab2BoolAsInt(pFile, "gaugeautoshift", (g->config).play.m_gas);
@@ -1164,8 +1164,8 @@ int ReadOpenLr2Config(game* g, const char* filepath) {
 	if (g->config.system.screenmode < 0 || g->config.system.screenmode > 2)
 		g->config.system.screenmode = 0; // out-of-range
 
-    ReadXml_PositiveIntAsBool("config", "select", "ignorepreviewfiles", false, &g->config.select.ignorePreviewFiles, hXml);
-    ReadXml_Int("config", "select", "previewdelay", 500, &g->config.select.previewDelay, hXml);
+	ReadXml_PositiveIntAsBool("config", "select", "ignorepreviewfiles", false, &g->config.select.ignorePreviewFiles, hXml);
+	ReadXml_Int("config", "select", "previewdelay", 500, &g->config.select.previewDelay, hXml);
 
 	ReadXml_PositiveIntAsBool("config", "play", "gaugeautoshift", false, &g->config.play.m_gas, hXml);
 

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -669,7 +669,7 @@ int EditTag(SONGDATA *song, sqlite3 *sql) {
 		SQL_Run(query, sql);
 		sqlite3_snprintf(1024, query, "INSERT INTO openlr2_preview (hash,previewpath) VALUES(\'%q\',\'%q\') ON CONFLICT(hash) DO UPDATE SET previewpath=excluded.previewpath",
 			meta.hash.body, meta.previewpath.body);
-		SQL_Run(query, sql);
+		sqlite3_exec(sql, query, nullptr, nullptr, nullptr);
 
 		if (meta.difficulty <= 0 || meta.difficulty > 5) {
 			SetUndefinedDifficulty(sql);
@@ -1377,7 +1377,7 @@ int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 					SQL_Run(str, sql);
 					sqlite3_snprintf(2048, str, "INSERT INTO openlr2_preview (hash,previewpath) VALUES(\'%q\',\'%q\') ON CONFLICT(hash) DO UPDATE SET previewpath=excluded.previewpath",
 						meta.hash.body, meta.previewpath.body);
-					SQL_Run(str, sql);
+					sqlite3_exec(sql, str, nullptr, nullptr, nullptr);
 					if (g_fullSongPass) g_processedSongPaths.insert(MakePathKey(searchPath));
 				}
 				count++;
@@ -1513,8 +1513,9 @@ int ReloadSongsByQuery(CSTR query, sqlite3 *sql, CONFIG_JUKEBOX *jb, ReloadProgr
 						LoadBMSMETAFromDB(&meta, sql);
 						SQL_Run(sqlite3_snprintf(1024, sBuf, "INSERT INTO song (hash,title,subtitle,genre,artist,subartist,level,date,path,folder,stagefile,banner,backbmp,parent,maxbpm,minbpm,random,longnote,judge,mode,bga,difficulty,favorite,type,txt,karinotes,adddate,exlevel) VALUES(\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,%d,%d,%d,%d,%d,%d,0,0,%d,%d,%d,%d)",
 							meta.hash.body, meta.title.body, meta.subtitle.body, meta.genre.body, meta.artist.body, meta.subartist.body, meta.selLevel, newTime, str.body, AssignCRC32(meta.folderpath).body, meta.stagefilepath.body, meta.bannerpath.body, meta.backBMPpath.body,AssignCRC32(meta.parentfolderpath).body,meta.maxbpm,meta.minbpm,meta.random,meta.longnote,meta.judge,meta.keymode,meta.bga,meta.difficulty,(int)meta.hasTxt,meta.notecount,now,meta.exlevel), sql);
-						SQL_Run(sqlite3_snprintf(1024, sBuf, "INSERT INTO openlr2_preview (hash,previewpath) VALUES(\'%q\',\'%q\') ON CONFLICT(hash) DO UPDATE SET previewpath=excluded.previewpath",
-							meta.hash.body, meta.previewpath.body), sql);
+						sqlite3_snprintf(1024, sBuf, "INSERT INTO openlr2_preview (hash,previewpath) VALUES(\'%q\',\'%q\') ON CONFLICT(hash) DO UPDATE SET previewpath=excluded.previewpath",
+							meta.hash.body, meta.previewpath.body);
+						sqlite3_exec(sql, sBuf, nullptr, nullptr, nullptr);
 						if (g_fullSongPass) g_processedSongPaths.insert(MakePathKey(str));
 					}
 					else if (is_lr2folder) {
@@ -2291,8 +2292,8 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 					sqlite3_stmt *pStmtPreview;
 					char previewQuery[512];
 					sqlite3_snprintf(512, previewQuery, "SELECT previewpath FROM openlr2_preview WHERE hash=\'%q\'", song.hash.body);
-					SQL_prepare(previewQuery, sql, &pStmtPreview);
-					if (sqlite3_step(pStmtPreview) == 100) {
+					sqlite3_prepare(sql, previewQuery, -1, &pStmtPreview, nullptr);
+					if (sqlite3_step(pStmtPreview) == SQLITE_ROW) {
 						song.previewfile = SQL_GetColumn(0, pStmtPreview);
 						if (song.previewfile.isDiff("(null)") && song.previewfile.length() > 4) song.isPreviewfile = true;
 					}
@@ -2779,7 +2780,7 @@ int LoadLR2CustomFolder(sqlite3 *sql, CONFIG_JUKEBOX *jb, CSTR scoreDBpath, char
 		SQL_Run("CREATE TABLE song(hash TEXT ,title TEXT ,subtitle TEXT ,genre TEXT,artist TEXT,subartist TEXT,tag TEXT ,path TEXT primary key ,type INTEGER,folder TEXT,stagefile TEXT,banner TEXT,backbmp TEXT,parent TEXT,level INTEGER,difficulty INTEGER,maxbpm INTEGER,minbpm INTEGER,mode INTEGER,judge INTEGER,longnote INTEGER,bga INTEGER,random INTEGER,date INTEGER,favorite INTEGER,txt INTEGER,karinotes INTEGER,adddate INTEGER,exlevel INTEGER)", sql);
 		SQL_Run("CREATE INDEX hashidx ON song (hash)", sql);
 		SQL_Run("CREATE INDEX parentidx ON song (parent)", sql);
-		SQL_Run("CREATE TABLE openlr2_preview(hash TEXT primary key, previewpath TEXT)", sql);
+		sqlite3_exec(sql, "CREATE TABLE openlr2_preview(hash TEXT primary key, previewpath TEXT)", nullptr, nullptr, nullptr);
 		SQL_Run("DROP TABLE course", sql);
 		SQL_Run("CREATE TABLE nonstop(id INTEGER primary key,title TEXT,line INTEGER,hash TEXT,ir INTEGER)", sql);
 		SQL_Run("CREATE TABLE expert(id INTEGER primary key,title TEXT,line INTEGER,hash TEXT,ir INTEGER)", sql);

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -200,7 +200,7 @@ bool IsTextCommand(std::string_view line) {
 		StartsWithICaseAscii(line, "#STAGEFILE") ||
 		StartsWithICaseAscii(line, "#BANNER") ||
 		StartsWithICaseAscii(line, "#BACKBMP") ||
-        StartsWithICaseAscii(line, "#PREVIEW");
+		StartsWithICaseAscii(line, "#PREVIEW");
 }
 
 bool ParseTextCommand(BMSMETA& meta, CSTR& line) {
@@ -221,7 +221,7 @@ bool ParseTextCommand(BMSMETA& meta, CSTR& line) {
 	if (GetStringBodyStr(&line, "#STAGEFILE", &meta.stagefilepath)) return true;
 	if (GetStringBodyStr(&line, "#BANNER", &meta.bannerpath)) return true;
 	if (GetStringBodyStr(&line, "#BACKBMP", &meta.backBMPpath)) return true;
-    if (GetStringBodyStr(&line, "#PREVIEW", &meta.previewpath)) return true;
+	if (GetStringBodyStr(&line, "#PREVIEW", &meta.previewpath)) return true;
 	return false;
 }
 
@@ -337,11 +337,11 @@ void COPY_SONGDATA(SONGDATA *self, SONGDATA *other){
 	self->stagefile = other->stagefile;
 	self->banner = other->banner;
 	self->backBMP = other->backBMP;
-    self->previewfile = other->previewfile;
+	self->previewfile = other->previewfile;
 	self->isStagefile = other->isStagefile;
 	self->isBanner = other->isBanner;
 	self->isBackBMP = other->isBackBMP;
-    self->isPreviewfile = other->isPreviewfile;
+	self->isPreviewfile = other->isPreviewfile;
 	self->difficulty = other->difficulty;
 	self->level = other->level;
 	self->exlevel = other->exlevel;
@@ -396,7 +396,7 @@ int InitSongData(SONGDATA *song){
 	song->stagefile.fillzero();
 	song->banner.fillzero();
 	song->backBMP.fillzero();
-    song->previewfile.fillzero();
+	song->previewfile.fillzero();
 	song->folder.fillzero();
 	song->difficulty = 0;
 	song->folderType = 0;
@@ -411,7 +411,7 @@ int InitSongData(SONGDATA *song){
 	song->isStagefile = false;
 	song->isBanner = false;
 	song->isBackBMP = false;
-    song->isPreviewfile = false;
+	song->isPreviewfile = false;
 	song->replayExist = 0;
 	song->favorite = 0;
 	song->adddate = 0;
@@ -667,9 +667,9 @@ int EditTag(SONGDATA *song, sqlite3 *sql) {
 		sqlite3_snprintf(1024, query, "INSERT INTO song (hash,title,subtitle,genre,artist,subartist,level,date,path,folder,stagefile,banner,backbmp,parent,maxbpm,minbpm,random,longnote,judge,mode,bga,difficulty,favorite,type,txt,karinotes,adddate,exlevel) VALUES(\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,%d,%d,%d,%d,%d,%d,0,0,%d,%d,%d,%d)",
 			meta.hash.body, meta.title.body, meta.subtitle.body, meta.genre.body, meta.artist.body, meta.subartist.body, meta.selLevel, wtime, song->filepath.body, AssignCRC32(meta.folderpath).body, meta.stagefilepath.body,meta.bannerpath.body,meta.backBMPpath.body, AssignCRC32(meta.parentfolderpath).body, meta.maxbpm,meta.minbpm, meta.random,meta.longnote,meta.judge,meta.keymode,meta.bga,meta.difficulty,(int)meta.hasTxt,meta.notecount,temp,meta.exlevel);
 		SQL_Run(query, sql);
-        sqlite3_snprintf(1024, query, "INSERT INTO openlr2_preview (hash,previewpath) VALUES(\'%q\',\'%q\') ON CONFLICT(hash) DO UPDATE SET previewpath=excluded.previewpath",
-                         meta.hash.body, meta.previewpath.body);
-        SQL_Run(query, sql);
+		sqlite3_snprintf(1024, query, "INSERT INTO openlr2_preview (hash,previewpath) VALUES(\'%q\',\'%q\') ON CONFLICT(hash) DO UPDATE SET previewpath=excluded.previewpath",
+			meta.hash.body, meta.previewpath.body);
+		SQL_Run(query, sql);
 
 		if (meta.difficulty <= 0 || meta.difficulty > 5) {
 			SetUndefinedDifficulty(sql);
@@ -1260,7 +1260,7 @@ int GetSongDataFromPath(CSTR filepath, SONGDATA *song, sqlite3 *sql, SONGSELECT 
 	song->artist = meta.artist;
 	song->backBMP = meta.backBMPpath;
 	song->stagefile = meta.stagefilepath;
-    song->previewfile = meta.previewpath;
+	song->previewfile = meta.previewpath;
 	song->banner = meta.bannerpath;
 	song->bga = meta.bga;
 	song->difficulty = meta.difficulty;
@@ -1375,9 +1375,9 @@ int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 					sqlite3_snprintf(2048, str, "INSERT INTO song (hash,title,subtitle,genre,artist,subartist,level,date,path,folder,stagefile,banner,backbmp,parent,maxbpm,minbpm,random,longnote,judge,mode,bga,difficulty,favorite,type,txt,karinotes,adddate,exlevel) VALUES(\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,%d,%d,%d,%d,%d,%d,0,0,%d,%d,%d,%d)",
 						meta.hash.body, meta.title.body, meta.subtitle.body, meta.genre.body, meta.artist.body, meta.subartist.body, meta.selLevel, filetime, searchPath.body, AssignCRC32(meta.folderpath).body, meta.stagefilepath.body, meta.bannerpath.body, meta.backBMPpath.body, AssignCRC32(meta.parentfolderpath).body, meta.maxbpm, meta.minbpm, meta.random, meta.longnote, meta.judge, meta.keymode, meta.bga, meta.difficulty, (int)meta.hasTxt, meta.notecount, now, meta.exlevel);
 					SQL_Run(str, sql);
-                    sqlite3_snprintf(2048, str, "INSERT INTO openlr2_preview (hash,previewpath) VALUES(\'%q\',\'%q\') ON CONFLICT(hash) DO UPDATE SET previewpath=excluded.previewpath",
-                         meta.hash.body, meta.previewpath.body);
-                    SQL_Run(str, sql);
+					sqlite3_snprintf(2048, str, "INSERT INTO openlr2_preview (hash,previewpath) VALUES(\'%q\',\'%q\') ON CONFLICT(hash) DO UPDATE SET previewpath=excluded.previewpath",
+						meta.hash.body, meta.previewpath.body);
+					SQL_Run(str, sql);
 					if (g_fullSongPass) g_processedSongPaths.insert(MakePathKey(searchPath));
 				}
 				count++;
@@ -1513,9 +1513,9 @@ int ReloadSongsByQuery(CSTR query, sqlite3 *sql, CONFIG_JUKEBOX *jb, ReloadProgr
 						LoadBMSMETAFromDB(&meta, sql);
 						SQL_Run(sqlite3_snprintf(1024, sBuf, "INSERT INTO song (hash,title,subtitle,genre,artist,subartist,level,date,path,folder,stagefile,banner,backbmp,parent,maxbpm,minbpm,random,longnote,judge,mode,bga,difficulty,favorite,type,txt,karinotes,adddate,exlevel) VALUES(\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,%d,%d,%d,%d,%d,%d,0,0,%d,%d,%d,%d)",
 							meta.hash.body, meta.title.body, meta.subtitle.body, meta.genre.body, meta.artist.body, meta.subartist.body, meta.selLevel, newTime, str.body, AssignCRC32(meta.folderpath).body, meta.stagefilepath.body, meta.bannerpath.body, meta.backBMPpath.body,AssignCRC32(meta.parentfolderpath).body,meta.maxbpm,meta.minbpm,meta.random,meta.longnote,meta.judge,meta.keymode,meta.bga,meta.difficulty,(int)meta.hasTxt,meta.notecount,now,meta.exlevel), sql);
-                        SQL_Run(sqlite3_snprintf(1024, sBuf, "INSERT INTO openlr2_preview (hash,previewpath) VALUES(\'%q\',\'%q\') ON CONFLICT(hash) DO UPDATE SET previewpath=excluded.previewpath",
-                            meta.hash.body, meta.previewpath.body), sql);
-                        if (g_fullSongPass) g_processedSongPaths.insert(MakePathKey(str));
+						SQL_Run(sqlite3_snprintf(1024, sBuf, "INSERT INTO openlr2_preview (hash,previewpath) VALUES(\'%q\',\'%q\') ON CONFLICT(hash) DO UPDATE SET previewpath=excluded.previewpath",
+							meta.hash.body, meta.previewpath.body), sql);
+						if (g_fullSongPass) g_processedSongPaths.insert(MakePathKey(str));
 					}
 					else if (is_lr2folder) {
 						SQL_Run(sqlite3_snprintf(1024, sBuf, "DELETE FROM folder WHERE path=\'%q\'", str.body), sql);
@@ -2288,17 +2288,17 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 					thisFolder = SQL_GetColumn(9, pStmt);
 					song.folder = thisFolder;
 
-                    sqlite3_stmt *pStmtPreview;
-                    char previewQuery[512];
-                    sqlite3_snprintf(512, previewQuery, "SELECT previewpath FROM openlr2_preview WHERE hash=\'%q\'", song.hash.body);
-                    SQL_prepare(previewQuery, sql, &pStmtPreview);
-                    if (sqlite3_step(pStmtPreview) == 100) {
-                        song.previewfile = SQL_GetColumn(0, pStmtPreview);
-                        if (song.previewfile.isDiff("(null)") && song.previewfile.length() > 4) song.isPreviewfile = true;
-                    }
-                    sqlite3_finalize(pStmtPreview);
+					sqlite3_stmt *pStmtPreview;
+					char previewQuery[512];
+					sqlite3_snprintf(512, previewQuery, "SELECT previewpath FROM openlr2_preview WHERE hash=\'%q\'", song.hash.body);
+					SQL_prepare(previewQuery, sql, &pStmtPreview);
+					if (sqlite3_step(pStmtPreview) == 100) {
+						song.previewfile = SQL_GetColumn(0, pStmtPreview);
+						if (song.previewfile.isDiff("(null)") && song.previewfile.length() > 4) song.isPreviewfile = true;
+					}
+					sqlite3_finalize(pStmtPreview);
 
-                    if (song.keymode > 0) {
+					if (song.keymode > 0) {
 						song.mybest.clear = sqlite3_column_int(pStmt, 30);
 						song.mybest.stat_pgreat = sqlite3_column_int(pStmt, 31);
 						song.mybest.stat_great = sqlite3_column_int(pStmt, 32);
@@ -2779,7 +2779,7 @@ int LoadLR2CustomFolder(sqlite3 *sql, CONFIG_JUKEBOX *jb, CSTR scoreDBpath, char
 		SQL_Run("CREATE TABLE song(hash TEXT ,title TEXT ,subtitle TEXT ,genre TEXT,artist TEXT,subartist TEXT,tag TEXT ,path TEXT primary key ,type INTEGER,folder TEXT,stagefile TEXT,banner TEXT,backbmp TEXT,parent TEXT,level INTEGER,difficulty INTEGER,maxbpm INTEGER,minbpm INTEGER,mode INTEGER,judge INTEGER,longnote INTEGER,bga INTEGER,random INTEGER,date INTEGER,favorite INTEGER,txt INTEGER,karinotes INTEGER,adddate INTEGER,exlevel INTEGER)", sql);
 		SQL_Run("CREATE INDEX hashidx ON song (hash)", sql);
 		SQL_Run("CREATE INDEX parentidx ON song (parent)", sql);
-        SQL_Run("CREATE TABLE openlr2_preview(hash TEXT primary key, previewpath TEXT)", sql);
+		SQL_Run("CREATE TABLE openlr2_preview(hash TEXT primary key, previewpath TEXT)", sql);
 		SQL_Run("DROP TABLE course", sql);
 		SQL_Run("CREATE TABLE nonstop(id INTEGER primary key,title TEXT,line INTEGER,hash TEXT,ir INTEGER)", sql);
 		SQL_Run("CREATE TABLE expert(id INTEGER primary key,title TEXT,line INTEGER,hash TEXT,ir INTEGER)", sql);
@@ -2910,7 +2910,7 @@ int InitBMSMETA(BMSMETA *meta_) {
 	meta.backBMPpath.fillzero();
 	meta.parentfolderpath.fillzero();
 	meta.folderpath.fillzero();
-    meta.previewpath.fillzero();
+	meta.previewpath.fillzero();
 	meta.tag.fillzero();
 	meta.notecount = 0;
 	meta.maxbpm = 0;
@@ -2928,24 +2928,24 @@ int InitBMSMETA(BMSMETA *meta_) {
 }
 
 static void tryFindPreviewFile(BMSMETA *meta) {
-    if (!std::filesystem::exists(meta->folderpath.body)) {
-        meta->previewpath.fillzero();
-        return;
-    }
+	if (!std::filesystem::exists(meta->folderpath.body)) {
+		meta->previewpath.fillzero();
+		return;
+	}
 
-    for (const auto& entry : std::filesystem::directory_iterator{meta->folderpath.body}) {
-        std::string filename = entry.path().filename().string();
-        std::string lowerFilename = filename;
-        for(auto& c : filename) {
-            c = tolower(c);
-        }
+	for (const auto& entry : std::filesystem::directory_iterator{meta->folderpath.body}) {
+		std::string filename = entry.path().filename().string();
+		std::string lowerFilename = filename;
+		for(auto& c : filename) {
+			c = tolower(c);
+		}
 
-        if (entry.is_regular_file() && lowerFilename.starts_with("preview") && (lowerFilename.ends_with(".wav")
-            || lowerFilename.ends_with(".ogg") || lowerFilename.ends_with(".mp3") || lowerFilename.ends_with(".flac"))) {
-            meta->previewpath = filename.c_str();
-            return;
-        }
-    }
+		if (entry.is_regular_file() && lowerFilename.starts_with("preview") && (lowerFilename.ends_with(".wav")
+			|| lowerFilename.ends_with(".ogg") || lowerFilename.ends_with(".mp3") || lowerFilename.ends_with(".flac"))) {
+			meta->previewpath = filename.c_str();
+			return;
+		}
+	}
 }
 
 int ParseBMSMETA(BMSMETA *meta, CSTR filepath, char flag) {
@@ -3089,11 +3089,11 @@ int ParseBMSMETA(BMSMETA *meta, CSTR filepath, char flag) {
 	if (IsFileExist(dir)) meta->hasTxt = true;
 	meta->notecount = notes;
 
-    CSTR previewFullPath;
-    previewFullPath.assign(meta->folderpath).add(meta->previewpath);
-    if (meta->previewpath.length() == 0 || !IsFileExist(previewFullPath)) {
-        tryFindPreviewFile(meta);
-    }
+	CSTR previewFullPath;
+	previewFullPath.assign(meta->folderpath).add(meta->previewpath);
+	if (meta->previewpath.length() == 0 || !IsFileExist(previewFullPath)) {
+		tryFindPreviewFile(meta);
+	}
 
 	return 1;
 }

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -199,7 +199,8 @@ bool IsTextCommand(std::string_view line) {
 		StartsWithICaseAscii(line, "#COMMAND") ||
 		StartsWithICaseAscii(line, "#STAGEFILE") ||
 		StartsWithICaseAscii(line, "#BANNER") ||
-		StartsWithICaseAscii(line, "#BACKBMP");
+		StartsWithICaseAscii(line, "#BACKBMP") ||
+        StartsWithICaseAscii(line, "#PREVIEW");
 }
 
 bool ParseTextCommand(BMSMETA& meta, CSTR& line) {
@@ -220,6 +221,7 @@ bool ParseTextCommand(BMSMETA& meta, CSTR& line) {
 	if (GetStringBodyStr(&line, "#STAGEFILE", &meta.stagefilepath)) return true;
 	if (GetStringBodyStr(&line, "#BANNER", &meta.bannerpath)) return true;
 	if (GetStringBodyStr(&line, "#BACKBMP", &meta.backBMPpath)) return true;
+    if (GetStringBodyStr(&line, "#PREVIEW", &meta.previewpath)) return true;
 	return false;
 }
 
@@ -335,9 +337,11 @@ void COPY_SONGDATA(SONGDATA *self, SONGDATA *other){
 	self->stagefile = other->stagefile;
 	self->banner = other->banner;
 	self->backBMP = other->backBMP;
+    self->previewfile = other->previewfile;
 	self->isStagefile = other->isStagefile;
 	self->isBanner = other->isBanner;
 	self->isBackBMP = other->isBackBMP;
+    self->isPreviewfile = other->isPreviewfile;
 	self->difficulty = other->difficulty;
 	self->level = other->level;
 	self->exlevel = other->exlevel;
@@ -392,6 +396,7 @@ int InitSongData(SONGDATA *song){
 	song->stagefile.fillzero();
 	song->banner.fillzero();
 	song->backBMP.fillzero();
+    song->previewfile.fillzero();
 	song->folder.fillzero();
 	song->difficulty = 0;
 	song->folderType = 0;
@@ -406,6 +411,7 @@ int InitSongData(SONGDATA *song){
 	song->isStagefile = false;
 	song->isBanner = false;
 	song->isBackBMP = false;
+    song->isPreviewfile = false;
 	song->replayExist = 0;
 	song->favorite = 0;
 	song->adddate = 0;
@@ -661,6 +667,9 @@ int EditTag(SONGDATA *song, sqlite3 *sql) {
 		sqlite3_snprintf(1024, query, "INSERT INTO song (hash,title,subtitle,genre,artist,subartist,level,date,path,folder,stagefile,banner,backbmp,parent,maxbpm,minbpm,random,longnote,judge,mode,bga,difficulty,favorite,type,txt,karinotes,adddate,exlevel) VALUES(\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,%d,%d,%d,%d,%d,%d,0,0,%d,%d,%d,%d)",
 			meta.hash.body, meta.title.body, meta.subtitle.body, meta.genre.body, meta.artist.body, meta.subartist.body, meta.selLevel, wtime, song->filepath.body, AssignCRC32(meta.folderpath).body, meta.stagefilepath.body,meta.bannerpath.body,meta.backBMPpath.body, AssignCRC32(meta.parentfolderpath).body, meta.maxbpm,meta.minbpm, meta.random,meta.longnote,meta.judge,meta.keymode,meta.bga,meta.difficulty,(int)meta.hasTxt,meta.notecount,temp,meta.exlevel);
 		SQL_Run(query, sql);
+        sqlite3_snprintf(1024, query, "INSERT INTO openlr2_preview (hash,previewpath) VALUES(\'%q\',\'%q\') ON CONFLICT(hash) DO UPDATE SET previewpath=excluded.previewpath",
+                         meta.hash.body, meta.previewpath.body);
+        SQL_Run(query, sql);
 
 		if (meta.difficulty <= 0 || meta.difficulty > 5) {
 			SetUndefinedDifficulty(sql);
@@ -1251,6 +1260,7 @@ int GetSongDataFromPath(CSTR filepath, SONGDATA *song, sqlite3 *sql, SONGSELECT 
 	song->artist = meta.artist;
 	song->backBMP = meta.backBMPpath;
 	song->stagefile = meta.stagefilepath;
+    song->previewfile = meta.previewpath;
 	song->banner = meta.bannerpath;
 	song->bga = meta.bga;
 	song->difficulty = meta.difficulty;
@@ -1365,6 +1375,9 @@ int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 					sqlite3_snprintf(2048, str, "INSERT INTO song (hash,title,subtitle,genre,artist,subartist,level,date,path,folder,stagefile,banner,backbmp,parent,maxbpm,minbpm,random,longnote,judge,mode,bga,difficulty,favorite,type,txt,karinotes,adddate,exlevel) VALUES(\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,%d,%d,%d,%d,%d,%d,0,0,%d,%d,%d,%d)",
 						meta.hash.body, meta.title.body, meta.subtitle.body, meta.genre.body, meta.artist.body, meta.subartist.body, meta.selLevel, filetime, searchPath.body, AssignCRC32(meta.folderpath).body, meta.stagefilepath.body, meta.bannerpath.body, meta.backBMPpath.body, AssignCRC32(meta.parentfolderpath).body, meta.maxbpm, meta.minbpm, meta.random, meta.longnote, meta.judge, meta.keymode, meta.bga, meta.difficulty, (int)meta.hasTxt, meta.notecount, now, meta.exlevel);
 					SQL_Run(str, sql);
+                    sqlite3_snprintf(2048, str, "INSERT INTO openlr2_preview (hash,previewpath) VALUES(\'%q\',\'%q\') ON CONFLICT(hash) DO UPDATE SET previewpath=excluded.previewpath",
+                         meta.hash.body, meta.previewpath.body);
+                    SQL_Run(str, sql);
 					if (g_fullSongPass) g_processedSongPaths.insert(MakePathKey(searchPath));
 				}
 				count++;
@@ -1500,7 +1513,9 @@ int ReloadSongsByQuery(CSTR query, sqlite3 *sql, CONFIG_JUKEBOX *jb, ReloadProgr
 						LoadBMSMETAFromDB(&meta, sql);
 						SQL_Run(sqlite3_snprintf(1024, sBuf, "INSERT INTO song (hash,title,subtitle,genre,artist,subartist,level,date,path,folder,stagefile,banner,backbmp,parent,maxbpm,minbpm,random,longnote,judge,mode,bga,difficulty,favorite,type,txt,karinotes,adddate,exlevel) VALUES(\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,%d,%d,%d,%d,%d,%d,0,0,%d,%d,%d,%d)",
 							meta.hash.body, meta.title.body, meta.subtitle.body, meta.genre.body, meta.artist.body, meta.subartist.body, meta.selLevel, newTime, str.body, AssignCRC32(meta.folderpath).body, meta.stagefilepath.body, meta.bannerpath.body, meta.backBMPpath.body,AssignCRC32(meta.parentfolderpath).body,meta.maxbpm,meta.minbpm,meta.random,meta.longnote,meta.judge,meta.keymode,meta.bga,meta.difficulty,(int)meta.hasTxt,meta.notecount,now,meta.exlevel), sql);
-						if (g_fullSongPass) g_processedSongPaths.insert(MakePathKey(str));
+                        SQL_Run(sqlite3_snprintf(1024, sBuf, "INSERT INTO openlr2_preview (hash,previewpath) VALUES(\'%q\',\'%q\') ON CONFLICT(hash) DO UPDATE SET previewpath=excluded.previewpath",
+                            meta.hash.body, meta.previewpath.body), sql);
+                        if (g_fullSongPass) g_processedSongPaths.insert(MakePathKey(str));
 					}
 					else if (is_lr2folder) {
 						SQL_Run(sqlite3_snprintf(1024, sBuf, "DELETE FROM folder WHERE path=\'%q\'", str.body), sql);
@@ -2273,7 +2288,17 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 					thisFolder = SQL_GetColumn(9, pStmt);
 					song.folder = thisFolder;
 
-					if (song.keymode > 0) {
+                    sqlite3_stmt *pStmtPreview;
+                    char previewQuery[512];
+                    sqlite3_snprintf(512, previewQuery, "SELECT previewpath FROM openlr2_preview WHERE hash=\'%q\'", song.hash.body);
+                    SQL_prepare(previewQuery, sql, &pStmtPreview);
+                    if (sqlite3_step(pStmtPreview) == 100) {
+                        song.previewfile = SQL_GetColumn(0, pStmtPreview);
+                        if (song.previewfile.isDiff("(null)") && song.previewfile.length() > 4) song.isPreviewfile = true;
+                    }
+                    sqlite3_finalize(pStmtPreview);
+
+                    if (song.keymode > 0) {
 						song.mybest.clear = sqlite3_column_int(pStmt, 30);
 						song.mybest.stat_pgreat = sqlite3_column_int(pStmt, 31);
 						song.mybest.stat_great = sqlite3_column_int(pStmt, 32);
@@ -2754,6 +2779,7 @@ int LoadLR2CustomFolder(sqlite3 *sql, CONFIG_JUKEBOX *jb, CSTR scoreDBpath, char
 		SQL_Run("CREATE TABLE song(hash TEXT ,title TEXT ,subtitle TEXT ,genre TEXT,artist TEXT,subartist TEXT,tag TEXT ,path TEXT primary key ,type INTEGER,folder TEXT,stagefile TEXT,banner TEXT,backbmp TEXT,parent TEXT,level INTEGER,difficulty INTEGER,maxbpm INTEGER,minbpm INTEGER,mode INTEGER,judge INTEGER,longnote INTEGER,bga INTEGER,random INTEGER,date INTEGER,favorite INTEGER,txt INTEGER,karinotes INTEGER,adddate INTEGER,exlevel INTEGER)", sql);
 		SQL_Run("CREATE INDEX hashidx ON song (hash)", sql);
 		SQL_Run("CREATE INDEX parentidx ON song (parent)", sql);
+        SQL_Run("CREATE TABLE openlr2_preview(hash TEXT primary key, previewpath TEXT)", sql);
 		SQL_Run("DROP TABLE course", sql);
 		SQL_Run("CREATE TABLE nonstop(id INTEGER primary key,title TEXT,line INTEGER,hash TEXT,ir INTEGER)", sql);
 		SQL_Run("CREATE TABLE expert(id INTEGER primary key,title TEXT,line INTEGER,hash TEXT,ir INTEGER)", sql);
@@ -2884,6 +2910,7 @@ int InitBMSMETA(BMSMETA *meta_) {
 	meta.backBMPpath.fillzero();
 	meta.parentfolderpath.fillzero();
 	meta.folderpath.fillzero();
+    meta.previewpath.fillzero();
 	meta.tag.fillzero();
 	meta.notecount = 0;
 	meta.maxbpm = 0;
@@ -2898,6 +2925,26 @@ int InitBMSMETA(BMSMETA *meta_) {
 	meta.bga = 0;
 	meta.hasTxt = false;
 	return 1;
+}
+
+static void tryFindPreviewFile(BMSMETA *meta) {
+    if (!std::filesystem::exists(meta->folderpath.body)) {
+        return;
+    }
+
+    for (const auto& entry : std::filesystem::directory_iterator{meta->folderpath.body}) {
+        std::string filename = entry.path().filename().string();
+        std::string lowerFilename = filename;
+        for(auto& c : filename) {
+            c = tolower(c);
+        }
+
+        if (entry.is_regular_file() && lowerFilename.starts_with("preview") && (lowerFilename.ends_with(".wav")
+            || lowerFilename.ends_with(".ogg") || lowerFilename.ends_with(".mp3") || lowerFilename.ends_with(".flac"))) {
+            meta->previewpath = filename.c_str();
+            return;
+        }
+    }
 }
 
 int ParseBMSMETA(BMSMETA *meta, CSTR filepath, char flag) {
@@ -3040,6 +3087,11 @@ int ParseBMSMETA(BMSMETA *meta, CSTR filepath, char flag) {
 	dir.add("*.txt");
 	if (IsFileExist(dir)) meta->hasTxt = true;
 	meta->notecount = notes;
+
+    if (meta->previewpath.length() == 0) {
+        tryFindPreviewFile(meta);
+    }
+
 	return 1;
 }
 

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -674,9 +674,7 @@ int EditTag(SONGDATA *song, sqlite3 *sql) {
 		sqlite3_snprintf(1024, query, "INSERT INTO song (hash,title,subtitle,genre,artist,subartist,level,date,path,folder,stagefile,banner,backbmp,parent,maxbpm,minbpm,random,longnote,judge,mode,bga,difficulty,favorite,type,txt,karinotes,adddate,exlevel) VALUES(\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,%d,%d,%d,%d,%d,%d,0,0,%d,%d,%d,%d)",
 			meta.hash.body, meta.title.body, meta.subtitle.body, meta.genre.body, meta.artist.body, meta.subartist.body, meta.selLevel, wtime, song->filepath.body, AssignCRC32(meta.folderpath).body, meta.stagefilepath.body,meta.bannerpath.body,meta.backBMPpath.body, AssignCRC32(meta.parentfolderpath).body, meta.maxbpm,meta.minbpm, meta.random,meta.longnote,meta.judge,meta.keymode,meta.bga,meta.difficulty,(int)meta.hasTxt,meta.notecount,temp,meta.exlevel);
 		SQL_Run(query, sql);
-		sqlite3_snprintf(1024, query, "INSERT INTO openlr2_preview (hash,previewpath) VALUES(\'%q\',\'%q\') ON CONFLICT(hash) DO UPDATE SET previewpath=excluded.previewpath",
-			meta.hash.body, meta.previewpath.c_str());
-		sqlite3_exec(sql, query, nullptr, nullptr, nullptr);
+		openlr2::updateSongPreview(meta.hash.body, meta.previewpath.c_str(), sql);
 
 		if (meta.difficulty <= 0 || meta.difficulty > 5) {
 			SetUndefinedDifficulty(sql);
@@ -1378,9 +1376,7 @@ int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 					sqlite3_snprintf(2048, str, "INSERT INTO song (hash,title,subtitle,genre,artist,subartist,level,date,path,folder,stagefile,banner,backbmp,parent,maxbpm,minbpm,random,longnote,judge,mode,bga,difficulty,favorite,type,txt,karinotes,adddate,exlevel) VALUES(\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,%d,%d,%d,%d,%d,%d,0,0,%d,%d,%d,%d)",
 						meta.hash.body, meta.title.body, meta.subtitle.body, meta.genre.body, meta.artist.body, meta.subartist.body, meta.selLevel, filetime, searchPath.body, AssignCRC32(meta.folderpath).body, meta.stagefilepath.body, meta.bannerpath.body, meta.backBMPpath.body, AssignCRC32(meta.parentfolderpath).body, meta.maxbpm, meta.minbpm, meta.random, meta.longnote, meta.judge, meta.keymode, meta.bga, meta.difficulty, (int)meta.hasTxt, meta.notecount, now, meta.exlevel);
 					SQL_Run(str, sql);
-					sqlite3_snprintf(2048, str, "INSERT INTO openlr2_preview (hash,previewpath) VALUES(\'%q\',\'%q\') ON CONFLICT(hash) DO UPDATE SET previewpath=excluded.previewpath",
-						meta.hash.body, meta.previewpath.c_str());
-					sqlite3_exec(sql, str, nullptr, nullptr, nullptr);
+					openlr2::updateSongPreview(meta.hash.body, meta.previewpath.c_str(), sql);
 					if (g_fullSongPass) g_processedSongPaths.insert(MakePathKey(searchPath));
 				}
 				count++;
@@ -1516,9 +1512,7 @@ int ReloadSongsByQuery(CSTR query, sqlite3 *sql, CONFIG_JUKEBOX *jb, ReloadProgr
 						LoadBMSMETAFromDB(&meta, sql);
 						SQL_Run(sqlite3_snprintf(1024, sBuf, "INSERT INTO song (hash,title,subtitle,genre,artist,subartist,level,date,path,folder,stagefile,banner,backbmp,parent,maxbpm,minbpm,random,longnote,judge,mode,bga,difficulty,favorite,type,txt,karinotes,adddate,exlevel) VALUES(\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,%d,%d,%d,%d,%d,%d,0,0,%d,%d,%d,%d)",
 							meta.hash.body, meta.title.body, meta.subtitle.body, meta.genre.body, meta.artist.body, meta.subartist.body, meta.selLevel, newTime, str.body, AssignCRC32(meta.folderpath).body, meta.stagefilepath.body, meta.bannerpath.body, meta.backBMPpath.body,AssignCRC32(meta.parentfolderpath).body,meta.maxbpm,meta.minbpm,meta.random,meta.longnote,meta.judge,meta.keymode,meta.bga,meta.difficulty,(int)meta.hasTxt,meta.notecount,now,meta.exlevel), sql);
-						sqlite3_snprintf(1024, sBuf, "INSERT INTO openlr2_preview (hash,previewpath) VALUES(\'%q\',\'%q\') ON CONFLICT(hash) DO UPDATE SET previewpath=excluded.previewpath",
-							meta.hash.body, meta.previewpath.c_str());
-						sqlite3_exec(sql, sBuf, nullptr, nullptr, nullptr);
+						openlr2::updateSongPreview(meta.hash.body, meta.previewpath.c_str(), sql);
 						if (g_fullSongPass) g_processedSongPaths.insert(MakePathKey(str));
 					}
 					else if (is_lr2folder) {
@@ -2930,18 +2924,6 @@ int InitBMSMETA(BMSMETA *meta_) {
 	return 1;
 }
 
-static std::string TryFindPreviewFile(const std::string &folderpath) {
-	std::error_code ec{};
-	for (const auto& entry : std::filesystem::directory_iterator{folderpath, ec}) {
-		std::string filename = entry.path().filename().string();
-		if (entry.is_regular_file() && StartsWithICaseAscii(filename, "preview") && IsSndFile(filename.c_str())) {
-			return filename;
-		}
-	}
-
-	return {};
-}
-
 int ParseBMSMETA(BMSMETA *meta, CSTR filepath, char flag) {
 	FILE *pFile;
 	float notes;
@@ -3086,7 +3068,7 @@ int ParseBMSMETA(BMSMETA *meta, CSTR filepath, char flag) {
 	CSTR previewFullPath;
 	previewFullPath.assign(meta->folderpath).add(meta->previewpath.c_str());
 	if (meta->previewpath.length() == 0 || !IsFileExist(previewFullPath)) {
-		meta->previewpath = TryFindPreviewFile(meta->folderpath.body);
+		meta->previewpath = openlr2::tryFindPreviewFile(meta->folderpath.body).value_or({});
 	}
 
 	return 1;
@@ -3100,4 +3082,23 @@ int openlr2::adjustFilterKey(CONFIG_SELECT const& cfg_select, int key) {
 	if (cfg_select.ignorePMS && key == 7) key = 0;
 	if (cfg_select.ignoreKeyAll && key == 0) key = 1;
 	return key;
+}
+
+std::optional<std::string> openlr2::tryFindPreviewFile(const std::filesystem::path& folderpath) {
+	std::error_code ec{};
+	for (const auto& entry : std::filesystem::directory_iterator{folderpath, ec}) {
+		std::string filename = entry.path().filename().string();
+		if (entry.is_regular_file() && StartsWithICaseAscii(filename, "preview") && IsSndFile(filename.c_str())) {
+			return filename;
+		}
+	}
+	return {};
+}
+
+void openlr2::updateSongPreview(const std::string& hash, const std::string& previewpath, sqlite3* sql) {
+	char query[512];
+
+	sqlite3_snprintf(512, query, "INSERT INTO openlr2_preview (hash,previewpath) VALUES(\'%q\',\'%q\') ON CONFLICT(hash) DO UPDATE SET previewpath=excluded.previewpath",
+		hash.c_str(), previewpath.c_str());
+	sqlite3_exec(sql, query, nullptr, nullptr, nullptr);
 }

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -172,6 +172,14 @@ bool GetRawBodyInt(std::string_view line, std::string_view head, int& out) {
 	return true;
 }
 
+bool GetStringBodyStr(std::string_view str, std::string_view head, std::string& out) {
+	if (StartsWithICaseAscii(str, head) && str.size() > head.size()) {
+		out = str.substr(head.length() + 1);
+		return true;
+	}
+	return false;
+}
+
 void UpdateBpmRange(BMSMETA& meta, const int bpm) {
 	if (bpm <= 0) return;
 	if (meta.maxbpm == 0) {
@@ -222,10 +230,7 @@ bool ParseTextCommand(BMSMETA& meta, CSTR& line) {
 	if (GetStringBodyStr(&line, "#STAGEFILE", &meta.stagefilepath)) return true;
 	if (GetStringBodyStr(&line, "#BANNER", &meta.bannerpath)) return true;
 	if (GetStringBodyStr(&line, "#BACKBMP", &meta.backBMPpath)) return true;
-	if (GetStringBodyStr(&line, "#PREVIEW", &buf)) {
-		meta.previewpath = buf.body;
-		return true;
-	}
+	if (GetStringBodyStr(line.body, "#PREVIEW", meta.previewpath)) return true;
 	return false;
 }
 
@@ -2291,11 +2296,8 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 					char previewQuery[512];
 					sqlite3_snprintf(512, previewQuery, "SELECT previewpath FROM openlr2_preview WHERE hash=\'%q\'", song.hash.body);
 					sqlite3_prepare(sql, previewQuery, -1, &pStmtPreview, nullptr);
-					if (sqlite3_step(pStmtPreview) == SQLITE_ROW) {
-						song.previewfile = SQL_GetColumn(0, pStmtPreview);
-						if (song.previewfile.value() == "(null)" || song.previewfile.value().length() <= 4) {
-							song.previewfile = {};
-						}
+					if (sqlite3_step(pStmtPreview) == SQLITE_ROW && sqlite3_column_bytes(pStmtPreview, 0) > 0) {
+						song.previewfile = reinterpret_cast<const char *>(sqlite3_column_text(pStmtPreview, 0));
 					}
 					sqlite3_finalize(pStmtPreview);
 
@@ -2780,7 +2782,7 @@ int LoadLR2CustomFolder(sqlite3 *sql, CONFIG_JUKEBOX *jb, CSTR scoreDBpath, char
 		SQL_Run("CREATE TABLE song(hash TEXT ,title TEXT ,subtitle TEXT ,genre TEXT,artist TEXT,subartist TEXT,tag TEXT ,path TEXT primary key ,type INTEGER,folder TEXT,stagefile TEXT,banner TEXT,backbmp TEXT,parent TEXT,level INTEGER,difficulty INTEGER,maxbpm INTEGER,minbpm INTEGER,mode INTEGER,judge INTEGER,longnote INTEGER,bga INTEGER,random INTEGER,date INTEGER,favorite INTEGER,txt INTEGER,karinotes INTEGER,adddate INTEGER,exlevel INTEGER)", sql);
 		SQL_Run("CREATE INDEX hashidx ON song (hash)", sql);
 		SQL_Run("CREATE INDEX parentidx ON song (parent)", sql);
-		sqlite3_exec(sql, "CREATE TABLE openlr2_preview(hash TEXT primary key, previewpath TEXT)", nullptr, nullptr, nullptr);
+		sqlite3_exec(sql, "CREATE TABLE openlr2_preview(hash TEXT PRIMARY KEY NOT NULL, previewpath TEXT NOT NULL)", nullptr, nullptr, nullptr);
 		SQL_Run("DROP TABLE course", sql);
 		SQL_Run("CREATE TABLE nonstop(id INTEGER primary key,title TEXT,line INTEGER,hash TEXT,ir INTEGER)", sql);
 		SQL_Run("CREATE TABLE expert(id INTEGER primary key,title TEXT,line INTEGER,hash TEXT,ir INTEGER)", sql);
@@ -2928,25 +2930,16 @@ int InitBMSMETA(BMSMETA *meta_) {
 	return 1;
 }
 
-static void tryFindPreviewFile(BMSMETA *meta) {
-	if (!std::filesystem::exists(meta->folderpath.body)) {
-		meta->previewpath.clear();
-		return;
-	}
-
-	for (const auto& entry : std::filesystem::directory_iterator{meta->folderpath.body}) {
+static std::string TryFindPreviewFile(const std::string &folderpath) {
+	std::error_code ec{};
+	for (const auto& entry : std::filesystem::directory_iterator{folderpath, ec}) {
 		std::string filename = entry.path().filename().string();
-		std::string lowerFilename = filename;
-		for(auto& c : filename) {
-			c = tolower(c);
-		}
-
-		if (entry.is_regular_file() && lowerFilename.starts_with("preview") && (lowerFilename.ends_with(".wav")
-			|| lowerFilename.ends_with(".ogg") || lowerFilename.ends_with(".mp3") || lowerFilename.ends_with(".flac"))) {
-			meta->previewpath = filename;
-			return;
+		if (entry.is_regular_file() && StartsWithICaseAscii(filename, "preview") && IsSndFile(filename.c_str())) {
+			return filename;
 		}
 	}
+
+	return {};
 }
 
 int ParseBMSMETA(BMSMETA *meta, CSTR filepath, char flag) {
@@ -3093,7 +3086,7 @@ int ParseBMSMETA(BMSMETA *meta, CSTR filepath, char flag) {
 	CSTR previewFullPath;
 	previewFullPath.assign(meta->folderpath).add(meta->previewpath.c_str());
 	if (meta->previewpath.length() == 0 || !IsFileExist(previewFullPath)) {
-		tryFindPreviewFile(meta);
+		meta->previewpath = TryFindPreviewFile(meta->folderpath.body);
 	}
 
 	return 1;

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -204,6 +204,7 @@ bool IsTextCommand(std::string_view line) {
 }
 
 bool ParseTextCommand(BMSMETA& meta, CSTR& line) {
+	CSTR buf;
 	if (GetDifficulty(&line, "#TITLE", &meta.title, &meta.subtitle, &meta.difficulty)) return true;
 	if (GetStringBodyStr(&line, "#GENRE", &meta.genre)) {
 		CSTR none;
@@ -221,7 +222,10 @@ bool ParseTextCommand(BMSMETA& meta, CSTR& line) {
 	if (GetStringBodyStr(&line, "#STAGEFILE", &meta.stagefilepath)) return true;
 	if (GetStringBodyStr(&line, "#BANNER", &meta.bannerpath)) return true;
 	if (GetStringBodyStr(&line, "#BACKBMP", &meta.backBMPpath)) return true;
-	if (GetStringBodyStr(&line, "#PREVIEW", &meta.previewpath)) return true;
+	if (GetStringBodyStr(&line, "#PREVIEW", &buf)) {
+		meta.previewpath = buf.body;
+		return true;
+	}
 	return false;
 }
 
@@ -341,7 +345,6 @@ void COPY_SONGDATA(SONGDATA *self, SONGDATA *other){
 	self->isStagefile = other->isStagefile;
 	self->isBanner = other->isBanner;
 	self->isBackBMP = other->isBackBMP;
-	self->isPreviewfile = other->isPreviewfile;
 	self->difficulty = other->difficulty;
 	self->level = other->level;
 	self->exlevel = other->exlevel;
@@ -396,7 +399,7 @@ int InitSongData(SONGDATA *song){
 	song->stagefile.fillzero();
 	song->banner.fillzero();
 	song->backBMP.fillzero();
-	song->previewfile.fillzero();
+	song->previewfile = {};
 	song->folder.fillzero();
 	song->difficulty = 0;
 	song->folderType = 0;
@@ -411,7 +414,6 @@ int InitSongData(SONGDATA *song){
 	song->isStagefile = false;
 	song->isBanner = false;
 	song->isBackBMP = false;
-	song->isPreviewfile = false;
 	song->replayExist = 0;
 	song->favorite = 0;
 	song->adddate = 0;
@@ -668,7 +670,7 @@ int EditTag(SONGDATA *song, sqlite3 *sql) {
 			meta.hash.body, meta.title.body, meta.subtitle.body, meta.genre.body, meta.artist.body, meta.subartist.body, meta.selLevel, wtime, song->filepath.body, AssignCRC32(meta.folderpath).body, meta.stagefilepath.body,meta.bannerpath.body,meta.backBMPpath.body, AssignCRC32(meta.parentfolderpath).body, meta.maxbpm,meta.minbpm, meta.random,meta.longnote,meta.judge,meta.keymode,meta.bga,meta.difficulty,(int)meta.hasTxt,meta.notecount,temp,meta.exlevel);
 		SQL_Run(query, sql);
 		sqlite3_snprintf(1024, query, "INSERT INTO openlr2_preview (hash,previewpath) VALUES(\'%q\',\'%q\') ON CONFLICT(hash) DO UPDATE SET previewpath=excluded.previewpath",
-			meta.hash.body, meta.previewpath.body);
+			meta.hash.body, meta.previewpath.c_str());
 		sqlite3_exec(sql, query, nullptr, nullptr, nullptr);
 
 		if (meta.difficulty <= 0 || meta.difficulty > 5) {
@@ -1376,7 +1378,7 @@ int SearchSongsFromPath(CSTR root, sqlite3 *sql, CSTR path) {
 						meta.hash.body, meta.title.body, meta.subtitle.body, meta.genre.body, meta.artist.body, meta.subartist.body, meta.selLevel, filetime, searchPath.body, AssignCRC32(meta.folderpath).body, meta.stagefilepath.body, meta.bannerpath.body, meta.backBMPpath.body, AssignCRC32(meta.parentfolderpath).body, meta.maxbpm, meta.minbpm, meta.random, meta.longnote, meta.judge, meta.keymode, meta.bga, meta.difficulty, (int)meta.hasTxt, meta.notecount, now, meta.exlevel);
 					SQL_Run(str, sql);
 					sqlite3_snprintf(2048, str, "INSERT INTO openlr2_preview (hash,previewpath) VALUES(\'%q\',\'%q\') ON CONFLICT(hash) DO UPDATE SET previewpath=excluded.previewpath",
-						meta.hash.body, meta.previewpath.body);
+						meta.hash.body, meta.previewpath.c_str());
 					sqlite3_exec(sql, str, nullptr, nullptr, nullptr);
 					if (g_fullSongPass) g_processedSongPaths.insert(MakePathKey(searchPath));
 				}
@@ -1514,7 +1516,7 @@ int ReloadSongsByQuery(CSTR query, sqlite3 *sql, CONFIG_JUKEBOX *jb, ReloadProgr
 						SQL_Run(sqlite3_snprintf(1024, sBuf, "INSERT INTO song (hash,title,subtitle,genre,artist,subartist,level,date,path,folder,stagefile,banner,backbmp,parent,maxbpm,minbpm,random,longnote,judge,mode,bga,difficulty,favorite,type,txt,karinotes,adddate,exlevel) VALUES(\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',\'%q\',%d,%d,%d,%d,%d,%d,%d,%d,0,0,%d,%d,%d,%d)",
 							meta.hash.body, meta.title.body, meta.subtitle.body, meta.genre.body, meta.artist.body, meta.subartist.body, meta.selLevel, newTime, str.body, AssignCRC32(meta.folderpath).body, meta.stagefilepath.body, meta.bannerpath.body, meta.backBMPpath.body,AssignCRC32(meta.parentfolderpath).body,meta.maxbpm,meta.minbpm,meta.random,meta.longnote,meta.judge,meta.keymode,meta.bga,meta.difficulty,(int)meta.hasTxt,meta.notecount,now,meta.exlevel), sql);
 						sqlite3_snprintf(1024, sBuf, "INSERT INTO openlr2_preview (hash,previewpath) VALUES(\'%q\',\'%q\') ON CONFLICT(hash) DO UPDATE SET previewpath=excluded.previewpath",
-							meta.hash.body, meta.previewpath.body);
+							meta.hash.body, meta.previewpath.c_str());
 						sqlite3_exec(sql, sBuf, nullptr, nullptr, nullptr);
 						if (g_fullSongPass) g_processedSongPaths.insert(MakePathKey(str));
 					}
@@ -2295,7 +2297,9 @@ int LoadFilteredBmsListFromDB(CSTR query, sqlite3 *sql, SONGSELECT *ss, int *dif
 					sqlite3_prepare(sql, previewQuery, -1, &pStmtPreview, nullptr);
 					if (sqlite3_step(pStmtPreview) == SQLITE_ROW) {
 						song.previewfile = SQL_GetColumn(0, pStmtPreview);
-						if (song.previewfile.isDiff("(null)") && song.previewfile.length() > 4) song.isPreviewfile = true;
+						if (song.previewfile.value() == "(null)" || song.previewfile.value().length() <= 4) {
+							song.previewfile = {};
+						}
 					}
 					sqlite3_finalize(pStmtPreview);
 
@@ -2911,7 +2915,7 @@ int InitBMSMETA(BMSMETA *meta_) {
 	meta.backBMPpath.fillzero();
 	meta.parentfolderpath.fillzero();
 	meta.folderpath.fillzero();
-	meta.previewpath.fillzero();
+	meta.previewpath.clear();
 	meta.tag.fillzero();
 	meta.notecount = 0;
 	meta.maxbpm = 0;
@@ -2930,7 +2934,7 @@ int InitBMSMETA(BMSMETA *meta_) {
 
 static void tryFindPreviewFile(BMSMETA *meta) {
 	if (!std::filesystem::exists(meta->folderpath.body)) {
-		meta->previewpath.fillzero();
+		meta->previewpath.clear();
 		return;
 	}
 
@@ -2943,7 +2947,7 @@ static void tryFindPreviewFile(BMSMETA *meta) {
 
 		if (entry.is_regular_file() && lowerFilename.starts_with("preview") && (lowerFilename.ends_with(".wav")
 			|| lowerFilename.ends_with(".ogg") || lowerFilename.ends_with(".mp3") || lowerFilename.ends_with(".flac"))) {
-			meta->previewpath = filename.c_str();
+			meta->previewpath = filename;
 			return;
 		}
 	}
@@ -3091,7 +3095,7 @@ int ParseBMSMETA(BMSMETA *meta, CSTR filepath, char flag) {
 	meta->notecount = notes;
 
 	CSTR previewFullPath;
-	previewFullPath.assign(meta->folderpath).add(meta->previewpath);
+	previewFullPath.assign(meta->folderpath).add(meta->previewpath.c_str());
 	if (meta->previewpath.length() == 0 || !IsFileExist(previewFullPath)) {
 		tryFindPreviewFile(meta);
 	}

--- a/LR2/LR2_songmanage.cpp
+++ b/LR2/LR2_songmanage.cpp
@@ -2929,6 +2929,7 @@ int InitBMSMETA(BMSMETA *meta_) {
 
 static void tryFindPreviewFile(BMSMETA *meta) {
     if (!std::filesystem::exists(meta->folderpath.body)) {
+        meta->previewpath.fillzero();
         return;
     }
 
@@ -3088,7 +3089,9 @@ int ParseBMSMETA(BMSMETA *meta, CSTR filepath, char flag) {
 	if (IsFileExist(dir)) meta->hasTxt = true;
 	meta->notecount = notes;
 
-    if (meta->previewpath.length() == 0) {
+    CSTR previewFullPath;
+    previewFullPath.assign(meta->folderpath).add(meta->previewpath);
+    if (meta->previewpath.length() == 0 || !IsFileExist(previewFullPath)) {
         tryFindPreviewFile(meta);
     }
 

--- a/LR2/LR2_songmanage.h
+++ b/LR2/LR2_songmanage.h
@@ -61,4 +61,8 @@ namespace openlr2 {
 
 int adjustFilterKey(CONFIG_SELECT const& cfg_select, int key);
 
+std::optional<std::string> tryFindPreviewFile(const std::filesystem::path& folderpath);
+
+void updateSongPreview(const std::string& hash, const std::string& previewpath, sqlite3* sql);
+
 } // namespace openlr2

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -813,7 +813,7 @@ int main(int argc, char** argv) {
 		gs.sSelect.listSelectedBarFromScreenTop = 0;
 		gs.sSelect.flag_folderlamp = 0;
 		gs.sSelect.cur_song = 0;
-        gs.sSelect.previewSound.load = 0;
+		gs.sSelect.previewSound.load = 0;
 		ProcS_Select(&gs);
 		gs.gameplay.replay.status = 0;
 		gs.gameplay.isAutoplay = (gs.cmd_auto != 0);

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -813,6 +813,7 @@ int main(int argc, char** argv) {
 		gs.sSelect.listSelectedBarFromScreenTop = 0;
 		gs.sSelect.flag_folderlamp = 0;
 		gs.sSelect.cur_song = 0;
+        gs.sSelect.previewSound.load = 0;
 		ProcS_Select(&gs);
 		gs.gameplay.replay.status = 0;
 		gs.gameplay.isAutoplay = (gs.cmd_auto != 0);

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1670,14 +1670,15 @@ static void ThreadProc_RankingAutoUpdate(game* g) {
 	SetObjectStrings_SongSelect(g);
 }
 
-static void LoadPreviewFile(game *g, CSTR *previewpath) {
+static void LoadPreviewFile(game *g, const std::string &previewpath) {
 	g->gameplay.flag_closingPhase = 0;
 	StopSound(&g->audio, &g->sSelect.previewSound);
 
-	if (!g->sSelect.previewSound.load || previewpath->isDiff(&g->sSelect.previewSound.filename)) {
+	const auto prevFile = g->sSelect.previewSound.filename.body;
+	if (!g->sSelect.previewSound.load || prevFile == nullptr || previewpath != prevFile) {
 		ReleaseSound(&g->audio, &g->sSelect.previewSound);
 		if (g->gameplay.flag_closingPhase == 0 && g->procSelecter == 2 && g->gameplay.previewStatus == 1) {
-			LoadSound(&g->audio, &g->sSelect.previewSound, *previewpath, true, false, true);
+			LoadSound(&g->audio, &g->sSelect.previewSound, previewpath.c_str(), true, false, true);
 		}
 	}
 
@@ -1696,11 +1697,10 @@ static void ThreadProc_LoadPreview(game *g) {
 
 	if (!g->config.select.ignorePreviewFiles) {
 		SONGDATA &song = g->sSelect.bmsList[g->sSelect.cur_song];
-		if (song.isPreviewfile) {
-			CSTR previewpath;
-			previewpath.assign(song.folder).add(song.previewfile);
-			if (IsFileExist(previewpath)) {
-				LoadPreviewFile(g, &previewpath);
+		if (song.previewfile) {
+			const auto previewpath = std::filesystem::path(song.folder.body) / song.previewfile.value();
+			if (std::filesystem::exists(previewpath)) {
+				LoadPreviewFile(g, previewpath.string());
 				return;
 			}
 		}

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1694,13 +1694,15 @@ static void LoadPreviewFile(game *g, CSTR *previewpath) {
 static void ThreadProc_LoadPreview(game *g) {
 	BMSMETA meta;
 
-    SONGDATA *song = &g->sSelect.bmsList[g->sSelect.cur_song];
-    if (song->isPreviewfile) {
-        CSTR previewpath;
-        previewpath.assign(song->folder).add(song->previewfile);
-        if (IsFileExist(previewpath)) {
-            LoadPreviewFile(g, &previewpath);
-            return;
+    if (!g->config.select.ignorePreviewFiles) {
+        SONGDATA *song = &g->sSelect.bmsList[g->sSelect.cur_song];
+        if (song->isPreviewfile) {
+            CSTR previewpath;
+            previewpath.assign(song->folder).add(song->previewfile);
+            if (IsFileExist(previewpath)) {
+                LoadPreviewFile(g, &previewpath);
+                return;
+            }
         }
     }
 
@@ -2736,7 +2738,7 @@ int ProcI_Select(game *g, sqlite3 *sql) {
 	}
 
 	if(g->config.select.isPreview){
-		if (GetTimeLapse(11, &g->timer1) >= 500.0 && g->gameplay.previewStatus == 0 &&
+		if (GetTimeLapse(11, &g->timer1) >= g->config.select.previewDelay && g->gameplay.previewStatus == 0 &&
 				g->sSelect.bmsList[g->sSelect.cur_song].keymode >= 5 &&
 				g->sSelect.bmsList[g->sSelect.cur_song].courseStageCount == 0 &&
 				(!g->gameplay.hThreadPreview.valid() ||

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1695,10 +1695,10 @@ static void ThreadProc_LoadPreview(game *g) {
 	BMSMETA meta;
 
 	if (!g->config.select.ignorePreviewFiles) {
-		SONGDATA *song = &g->sSelect.bmsList[g->sSelect.cur_song];
-		if (song->isPreviewfile) {
+		SONGDATA &song = g->sSelect.bmsList[g->sSelect.cur_song];
+		if (song.isPreviewfile) {
 			CSTR previewpath;
-			previewpath.assign(song->folder).add(song->previewfile);
+			previewpath.assign(song.folder).add(song.previewfile);
 			if (IsFileExist(previewpath)) {
 				LoadPreviewFile(g, &previewpath);
 				return;

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1670,8 +1670,39 @@ static void ThreadProc_RankingAutoUpdate(game* g) {
 	SetObjectStrings_SongSelect(g);
 }
 
+static void LoadPreviewFile(game *g, CSTR *previewpath) {
+    g->gameplay.flag_closingPhase = 0;
+    StopSound(&g->audio, &g->sSelect.previewSound);
+
+    if (!g->sSelect.previewSound.load || previewpath->isDiff(&g->sSelect.previewSound.filename)) {
+        ReleaseSound(&g->audio, &g->sSelect.previewSound);
+        if (g->gameplay.flag_closingPhase == 0 && g->procSelecter == 2 && g->gameplay.previewStatus == 1) {
+            LoadSound(&g->audio, &g->sSelect.previewSound, *previewpath, true, false, true);
+        }
+    }
+
+    if (g->gameplay.flag_closingPhase == 0 && g->procSelecter == 2 && g->gameplay.previewStatus == 1) {
+        SetFadePreview(&g->audio, 500, 1);
+        PlaySound(&g->audio, &g->sSelect.previewSound, g->audio.chnKey, -1);
+        g->gameplay.previewStatus = 2;
+    } else {
+        g->gameplay.previewStatus = 0;
+        g->gameplay.isPreviewLoad = 0;
+    }
+}
+
 static void ThreadProc_LoadPreview(game *g) {
 	BMSMETA meta;
+
+    SONGDATA *song = &g->sSelect.bmsList[g->sSelect.cur_song];
+    if (song->isPreviewfile) {
+        CSTR previewpath;
+        previewpath.assign(song->folder).add(song->previewfile);
+        if (IsFileExist(previewpath)) {
+            LoadPreviewFile(g, &previewpath);
+            return;
+        }
+    }
 
 	if (!IsFileExist(g->gameplay.previewBMSfilepath)) {
 		g->gameplay.isPreviewLoad = 0;
@@ -2726,12 +2757,16 @@ int ProcI_Select(game *g, sqlite3 *sql) {
 				for (int i = 0; i < SLOTS; i++) {
 					StopSound(&g->audio, &g->gameplay.keysound[i]);
 				}
+                StopSound(&g->audio, &g->sSelect.previewSound);
 				g->gameplay.previewStatus = 0;
 				SetFadePreview(&g->audio, 1000, 0);
 				g->gameplay.previewBMShash = g->sSelect.bmsList[g->sSelect.cur_song].hash;
 				ErrorLogFmtAdd("プレビュー終了\n");
 			}
 		}
+        if (g->procSelecter != 2) { // stop playing preview on scene transition
+            StopSound(&g->audio, &g->sSelect.previewSound);
+        }
 	}
 	g->sSelect.is_mouseOnTextInput = 0;
 

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1683,7 +1683,7 @@ static void LoadPreviewFile(game *g, const std::string &previewpath) {
 	}
 
 	if (g->gameplay.flag_closingPhase == 0 && g->procSelecter == 2 && g->gameplay.previewStatus == 1) {
-		SetFadePreview(&g->audio, 500, 1);
+		SetFadePreview(&g->audio, 200, 1);
 		PlaySound(&g->audio, &g->sSelect.previewSound, g->audio.chnKey, -1);
 		g->gameplay.previewStatus = 2;
 	} else {
@@ -1698,7 +1698,7 @@ static void ThreadProc_LoadPreview(game *g) {
 	if (!g->config.select.ignorePreviewFiles) {
 		SONGDATA &song = g->sSelect.bmsList[g->sSelect.cur_song];
 		if (song.previewfile) {
-			const auto previewpath = std::filesystem::path(song.folder.body) / song.previewfile.value();
+			const auto previewpath = std::filesystem::path(song.filepath.getDirectory().body) / song.previewfile.value();
 			if (std::filesystem::exists(previewpath)) {
 				LoadPreviewFile(g, previewpath.string());
 				return;

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1694,13 +1694,23 @@ static void LoadPreviewFile(game *g, const std::filesystem::path &previewpath) {
 	}
 }
 
-static void ThreadProc_LoadPreview(game *g) {
+static void ThreadProc_LoadPreview(game *g, sqlite3 *sql) {
 	BMSMETA meta;
 
 	if (!g->config.select.ignorePreviewFiles) {
 		SONGDATA &song = g->sSelect.bmsList[g->sSelect.cur_song];
+		std::filesystem::path folderpath = song.filepath.getDirectory().body;
+
+		if (!song.previewfile) {
+			auto foundFile = openlr2::tryFindPreviewFile(folderpath);
+			if (foundFile) {
+				song.previewfile = foundFile.value();
+				openlr2::updateSongPreview(song.hash.body, song.previewfile.value(), sql);
+			}
+		}
+
 		if (song.previewfile) {
-			const auto previewpath = std::filesystem::path(song.filepath.getDirectory().body) / song.previewfile.value();
+			const auto previewpath = folderpath / song.previewfile.value();
 			if (std::filesystem::exists(previewpath)) {
 				LoadPreviewFile(g, previewpath.string());
 				return;
@@ -2751,7 +2761,7 @@ int ProcI_Select(game *g, sqlite3 *sql) {
 			g->gameplay.previewStatus = 1;
 			g->gameplay.previewBMShash = g->sSelect.bmsList[g->sSelect.cur_song].hash;
 			g->gameplay.previewBMSfilepath = g->sSelect.bmsList[g->sSelect.cur_song].filepath;
-			g->gameplay.hThreadPreview = std::async(std::launch::async, ThreadProc_LoadPreview, g);
+			g->gameplay.hThreadPreview = std::async(std::launch::async, ThreadProc_LoadPreview, g, sql);
 		}
 		else if (g->gameplay.previewStatus) {
 			if (g->gameplay.previewBMShash.isDiff(g->sSelect.bmsList[g->sSelect.cur_song].hash)) {

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1671,40 +1671,40 @@ static void ThreadProc_RankingAutoUpdate(game* g) {
 }
 
 static void LoadPreviewFile(game *g, CSTR *previewpath) {
-    g->gameplay.flag_closingPhase = 0;
-    StopSound(&g->audio, &g->sSelect.previewSound);
+	g->gameplay.flag_closingPhase = 0;
+	StopSound(&g->audio, &g->sSelect.previewSound);
 
-    if (!g->sSelect.previewSound.load || previewpath->isDiff(&g->sSelect.previewSound.filename)) {
-        ReleaseSound(&g->audio, &g->sSelect.previewSound);
-        if (g->gameplay.flag_closingPhase == 0 && g->procSelecter == 2 && g->gameplay.previewStatus == 1) {
-            LoadSound(&g->audio, &g->sSelect.previewSound, *previewpath, true, false, true);
-        }
-    }
+	if (!g->sSelect.previewSound.load || previewpath->isDiff(&g->sSelect.previewSound.filename)) {
+		ReleaseSound(&g->audio, &g->sSelect.previewSound);
+		if (g->gameplay.flag_closingPhase == 0 && g->procSelecter == 2 && g->gameplay.previewStatus == 1) {
+			LoadSound(&g->audio, &g->sSelect.previewSound, *previewpath, true, false, true);
+		}
+	}
 
-    if (g->gameplay.flag_closingPhase == 0 && g->procSelecter == 2 && g->gameplay.previewStatus == 1) {
-        SetFadePreview(&g->audio, 500, 1);
-        PlaySound(&g->audio, &g->sSelect.previewSound, g->audio.chnKey, -1);
-        g->gameplay.previewStatus = 2;
-    } else {
-        g->gameplay.previewStatus = 0;
-        g->gameplay.isPreviewLoad = 0;
-    }
+	if (g->gameplay.flag_closingPhase == 0 && g->procSelecter == 2 && g->gameplay.previewStatus == 1) {
+		SetFadePreview(&g->audio, 500, 1);
+		PlaySound(&g->audio, &g->sSelect.previewSound, g->audio.chnKey, -1);
+		g->gameplay.previewStatus = 2;
+	} else {
+		g->gameplay.previewStatus = 0;
+		g->gameplay.isPreviewLoad = 0;
+	}
 }
 
 static void ThreadProc_LoadPreview(game *g) {
 	BMSMETA meta;
 
-    if (!g->config.select.ignorePreviewFiles) {
-        SONGDATA *song = &g->sSelect.bmsList[g->sSelect.cur_song];
-        if (song->isPreviewfile) {
-            CSTR previewpath;
-            previewpath.assign(song->folder).add(song->previewfile);
-            if (IsFileExist(previewpath)) {
-                LoadPreviewFile(g, &previewpath);
-                return;
-            }
-        }
-    }
+	if (!g->config.select.ignorePreviewFiles) {
+		SONGDATA *song = &g->sSelect.bmsList[g->sSelect.cur_song];
+		if (song->isPreviewfile) {
+			CSTR previewpath;
+			previewpath.assign(song->folder).add(song->previewfile);
+			if (IsFileExist(previewpath)) {
+				LoadPreviewFile(g, &previewpath);
+				return;
+			}
+		}
+	}
 
 	if (!IsFileExist(g->gameplay.previewBMSfilepath)) {
 		g->gameplay.isPreviewLoad = 0;
@@ -2759,16 +2759,16 @@ int ProcI_Select(game *g, sqlite3 *sql) {
 				for (int i = 0; i < SLOTS; i++) {
 					StopSound(&g->audio, &g->gameplay.keysound[i]);
 				}
-                StopSound(&g->audio, &g->sSelect.previewSound);
+				StopSound(&g->audio, &g->sSelect.previewSound);
 				g->gameplay.previewStatus = 0;
 				SetFadePreview(&g->audio, 1000, 0);
 				g->gameplay.previewBMShash = g->sSelect.bmsList[g->sSelect.cur_song].hash;
 				ErrorLogFmtAdd("プレビュー終了\n");
 			}
 		}
-        if (g->procSelecter != 2) { // stop playing preview on scene transition
-            StopSound(&g->audio, &g->sSelect.previewSound);
-        }
+		if (g->procSelecter != 2) { // stop playing preview on scene transition
+			StopSound(&g->audio, &g->sSelect.previewSound);
+		}
 	}
 	g->sSelect.is_mouseOnTextInput = 0;
 

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1672,15 +1672,15 @@ static void ThreadProc_RankingAutoUpdate(game* g) {
 	SetObjectStrings_SongSelect(g);
 }
 
-static void LoadPreviewFile(game *g, const std::string &previewpath) {
+static void LoadPreviewFile(game *g, const std::filesystem::path &previewpath) {
 	g->gameplay.flag_closingPhase = 0;
 	StopSound(&g->audio, &g->sSelect.previewSound);
 
 	const auto prevFile = g->sSelect.previewSound.filename.body;
-	if (!g->sSelect.previewSound.load || prevFile == nullptr || previewpath != prevFile) {
+	if (!g->sSelect.previewSound.load || prevFile == nullptr || previewpath.string() != prevFile) {
 		ReleaseSound(&g->audio, &g->sSelect.previewSound);
 		if (g->gameplay.flag_closingPhase == 0 && g->procSelecter == 2 && g->gameplay.previewStatus == 1) {
-			LoadSound(&g->audio, &g->sSelect.previewSound, previewpath.c_str(), true, false, true);
+			LoadSound(&g->audio, &g->sSelect.previewSound, previewpath.string().c_str(), true, false, true);
 		}
 	}
 

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -299,6 +299,7 @@ struct BMSMETA {
 	CSTR backBMPpath;
 	CSTR parentfolderpath;
 	CSTR folderpath;
+    CSTR previewpath;
 	CSTR tag;
 	int notecount;
 	int maxbpm;
@@ -609,9 +610,11 @@ struct SONGDATA { /* 712bytes */
 	CSTR stagefile;
 	CSTR banner;
 	CSTR backBMP;
+    CSTR previewfile;
 	bool isStagefile{};
 	bool isBanner{};
 	int isBackBMP{};
+    bool isPreviewfile{};
 	uint difficulty{};
 	int level{};
 	int exlevel{};

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1229,6 +1229,7 @@ struct SONGSELECT {
 	int rivalID;
 	struct COURSESELECT course;
 	int isExLevel;
+    struct SOUNDDATA previewSound;
 };
 
 struct ReplayData {

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -456,6 +456,8 @@ struct CONFIG_SELECT {
 	bool disableDifficultyFilter{};
 	bool isPreview{};
 	bool disableSubtitle{};
+    bool ignorePreviewFiles{};
+    int previewDelay{};
 };
 
 struct CONFIG_SKIN {

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -299,7 +299,7 @@ struct BMSMETA {
 	CSTR backBMPpath;
 	CSTR parentfolderpath;
 	CSTR folderpath;
-	CSTR previewpath;
+	std::string previewpath{};
 	CSTR tag;
 	int notecount;
 	int maxbpm;
@@ -612,11 +612,10 @@ struct SONGDATA { /* 712bytes */
 	CSTR stagefile;
 	CSTR banner;
 	CSTR backBMP;
-	CSTR previewfile;
+	std::optional<std::string> previewfile{};
 	bool isStagefile{};
 	bool isBanner{};
 	int isBackBMP{};
-	bool isPreviewfile{};
 	uint difficulty{};
 	int level{};
 	int exlevel{};

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -299,7 +299,7 @@ struct BMSMETA {
 	CSTR backBMPpath;
 	CSTR parentfolderpath;
 	CSTR folderpath;
-    CSTR previewpath;
+	CSTR previewpath;
 	CSTR tag;
 	int notecount;
 	int maxbpm;
@@ -456,8 +456,8 @@ struct CONFIG_SELECT {
 	bool disableDifficultyFilter{};
 	bool isPreview{};
 	bool disableSubtitle{};
-    bool ignorePreviewFiles{};
-    int previewDelay{};
+	bool ignorePreviewFiles{};
+	int previewDelay{};
 };
 
 struct CONFIG_SKIN {
@@ -612,11 +612,11 @@ struct SONGDATA { /* 712bytes */
 	CSTR stagefile;
 	CSTR banner;
 	CSTR backBMP;
-    CSTR previewfile;
+	CSTR previewfile;
 	bool isStagefile{};
 	bool isBanner{};
 	int isBackBMP{};
-    bool isPreviewfile{};
+	bool isPreviewfile{};
 	uint difficulty{};
 	int level{};
 	int exlevel{};
@@ -1231,7 +1231,7 @@ struct SONGSELECT {
 	int rivalID;
 	struct COURSESELECT course;
 	int isExLevel;
-    struct SOUNDDATA previewSound;
+	struct SOUNDDATA previewSound;
 };
 
 struct ReplayData {

--- a/new_command(bms).md
+++ b/new_command(bms).md
@@ -14,4 +14,5 @@ Change note speed without `#BPM`. ([Related Article](https://note.com/numuther/n
 * [$trange Attraktor [Labyrinth]](https://ux.getuploader.com/numuther/download/108)
 * [#GOTO [Oraja Innovation]](https://www.dropbox.com/s/8w4g9h6egbmdrn2/%23GOTO.zip?dl=1)
 
-
+## `#PREVIEW` (From Beatoraja)
+Specifies preview audio for chart.


### PR DESCRIPTION
song preview filenames are saved to db during initial chart parsing. a separate table is used for that. #PREVIEW directive in BMS file is used to determine the filename of the preview, or if it's not present the song directory is scanned for audio files with "preview" in name.
two new options have been added to the config file: one allows to ignore preview files (and always play the full previews), another determines the delay before preview playback.