### PR TITLE
perf(play): don't delay loading BMS resources on #LOADSTART

### DIFF
--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -771,6 +771,19 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 			}
 		}
 		while (true) {
+			if (gp->flag_closingPhase) {
+				for (auto& [i, _loaded] : bgaHandleLoaded) {
+					// NOTE: SetASyncLoadFinishDeleteFlag is the same as DeleteGraph for already loaded images
+					SetASyncLoadFinishDeleteFlag(gp->bgaHandle[i]);
+					gp->bgaHandle[i] = -1;
+				}
+				SetUseASyncLoadFlag(FALSE);
+#ifdef _WIN32
+				CoUninitialize();
+#endif // _WIN32
+				return 1;
+			}
+
 			bool anyLoading = false;
 			for (auto& [i, loaded] : bgaHandleLoaded) {
 				if (loaded) continue;

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1679,7 +1679,7 @@ void ProcGameThread(game *g) {
 	g->gameplay.flag_threadExist = 1;
 	g->gameplay.flag_closingPhase = 0;
 	
-	while (g->procPhase == 0 || GetTimeLapse(0,&g->timer1) < g->skstruct.loadstart) {
+	while (g->procPhase == 0) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(16));
 		if (g->gameplay.flag_closingPhase) {
 			g->gameplay.flag_threadExist = 0;

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -918,6 +918,7 @@ struct skstruct {
 	int startinput_rank{};
 	int startinput_update{};
 	int scenetime{};
+	// In LR2 it used to actually delay loading resources, but in OpenLR2 it's only used for animations.
 	int loadstart{};
 	int loadend{};
 	int playstart{};


### PR DESCRIPTION
Please, see commit messages for details.