### PR TITLE
Add opcode(274, 275) to check lanecover status

### DIFF
--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -943,6 +943,17 @@ bool GetOptionFlag_dst(game *gs, int option) {
 			}
 			break;
 
+		case 274: // Extension: is lanecoverP1 enabled
+			if (gs->procSelecter == 4) {
+				if (gs->gameplay.lanecoverDisplayP1) return ret;
+			}
+			break;
+		case 275: // Extension: is lanecoverP2 enabled
+			if (gs->procSelecter == 4) {
+				if (gs->gameplay.lanecoverDisplayP2) return ret;
+			}
+			break;
+
 		case 280:
 			if ((gs->gameplay.courseStageNow != gs->gameplay.courseStageCount - 1) && gs->gameplay.courseStageNow == 0 && gs->gameplay.courseStageCount > 0) return ret;
 			break;

--- a/new_command(skin).md
+++ b/new_command(skin).md
@@ -36,6 +36,16 @@ Imported score displayed
 
 Also active while Start/Select is held and lift is on (same timing as Sudden+ value display). Shows the lift value HUD when lift is enabled.
 
+### `274`
+* 260817
+
+is 1P lanecover enabled
+
+### `275`
+* 260817
+
+is 2P lanecover enabled
+
 ## bargraph_type
 ### `48` (from LR2 with Fast/Slow)
 * 260624


### PR DESCRIPTION
This PR adds opcodes 274 and 275 to check the current status of Lanecover (Sudden).
implemented while adding the Lift feature to skins.

### Background / Motivation
1. To adjust the Lift, lanecover must be turned off.
2. However, when pressing `START/SELECT` to adjust Lift while lanecover is off, the lanecover value is still rendered on screen (if skin renders lanecover value, [video](https://youtu.be/1Rdtvlr7YlA?t=11)).
3. To prevent rendering the lanecover value when lanecover is inactive, an opcode was needed to query whether lanecover is currently enabled. Since I couldn't find an existing opcode for this, I implemented opcodes 274 and 275.
4. Separating opcode 270 into two distinct opcodes for lanecover and Lift could be another option, but I chose this method to offer better compatibility for skin creators who may want to display both values simultaneously.

<img width="722" height="288" alt="image" src="https://github.com/user-attachments/assets/c26f1b5f-1134-4831-ac22-682d7116bc7c" />

Opcodes 274(p1) and 275(p2) were selected based on the unofficial LR2 skin documentation, where the Lunatic Vibes project uses these opcode numbers for similar functionality.
However, since I haven't inspected the actual source code, I cannot guarantee that the internal implementation is identical.

Because of this, I'm still considering whether it would be better to assign different opcode numbers, and how to properly write the extension comments.