### PR TITLE
fix(bmsload): pump ProcessMessage while waiting for async BGA

### DIFF
--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -325,14 +325,6 @@ int ReleaseBGA(game *g){
 	return 1;
 }
 
-void ProcLoadBmsResource(game *g) {
-	g->gameplay.bmsResourceLoaded = 0;
-	g->gameplay.flag_closingPhase = 0;
-	LoadBmsResource(&g->gameplay, g->sSelect.metaSelected.filepath, &g->audio, &g->config, &g->sSelect.metaSelected, g->skstruct.flag_BGA, g->skstruct.flag_flip, 0, false);
-	g->gameplay.bmsResourceLoaded = 1;
-}
-
-
 bool isVisibleNote(int ch){
 	if (CHANNEL_1P_NOTE_SC <= ch && ch <= CHANNEL_2P_NOTE_END) {
 		return true;

--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -328,7 +328,7 @@ int ReleaseBGA(game *g){
 void ProcLoadBmsResource(game *g) {
 	g->gameplay.bmsResourceLoaded = 0;
 	g->gameplay.flag_closingPhase = 0;
-	LoadBmsResource(&g->gameplay, g->sSelect.metaSelected.filepath, &g->audio, &g->config, &g->sSelect.metaSelected, g->skstruct.flag_BGA, g->skstruct.flag_flip, 0);
+	LoadBmsResource(&g->gameplay, g->sSelect.metaSelected.filepath, &g->audio, &g->config, &g->sSelect.metaSelected, g->skstruct.flag_BGA, g->skstruct.flag_flip, 0, false);
 	g->gameplay.bmsResourceLoaded = 1;
 }
 
@@ -656,7 +656,7 @@ int InitGameplay(gameplay *gp, CONFIG_PLAY *cfg) {
 	return 1;
 }
 
-int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct *cfg, BMSMETA */*meta*/, char /*bga*/, char /*flip*/, char noVideo){
+int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct *cfg, BMSMETA */*meta*/, char /*bga*/, char /*flip*/, char noVideo, bool isMainThread){
 
 	int Rtmp, Gtmp, Btmp;
 
@@ -720,13 +720,14 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 		gp->loadObject_loaded = gp->loadObject_total;
 		return 1;
 	}
-	
-	// Add async load functions from DxLib: SetUseASyncLoadFlag, CheckHandleASyncLoad
-	// We are on a non-main thread here, but graphics APIs, DirectX normally and OpenGL with dxlib-for-linux, require
-	// resources to be loaded from the main thread. 
-	// The async calls will make DxLib do it itself on the main thread.
-	// This fixes crashes in DX11 and fixes BGAs not displaying with dxlib-for-linux.
-	if (cfg->system.isablebmsthread == 0) {
+
+	// Use DxLib's async load methods when not on the main thread.
+	// Needed because graphics APIs, DirectX normally and OpenGL with dxlib-for-linux, require resources to be
+	// loaded from the main thread.
+	// These async methods will make DxLib delay uploading resources to the GPU until we call ProcessMessage, which
+	// we do on the main thread.
+	// Fixes crashes in DX11 and fixes BGAs not displaying with dxlib-for-linux.
+	if (!isMainThread) {
 #ifdef _WIN32
 		CoInitialize(NULL);
 #endif // _WIN32
@@ -746,13 +747,13 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 			}
 
 			// Count only after load finish. Only add if using synchronous load here
-			if (cfg->system.isablebmsthread != 0) {
+			if (isMainThread) {
 				gp->loadObject_loaded++;
 			}
 		}
 
 		if (gp->flag_closingPhase) {
-			if (cfg->system.isablebmsthread == 0) {
+			if (!isMainThread) {
 				SetUseASyncLoadFlag(FALSE);
 #ifdef _WIN32
 				CoUninitialize();
@@ -763,7 +764,7 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 	}
 
 	// Check and wait until the handles finished loading
-	if (cfg->system.isablebmsthread == 0) {
+	if (!isMainThread) {
 		std::unordered_map<int, bool> bgaHandleLoaded;	// to prevent count repeateadly
 		for (int i = 0; i < SLOTS; i++) {
 			if (gp->bgaHandle[i] != -1) {
@@ -806,7 +807,7 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 	}
 
 	SetTransColor(Rtmp, Gtmp, Btmp);
-	if (cfg->system.isablebmsthread == 0) {
+	if (!isMainThread) {
 		SetUseASyncLoadFlag(FALSE);
 #ifdef _WIN32
 		CoUninitialize();
@@ -4108,7 +4109,7 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 		}
 	}
 	if (cfg->system.isablebmsthread == 1 && gp->isPreviewLoad == 0) {
-		LoadBmsResource(gp, filename, aud, cfg, meta, bgaFlag, scratchSide, 0);
+		LoadBmsResource(gp, filename, aud, cfg, meta, bgaFlag, scratchSide, 0, true);
 	}
 	for (int i = 0; i < 5; i++) {
 		if (gp->fadeinSOUNDstart[i] <= 0 || gp->fadeinSOUNDend[i] <= 0) {

--- a/LR2/LR2_bmsload.h
+++ b/LR2/LR2_bmsload.h
@@ -12,7 +12,6 @@ int InitGameplay_retry(gameplay *gp, AUDIO *snd, game *g);
 // \param isMainThread when true, BGA loads synchronously (required on main thread). when false, uses DxLib async BGA
 // load so the main thread can pump completion (#263).
 int LoadBmsResource(gameplay *gp, CSTR BMSfilepath, AUDIO *aud, ConfigStruct *cfg, BMSMETA *meta, char bga, char flip, char noVideo, bool isMainThread);
-void ProcLoadBmsResource(game *g);
 
 int StopAllKeysound(game *g);
 int InitKeysound(game *g);

--- a/LR2/LR2_bmsload.h
+++ b/LR2/LR2_bmsload.h
@@ -9,8 +9,9 @@ int PlayerCheckAndSwap(gameplay * gp);
 int InitGameplay(gameplay *gp, CONFIG_PLAY *cfg);
 int InitGameplay_retry(gameplay *gp, AUDIO *snd, game *g);
 
-//resource
-int LoadBmsResource(gameplay *gp, CSTR BMSfilepath, AUDIO *aud, ConfigStruct *cfg, BMSMETA *meta, char bga, char flip, char noVideo);
+// \param isMainThread when true, BGA loads synchronously (required on main thread). when false, uses DxLib async BGA
+// load so the main thread can pump completion (#263).
+int LoadBmsResource(gameplay *gp, CSTR BMSfilepath, AUDIO *aud, ConfigStruct *cfg, BMSMETA *meta, char bga, char flip, char noVideo, bool isMainThread);
 void ProcLoadBmsResource(game *g);
 
 int StopAllKeysound(game *g);

--- a/LR2/Scene02_Songselect.cpp
+++ b/LR2/Scene02_Songselect.cpp
@@ -1697,7 +1697,7 @@ static void ThreadProc_LoadPreview(game *g) {
 	g->gameplay.isPreviewLoad = 1;
 	ParseBmsFile(&g->gameplay, g->gameplay.previewBMSfilepath, &g->audio, &g->config, &meta, 0, 0);
 	if (g->gameplay.flag_closingPhase == 0 && g->procSelecter == 2 && g->gameplay.previewStatus == 1) {
-		LoadBmsResource(&g->gameplay, g->gameplay.previewBMSfilepath, &g->audio, &g->config, &meta, 0, g->skstruct.flag_flip, 1);
+		LoadBmsResource(&g->gameplay, g->gameplay.previewBMSfilepath, &g->audio, &g->config, &meta, 0, g->skstruct.flag_flip, 1, false);
 	}
 
 	if (g->gameplay.flag_closingPhase == 0 && g->procSelecter == 2 && g->gameplay.previewStatus == 1) {

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1688,13 +1688,13 @@ void ProcGameThread(game *g) {
 	}
 
 	if (g->gameplay.flag_retry == 0 && g->config.system.isablebmsthread == 0) {
-		std::jthread(ProcLoadBmsResource, g).detach();
+		g->gameplay.bmsResourceLoaded = 0;
+		g->gameplay.flag_closingPhase = 0;
+		LoadBmsResource(&g->gameplay, g->sSelect.metaSelected.filepath, &g->audio, &g->config, &g->sSelect.metaSelected, g->skstruct.flag_BGA, g->skstruct.flag_flip, 0, false);
 	}
-	else {
-		g->gameplay.bmsResourceLoaded = 1;
-	}
+	g->gameplay.bmsResourceLoaded = 1;
 
-	while (GetTimeLapse(0, &g->timer1) < g->skstruct.loadstart + g->skstruct.loadend || g->gameplay.bmsResourceLoaded == 0) {
+	while (GetTimeLapse(0, &g->timer1) < g->skstruct.loadstart + g->skstruct.loadend) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(16));
 		if (g->gameplay.flag_closingPhase) {
 			g->gameplay.flag_threadExist = 0;

--- a/LR2/Scene07_Skinselect.cpp
+++ b/LR2/Scene07_Skinselect.cpp
@@ -350,7 +350,7 @@ int PlayPreviewSample(game *g) {
 			g->sSelect.metaSelected.keymode = 7;
 			InitGameplay(&g->gameplay, &tCfg.play);
 			ParseBmsFile(&g->gameplay, fs::make_preferred("LR2files/Config/sample_7.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
-			LoadBmsResource(&g->gameplay, fs::make_preferred("LR2files/Config/sample_7.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
+			LoadBmsResource(&g->gameplay, fs::make_preferred("LR2files/Config/sample_7.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0, true);
 			break;
 
 		case 1:
@@ -361,7 +361,7 @@ int PlayPreviewSample(game *g) {
 			g->sSelect.metaSelected.keymode = 5;
 			InitGameplay(&g->gameplay, &tCfg.play);
 			ParseBmsFile(&g->gameplay, fs::make_preferred("LR2files/Config/sample_5.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
-			LoadBmsResource(&g->gameplay, fs::make_preferred("LR2files/Config/sample_5.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
+			LoadBmsResource(&g->gameplay, fs::make_preferred("LR2files/Config/sample_5.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0, true);
 			break;
 
 		case 2:
@@ -369,7 +369,7 @@ int PlayPreviewSample(game *g) {
 			g->sSelect.metaSelected.keymode = 14;
 			InitGameplay(&g->gameplay, &tCfg.play);
 			ParseBmsFile(&g->gameplay, fs::make_preferred("LR2files/Config/sample_14.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
-			LoadBmsResource(&g->gameplay, fs::make_preferred("LR2files/Config/sample_14.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
+			LoadBmsResource(&g->gameplay, fs::make_preferred("LR2files/Config/sample_14.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0, true);
 			break;
 
 		case 3:
@@ -380,7 +380,7 @@ int PlayPreviewSample(game *g) {
 			g->sSelect.metaSelected.keymode = 10;
 			InitGameplay(&g->gameplay, &tCfg.play);
 			ParseBmsFile(&g->gameplay, fs::make_preferred("LR2files/Config/sample_10.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
-			LoadBmsResource(&g->gameplay, fs::make_preferred("LR2files/Config/sample_10.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
+			LoadBmsResource(&g->gameplay, fs::make_preferred("LR2files/Config/sample_10.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0, true);
 			break;
 
 		case 4:
@@ -388,7 +388,7 @@ int PlayPreviewSample(game *g) {
 			g->sSelect.metaSelected.keymode = 9;
 			InitGameplay(&g->gameplay, &tCfg.play);
 			ParseBmsFile(&g->gameplay, fs::make_preferred("LR2files/Config/sample_9.pms").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
-			LoadBmsResource(&g->gameplay, fs::make_preferred("LR2files/Config/sample_9.pms").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
+			LoadBmsResource(&g->gameplay, fs::make_preferred("LR2files/Config/sample_9.pms").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0, true);
 			break;
 
 		case 13:
@@ -399,7 +399,7 @@ int PlayPreviewSample(game *g) {
 			g->sSelect.metaSelected.keymode = 5;
 			InitGameplay(&g->gameplay, &tCfg.play);
 			ParseBmsFile(&g->gameplay, fs::make_preferred("LR2files/Config/sample_5.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide);
-			LoadBmsResource(&g->gameplay, fs::make_preferred("LR2files/Config/sample_5.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0);
+			LoadBmsResource(&g->gameplay, fs::make_preferred("LR2files/Config/sample_5.bme").data(), &g->audio, &tCfg, &g->sSelect.metaSelected, 1, scratchSide, 0, true);
 			break;
 	}
 


### PR DESCRIPTION
Skin select preview calls LoadBmsResource on the main thread; without pumping ProcessMessage the async BGA wait never completes and hangs.

Issue Log [Log.txt](https://github.com/user-attachments/files/30598661/Log.txt)
