### PR TITLE
Use async load functions on bga loading

### DIFF
--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -788,6 +788,7 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 			if (!anyLoading) break;
 			std::this_thread::sleep_for(std::chrono::milliseconds(10));
 		}
+	}
 
 	SetTransColor(Rtmp, Gtmp, Btmp);
 #ifdef _WIN32

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -768,33 +768,26 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 				bgaHandleLoaded[i] = false;
 			}
 		}
-		bool finishedLoading = false;
-		while (!finishedLoading) {
-			finishedLoading = true;
+		while (true) {
+			bool anyLoading = false;
 			for (auto& [i, loaded] : bgaHandleLoaded) {
-				if (!loaded && gp->bgaHandle[i] != -1) {
-					int loadResult = CheckHandleASyncLoad(gp->bgaHandle[i]);
-					if (loadResult == FALSE) {
-						// FALSE: finished
-						loaded = true;
-						gp->loadObject_loaded++;
-					} else if (loadResult == TRUE) {
-						// TRUE: still loading
-						finishedLoading = false;
-						break;
-					} else {
-						// -1: error
-						// Release the handle and do not care about it anymore
-						DeleteGraph(gp->bgaHandle[i]);
-						gp->bgaHandle[i] = -1;
-					}
+				if (loaded) continue;
+				int loadResult = CheckHandleASyncLoad(gp->bgaHandle[i]);
+				if (loadResult == TRUE/*still loading*/) {
+					anyLoading = true;
+					continue;
 				}
+				if (loadResult != FALSE/*finished*/) {
+					// Error
+					DeleteGraph(gp->bgaHandle[i]);
+					gp->bgaHandle[i] = -1;
+				}
+				loaded = true;
+				gp->loadObject_loaded++;
 			}
-			if (!finishedLoading) {
-				std::this_thread::sleep_for(std::chrono::milliseconds(10));
-			}
+			if (!anyLoading) break;
+			std::this_thread::sleep_for(std::chrono::milliseconds(10));
 		}
-	}
 
 	SetTransColor(Rtmp, Gtmp, Btmp);
 #ifdef _WIN32

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -776,7 +776,7 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 				}
 			}
 			if (!finishedLoading) {
-				std::this_thread::sleep_for(std::chrono::milliseconds(100));
+				std::this_thread::sleep_for(std::chrono::milliseconds(10));
 			}
 		}
 	}

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -742,7 +742,11 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 			else {
 				gp->bgaHandle[i] = LoadGraph(gp->BMP_filename[i]);	// Note: When using SetUseASyncLoadFlag, LoadGraph returns the handle immediately. Further check is required
 			}
