### PR TITLE
Show LR2IR placement even when LR2IR is disabled in the launcher

### DIFF
--- a/LR2/En_audio.cpp
+++ b/LR2/En_audio.cpp
@@ -9,11 +9,7 @@
 #include "filesystem.h"
 using std::uintptr_t;
 
-#ifdef _WIN32
-
-#include <codecvt>
-
-#else
+#ifndef _WIN32
 
 #include <chrono>
 

--- a/LR2/En_fileutil.cpp
+++ b/LR2/En_fileutil.cpp
@@ -165,18 +165,8 @@ int makeFileHash(LPCSTR filepath, LPCSTR oBuf) {
 //TODO : posix 2038y problem
 // Seconds since the Unix Epoch
 time_t GetNowUnixtime() {
-#ifdef _WIN32
-	SYSTEMTIME systime;
-	GetSystemTime((LPSYSTEMTIME)&systime);
-
-	_FILETIME filetime;
-	SystemTimeToFileTime(&systime, &filetime);
-
-	return GetUnixtimeFromFiletime(filetime);
-#else
 	return std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch())
 		.count();
-#endif // _WIN32
 }
 
 // Seconds since the Unix Epoch

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -722,14 +722,16 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 	}
 	
 	// Add async load functions from DxLib: SetUseASyncLoadFlag, CheckHandleASyncLoad
-	// We are on a detached thread here (see ProcGameThread), but DirectX requires resouces to be loaded from the main thread. 
-	// The async calls will make DxLib do it itself on the main thread. This fixes crashes in DX11
-#ifdef _WIN32
+	// We are on a non-main thread here, but graphics APIs, DirectX normally and OpenGL with dxlib-for-linux, require
+	// resources to be loaded from the main thread. 
+	// The async calls will make DxLib do it itself on the main thread.
+	// This fixes crashes in DX11 and fixes BGAs not displaying with dxlib-for-linux.
 	if (cfg->system.isablebmsthread == 0) {
+#ifdef _WIN32
 		CoInitialize(NULL);
+#endif // _WIN32
 		SetUseASyncLoadFlag(TRUE);
 	}
-#endif // _WIN32
 	GetTransColor(&Rtmp,&Gtmp,&Btmp);
 	SetTransColor(0,0,0);
 	for (int i = 0; i < SLOTS; i++) {
@@ -750,12 +752,12 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 		}
 
 		if (gp->flag_closingPhase) {
-#ifdef _WIN32
 			if (cfg->system.isablebmsthread == 0) {
 				SetUseASyncLoadFlag(FALSE);
+#ifdef _WIN32
 				CoUninitialize();
-			}
 #endif // _WIN32
+			}
 			return 1;
 		}
 	}
@@ -791,12 +793,12 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 	}
 
 	SetTransColor(Rtmp, Gtmp, Btmp);
-#ifdef _WIN32
 	if (cfg->system.isablebmsthread == 0) {
 		SetUseASyncLoadFlag(FALSE);
+#ifdef _WIN32
 		CoUninitialize();
-	}
 #endif // _WIN32
