### PR TITLE
fix: ignore WM_DEVICECHANGE resync during play

### DIFF
--- a/LR2/En_dxlibstub.h
+++ b/LR2/En_dxlibstub.h
@@ -166,4 +166,9 @@ inline int GetUseDirect3DVersion() { return 0; }
 inline int GetWindowActiveFlag() { return 1; }
 // we are windowed
 inline int GetWindowModeFlag(void) { return 1; }
+
+inline int SetUseJoypadDeviceChangeResyncFlag(int Flag) {
+  ErrorLogFmtAdd("STUB!!! SetUseJoypadDeviceChangeResyncFlag(Flag=%d)", Flag);
+  return -1;
+}
 #endif // _WIN32

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -1004,6 +1004,8 @@ int main(int argc, char** argv) {
 
 			switch (gs.procSelecter) {
 				case SCENE_SELECT:
+					// Hotplug resync only on song select enter (never during play).
+					ReSetupJoypad();
 					gs.gameplay.ghostBattle = 0;
 					ReadKeyConfig(&gs, (!gs.config.select.control)
 							? fs::make_preferred("LR2files/Config/keyconfig.xml" ).data()

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -983,6 +983,9 @@ int main(int argc, char** argv) {
 			};
 			std::ofstream("nowstate.json") << get_scene_status_string(gs);
 
+			// Disable DEVICECHANGE joypad resync only while playing (avoids mid-chart hitch).
+			SetUseJoypadDeviceChangeResyncFlag(gs.procSelecter != SCENE_PLAY);
+
 			InitFade(&gs.audio);
 			gs.gameplay.flag_closingPhase = 1;
 			gs.gameplay.isPreviewLoad = 0;
@@ -1004,8 +1007,6 @@ int main(int argc, char** argv) {
 
 			switch (gs.procSelecter) {
 				case SCENE_SELECT:
-					// Hotplug resync only on song select enter (never during play).
-					ReSetupJoypad();
 					gs.gameplay.ghostBattle = 0;
 					ReadKeyConfig(&gs, (!gs.config.select.control)
 							? fs::make_preferred("LR2files/Config/keyconfig.xml" ).data()

--- a/dep/DxLib/DxFunctionWin.h
+++ b/dep/DxLib/DxFunctionWin.h
@@ -274,6 +274,7 @@ extern	int			SetKeyboardNotDirectInputFlag(			int Flag ) ;															// キ�
 extern	int			SetUseDirectInputFlag(					int UseFlag ) ;															// 入力処理に DirectInput を使用するかどうかを設定する( TRUE:DirectInput を使用する　　FALSE:DirectInput を使わず、Windows標準機能を使用する )
 extern	int			SetDirectInputMouseMode(				int Mode ) ;															// マウスの入力処理に DirectInput を使用する場合の動作モードを設定する( 0:ウィンドウがアクティブな場合のみ DirectInput を使用する  1:ウィンドウのアクティブ状態に関係なく DirectInput を使用する )
 extern	int			SetUseXInputFlag(						int Flag ) ;															// Xbox360コントローラの入力処理に XInput を使用するかどうかを設定する( TRUE:XInput を使用する( デフォルト )　　FALSE:XInput を使用しない )
+extern	int			SetUseJoypadDeviceChangeResyncFlag(		int Flag ) ;															// Whether to resync joypads on WM_DEVICECHANGE ( TRUE: do it (default)  FALSE: skip ). DEVICECHANGE while FALSE is pending and flushed when set back to TRUE
 extern	int			SetUseXboxControllerDirectInputFlag(	int Flag ) ;															// Xbox360コントローラや Xbox Oneコントローラを DirectInputコントローラとしても検出するかどうかを設定する( TRUE:DirectInputコントローラとしても検出する  FALSE:DirectInputコントローラとしては検出しない(デフォルト) )、DxLib_Init の呼び出し前でのみ実行可能
 extern	int			GetJoypadGUID(							int PadIndex, GUID *GuidInstanceBuffer, GUID *GuidProductBuffer DEFAULTPARAM( = NULL ) ) ;	// ジョイパッドのＧＵIＤを得る
 extern	int			GetJoypadName(							int InputType, TCHAR *InstanceNameBuffer, TCHAR *ProductNameBuffer ) ;	// ジョイパッドのデバイス登録名と製品登録名を取得する( InstanceNameBuffer, ProductNameBuffer 共に 260 以上のバッファサイズが必要 )

--- a/dep/DxLib/DxGateway.cpp
+++ b/dep/DxLib/DxGateway.cpp
@@ -4741,6 +4741,15 @@ extern int SetUseXInputFlag( int Flag )
 	return Result ;
 }
 
+extern int SetUseJoypadDeviceChangeResyncFlag( int Flag )
+{
+	int Result ;
+	DXFUNC_BEGIN
+	Result = NS_SetUseJoypadDeviceChangeResyncFlag( Flag ) ;
+	DXFUNC_END
+	return Result ;
+}
+
 extern int SetUseXboxControllerDirectInputFlag( int Flag )
 {
 	int Result ;

--- a/dep/DxLib/DxInput.h
+++ b/dep/DxLib/DxInput.h
@@ -134,6 +134,7 @@ struct INPUTSYSTEMDATA
 	volatile int			InitializeFlag ;					// 初期化完了フラグ
 
 	int						NoUseVibrationFlag ;				// ＤｉｒｅｃｔＩｎｐｕｔの振動機能を使用しないかどうかのフラグ
+	int						NoUseDeviceChangeJoypadResyncFlag ;	// If TRUE, skip joypad resync on WM_DEVICECHANGE (FALSE: resync, default)
 	int						KeyInputGetTime ;					// 一つ前に状態を取得した時間
 	unsigned char			KeyInputBuf[ 256 ] ;				// キーボードの入力状態
 

--- a/dep/DxLib/DxStatic.h
+++ b/dep/DxLib/DxStatic.h
@@ -1065,6 +1065,7 @@ extern	int			NS_SetKeyboardNotDirectInputFlag(			int Flag ) ;															// �
 extern	int			NS_SetUseDirectInputFlag(					int Flag ) ;															// 入力処理に DirectInput を使用するかどうかを設定する( TRUE:DirectInput を使用する　　FALSE:DirectInput を使わず、Windows標準機能を使用する )
 extern	int			NS_SetDirectInputMouseMode(				int Mode ) ;															// マウスの入力処理に DirectInput を使用する場合の動作モードを設定する( 0:ウィンドウがアクティブな場合のみ DirectInput を使用する  1:ウィンドウのアクティブ状態に関係なく DirectInput を使用する )
 extern	int			NS_SetUseXInputFlag(						int Flag ) ;															// Xbox360コントローラの入力処理に XInput を使用するかどうかを設定する( TRUE:XInput を使用する( デフォルト )　　FALSE:XInput を使用しない )
+extern	int			NS_SetUseJoypadDeviceChangeResyncFlag(		int Flag ) ;															// Whether to resync joypads on WM_DEVICECHANGE ( TRUE: do it (default)  FALSE: skip )
 extern	int			NS_SetUseXboxControllerDirectInputFlag(	int Flag ) ;															// Xbox360コントローラや Xbox Oneコントローラを DirectInputコントローラとしても検出するかどうかを設定する( TRUE:DirectInputコントローラとしても検出する  FALSE:DirectInputコントローラとしては検出しない(デフォルト) )
 extern	int			NS_GetJoypadGUID(							int PadIndex, GUID *GuidInstanceBuffer, GUID *GuidProductBuffer ) ;		// ジョイパッドのＧＵIＤを得る
 extern	int			NS_GetJoypadName(							int InputType, TCHAR *InstanceNameBuffer, TCHAR *ProductNameBuffer ) ;	// ジョイパッドのデバイス登録名と製品登録名を取得する
@@ -3995,6 +3996,7 @@ extern	float		NS_Live2D_Model_GetCanvasHeight(						int Live2DModelHandle ) ;			
 #define NS_SetUseDirectInputFlag				SetUseDirectInputFlag
 #define NS_SetDirectInputMouseMode				SetDirectInputMouseMode
 #define NS_SetUseXInputFlag						SetUseXInputFlag
+#define NS_SetUseJoypadDeviceChangeResyncFlag	SetUseJoypadDeviceChangeResyncFlag
 #define NS_SetUseXboxControllerDirectInputFlag	SetUseXboxControllerDirectInputFlag
 #define NS_SetUseJoypadVibrationFlag			SetUseJoypadVibrationFlag
 

--- a/dep/DxLib/Windows/DxInputWin.cpp
+++ b/dep/DxLib/Windows/DxInputWin.cpp
@@ -1768,6 +1768,7 @@ extern int InitializeInputSystem_PF_Timing0( void )
 	int    KeyExclusiveCooperativeLevelFlag				= InputSysData.PF.KeyExclusiveCooperativeLevelFlag ;
 	int    KeyToJoypadInputInitializeFlag				= InputSysData.KeyToJoypadInputInitializeFlag ;
 	int    NoUseVibrationFlag							= InputSysData.NoUseVibrationFlag ;
+	int    NoUseDeviceChangeJoypadResyncFlag			= InputSysData.NoUseDeviceChangeJoypadResyncFlag ;
 	int    EnablePadDefaultDeadZone						= InputSysData.EnablePadDefaultDeadZone ;
 	DWORD  PadDefaultDeadZone							= InputSysData.PadDefaultDeadZone ;
 	double PadDefaultDeadZoneD							= InputSysData.PadDefaultDeadZoneD ;
@@ -1782,6 +1783,7 @@ extern int InitializeInputSystem_PF_Timing0( void )
 	InputSysData.PF.KeyExclusiveCooperativeLevelFlag	= KeyExclusiveCooperativeLevelFlag ;
 	InputSysData.KeyToJoypadInputInitializeFlag			= KeyToJoypadInputInitializeFlag ;
 	InputSysData.NoUseVibrationFlag						= NoUseVibrationFlag ;
+	InputSysData.NoUseDeviceChangeJoypadResyncFlag		= NoUseDeviceChangeJoypadResyncFlag ;
 	InputSysData.EnablePadDefaultDeadZone				= EnablePadDefaultDeadZone ;
 	InputSysData.PadDefaultDeadZone						= PadDefaultDeadZone ;
 	InputSysData.PadDefaultDeadZoneD					= PadDefaultDeadZoneD ;
@@ -3533,6 +3535,25 @@ extern int NS_SetUseXInputFlag(	int Flag )
 	InputSysData.PF.NoUseXInputFlag = !Flag ;
 
 	// 終了
+	return 0 ;
+}
+
+// Whether to resync joypads on WM_DEVICECHANGE ( TRUE: do it (default)  FALSE: skip )
+// DEVICECHANGE while FALSE is pending and flushed when set back to TRUE
+extern int NS_SetUseJoypadDeviceChangeResyncFlag( int Flag )
+{
+	InputSysData.NoUseDeviceChangeJoypadResyncFlag = !Flag ;
+
+	if( Flag && WinData.PendingJoypadDeviceChangeResyncFlag )
+	{
+		WinData.PendingJoypadDeviceChangeResyncFlag = FALSE ;
+		if( WinData.QuitMessageFlag == FALSE )
+		{
+			NS_ReSetupJoypad() ;
+		}
+	}
+
+	// Finished
 	return 0 ;
 }
 

--- a/dep/DxLib/Windows/DxSystemWin.cpp
+++ b/dep/DxLib/Windows/DxSystemWin.cpp
@@ -826,9 +826,9 @@ extern int NS_ProcessMessage( void )
 #endif // DX_NON_SOUND
 
 #ifndef DX_NON_INPUT
-	// WM_DEVICECHANGE ではジョイパッドを自動再セットアップしない。
-	// (DBT_DEVNODES_CHANGED はパッド以外のデバイスでも飛ぶため、プレイ中のフリーズの原因になる)
-	// OpenLR2 側で Scene02(選曲) 進入時に ReSetupJoypad() を明示呼び出しする。
+	// Do not auto-resync joypads on WM_DEVICECHANGE.
+	// (DBT_DEVNODES_CHANGED also fires for non-pad devices and can freeze mid-play.)
+	// OpenLR2 calls ReSetupJoypad() explicitly on Scene02 (song select) enter.
 	if( WinData.RecvWM_DEVICECHANGEFlag )
 	{
 		WinData.RecvWM_DEVICECHANGEFlag = FALSE ;

--- a/dep/DxLib/Windows/DxSystemWin.cpp
+++ b/dep/DxLib/Windows/DxSystemWin.cpp
@@ -826,12 +826,21 @@ extern int NS_ProcessMessage( void )
 #endif // DX_NON_SOUND
 
 #ifndef DX_NON_INPUT
-	// Do not auto-resync joypads on WM_DEVICECHANGE.
-	// (DBT_DEVNODES_CHANGED also fires for non-pad devices and can freeze mid-play.)
-	// OpenLR2 calls ReSetupJoypad() explicitly on Scene02 (song select) enter.
+	// WM_DEVICECHANGE: optionally resync joypads (can hitch; gate with SetUseJoypadDeviceChangeResyncFlag).
 	if( WinData.RecvWM_DEVICECHANGEFlag )
 	{
 		WinData.RecvWM_DEVICECHANGEFlag = FALSE ;
+		if( WinData.QuitMessageFlag == FALSE )
+		{
+			if( InputSysData.NoUseDeviceChangeJoypadResyncFlag == FALSE )
+			{
+				NS_ReSetupJoypad() ;
+			}
+			else
+			{
+				WinData.PendingJoypadDeviceChangeResyncFlag = TRUE ;
+			}
+		}
 	}
 
 	// キーボードの周期的処理を行う

--- a/dep/DxLib/Windows/DxSystemWin.cpp
+++ b/dep/DxLib/Windows/DxSystemWin.cpp
@@ -826,14 +826,12 @@ extern int NS_ProcessMessage( void )
 #endif // DX_NON_SOUND
 
 #ifndef DX_NON_INPUT
-	// WM_DEVICECHANGE メッセージが来ていたらパッドの再セットアップを行う
+	// WM_DEVICECHANGE ではジョイパッドを自動再セットアップしない。
+	// (DBT_DEVNODES_CHANGED はパッド以外のデバイスでも飛ぶため、プレイ中のフリーズの原因になる)
+	// OpenLR2 側で Scene02(選曲) 進入時に ReSetupJoypad() を明示呼び出しする。
 	if( WinData.RecvWM_DEVICECHANGEFlag )
 	{
 		WinData.RecvWM_DEVICECHANGEFlag = FALSE ;
-		if( WinData.QuitMessageFlag == FALSE )
-		{
-			NS_ReSetupJoypad() ;
-		}
 	}
 
 	// キーボードの周期的処理を行う

--- a/dep/DxLib/Windows/DxWindow.h
+++ b/dep/DxLib/Windows/DxWindow.h
@@ -127,6 +127,7 @@ struct WINDATA
 
 #ifndef DX_NON_INPUT
 	int						RecvWM_DEVICECHANGEFlag ;			// WM_DEVICECHANGE メッセージが来たかどうかのフラグ
+	int						PendingJoypadDeviceChangeResyncFlag ;	// DEVICECHANGE arrived while joypad device-change resync was disabled; flush when re-enabled
 #endif // DX_NON_INPUT
 
 	wchar_t					InputSysChara ;						// 入力されたシステム文字コード


### PR DESCRIPTION
Auto ReSetupJoypad on device-node changes caused mid-play hitches. Disable that path and resync only when entering song select.

Due to ongoing stuttering issues causing persistent inconvenience for players, I have submitted a PR.

This PR is currently under review and has not been sufficiently tested yet. Furthermore, since it remains unconfirmed whether detecting devices only upon entering Scene02 is the correct approach, I am keeping it in Draft status.

Fix #253