-			gp->loadObject_loaded++;
+
+			// Count only after load finish. Only add if using synchronous load here
+			if (cfg->system.isablebmsthread != 0) {
+				gp->loadObject_loaded++;
+			}
 		}
 
 		if (gp->flag_closingPhase) {
@@ -758,14 +762,22 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 
 	// Check and wait until the handles finished loading
 	if (cfg->system.isablebmsthread == 0) {
+		std::unordered_map<int, bool> bgaHandleLoaded;	// to prevent count repeateadly
+		for (int i = 0; i < SLOTS; i++) {
+			if (gp->bgaHandle[i] != -1) {
+				bgaHandleLoaded[i] = false;
+			}
+		}
 		bool finishedLoading = false;
 		while (!finishedLoading) {
 			finishedLoading = true;
-			for (int i = 0; i < SLOTS; i++) {
-				if (gp->bgaHandle[i] != -1) {
+			for (auto& [i, loaded] : bgaHandleLoaded) {
+				if (!loaded && gp->bgaHandle[i] != -1) {
 					int loadResult = CheckHandleASyncLoad(gp->bgaHandle[i]);
 					if (loadResult == FALSE) {
 						// FALSE: finished
+						loaded = true;
+						gp->loadObject_loaded++;
 					} else if (loadResult == TRUE) {
 						// TRUE: still loading
 						finishedLoading = false;

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -721,6 +721,9 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 		return 1;
 	}
 	
+	// Add async load functions from DxLib: SetUseASyncLoadFlag, CheckHandleASyncLoad
+	// We are on a detached thread here (see ProcGameThread), but DirectX requires resouces to be loaded from the main thread. 
+	// The async calls will make DxLib do it itself on the main thread. This fixes crashes in DX11
 #ifdef _WIN32
 	if (cfg->system.isablebmsthread == 0) {
 		CoInitialize(NULL);

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -722,7 +722,10 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 	}
 	
 #ifdef _WIN32
-	if (cfg->system.isablebmsthread == 0) CoInitialize(NULL);
+	if (cfg->system.isablebmsthread == 0) {
+		CoInitialize(NULL);
+		SetUseASyncLoadFlag(TRUE);
+	}
 #endif // _WIN32
 	GetTransColor(&Rtmp,&Gtmp,&Btmp);
 	SetTransColor(0,0,0);
@@ -730,26 +733,60 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 		if (gp->BMP_filename[i].length() > 0) {
 			if (gp->BMP_filename[i].right(3).isSame("mpg") || gp->BMP_filename[i].right(3).isSame("avi")) {
 				SetTransColor(0, 255, 0);
-				gp->bgaHandle[i] = LoadGraph(gp->BMP_filename[i]);
+				gp->bgaHandle[i] = LoadGraph(gp->BMP_filename[i]);	// Note: When using SetUseASyncLoadFlag, LoadGraph returns the handle immediately. Further check is required
 				SetTransColor(0, 0, 0);
 			}
 			else {
-				gp->bgaHandle[i] = LoadGraph(gp->BMP_filename[i]);
+				gp->bgaHandle[i] = LoadGraph(gp->BMP_filename[i]);	// Note: When using SetUseASyncLoadFlag, LoadGraph returns the handle immediately. Further check is required
 			}
 			gp->loadObject_loaded++;
 		}
 
 		if (gp->flag_closingPhase) {
 #ifdef _WIN32
-			if (cfg->system.isablebmsthread == 0) CoUninitialize();
+			if (cfg->system.isablebmsthread == 0) {
+				SetUseASyncLoadFlag(FALSE);
+				CoUninitialize();
+			}
 #endif // _WIN32
 			return 1;
 		}
 	}
 
+	// Check and wait until the handles finished loading
+	if (cfg->system.isablebmsthread == 0) {
+		bool finishedLoading = false;
+		while (!finishedLoading) {
+			finishedLoading = true;
+			for (int i = 0; i < SLOTS; i++) {
+				if (gp->bgaHandle[i] != -1) {
+					int loadResult = CheckHandleASyncLoad(gp->bgaHandle[i]);
+					if (loadResult == FALSE) {
+						// FALSE: finished
+					} else if (loadResult == TRUE) {
+						// TRUE: still loading
+						finishedLoading = false;
+						break;
+					} else {
+						// -1: error
+						// Release the handle and do not care about it anymore
+						DeleteGraph(gp->bgaHandle[i]);
+						gp->bgaHandle[i] = -1;
+					}
+				}
+			}
+			if (!finishedLoading) {
+				std::this_thread::sleep_for(std::chrono::milliseconds(100));
+			}
+		}
+	}
+
 	SetTransColor(Rtmp, Gtmp, Btmp);
 #ifdef _WIN32
-	if (cfg->system.isablebmsthread == 0) CoUninitialize();
+	if (cfg->system.isablebmsthread == 0) {
+		SetUseASyncLoadFlag(FALSE);
+		CoUninitialize();
+	}
 #endif // _WIN32
 	if (gp->bgaHandle[0] != -1) gp->missLayer = 0;
 


### PR DESCRIPTION
This fixes crashes when playing a chart with image BGA on dx11 mode. Details:
- Disable parallel loading (a setting in LR2.exe) : ok
- Enable parallel loading, video bga: ok
- Enable parallel loading, image bga: crash
- Enable parallel loading, image bga, bga off: ok

It won't crash in dx9 but well I just leave it here
I've seen the panels on the screen flickers when loading the chart on vanilla LR2. Happens rarely. I reckon it is affected by this too

ref: https://dxlib.xsrv.jp/cgi/patiobbs/patio.cgi?mode=view&no=3929

also CONFIG_SYSTEM::isablebmsthread is a very misleading typo, pls consider rename