+	}
 	if (gp->bgaHandle[0] != -1) gp->missLayer = 0;
 
 	if (gp->isAutoplay == 1) {

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -26,27 +26,7 @@
 #include <dlfcn.h>
 #endif // _WIN32
 
-#if _WIN32
-
-#if _WIN64
-#ifndef NDEBUG
-constexpr auto&& ARCH = "_D.x64";
-#else
-constexpr auto&& ARCH = ".x64";
-#endif // NDEBUG
-#else
-#ifndef NDEBUG
-constexpr auto&& ARCH = "_D.x86";
-#else
-constexpr auto&& ARCH = ".x86";
-#endif // NDEBUG
-#endif // _WIN64
-
-constexpr auto&& DLL = ".dll";
-
-#else
-
-#if __x86_64__
+#if _WIN64 || __x86_64__
 #ifndef NDEBUG
 constexpr auto&& ARCH = "_D.x64";
 #else
@@ -60,8 +40,10 @@ constexpr auto&& ARCH = ".x86";
 #endif // NDEBUG
 #endif // __x86_64__
 
+#if _WIN32
+constexpr auto&& DLL = ".dll";
+#else
 constexpr auto&& DLL = ".so";
-
 using HMODULE = void*;
 static HMODULE LoadLibrary(const char* fp) {
 	HMODULE out = dlopen(fp, RTLD_NOW);
@@ -73,7 +55,6 @@ static HMODULE LoadLibrary(const char* fp) {
 }
 static void* GetProcAddress(HMODULE h, const char* name) { return dlsym(h, name); }
 static void FreeLibrary(HMODULE h) { dlclose(h);}
-
 #endif // _WIN32
 
 // TODO

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -578,19 +578,20 @@ int main(int argc, char** argv) {
 		}
 	}
 
-	if (gs.config.network.lr2ir == 1 && gs.is_starter == 0 && gs.cmd_nosave == 0) {
+	if (gs.is_starter == 0 && gs.cmd_nosave == 0) {
 		gs.net.IR_pass = gs.config.player.pass;
 		gs.net.IR_name = gs.config.player.id;
 		gs.net.IR_passMD5 = MD5str(gs.config.player.pass);
 		gs.net.getRival = gs.config.network.getRival;
 		gs.net.IR_ID = gs.gameplay.playerstat.irid;
-		if (gs.net.LR2IR_Login(gs.cmd_directplay) == 1) {
-			SaveIRID(gs.net.rankingData.myID, gs.config.player.id);
-		} else {
-			gs.net.rankingData.myID = gs.net.IR_ID;
+		gs.net.rankingData.myID = gs.net.IR_ID;
+		if (gs.config.network.lr2ir == 1) {
+			if (gs.net.LR2IR_Login(gs.cmd_directplay) == 1) {
+				SaveIRID(gs.net.rankingData.myID, gs.config.player.id);
+			}
+			printfDx(gs.net.request_result);
+			ErrorLogAdd(gs.net.request_result);
 		}
-		printfDx(gs.net.request_result);
-		ErrorLogAdd(gs.net.request_result);
 	}
 
 	memcpy(gs.config.jukebox.rival, gs.net.rivals, 4 * 20);

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1112,16 +1112,12 @@ int CmdSearch(game *g, CSTR *cmd, sqlite3 *sql) {
 
 	if (cmd->isSame("/hash")) {
 		*cmd = g->sSelect.bmsList[g->sSelect.cur_song].hash;
-#ifdef _WIN32
 		SetClipboardText(g->sSelect.bmsList[g->sSelect.cur_song].hash);
-#endif // _WIN32
 		return 1;
 	}
 	else if (cmd->isSame("/path")) {
 		*cmd = g->sSelect.bmsList[g->sSelect.cur_song].filepath;
-#ifdef _WIN32
 		SetClipboardText(g->sSelect.bmsList[g->sSelect.cur_song].filepath);
-#endif // _WIN32
 		return 1;
 	}
 	else if (cmd->isSame("/avi")) {

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1580,7 +1580,7 @@ static void ThreadProc_RankingAutoUpdate(game* g) {
 			g->net.ParseRankingXml(path);
 		}
 
-		if (g->net.rankingData.rankingCount > 0) {
+		if (g->net.rankingData.rankingCount > 0 && hash.isSame(g->sSelect.bmsList[g->sSelect.cur_song].hash)) {
 			g->sSelect.bmsList[g->sSelect.cur_song].mybest.IRranking = g->net.rankingData.myRanking;
 			g->sSelect.bmsList[g->sSelect.cur_song].mybest.IRplayercount = g->net.rankingData.rankingCount;
 			g->sSelect.bmsList[g->sSelect.cur_song].mybest.IRclearRate = (g->net.rankingData.clearPlayers[2] + g->net.rankingData.clearPlayers[3] + g->net.rankingData.clearPlayers[4] + g->net.rankingData.clearPlayers[5]) * 100 / g->net.rankingData.rankingCount;


### PR DESCRIPTION
And a little #ifdef _WIN32 refactor. See commit messages for details.