### PR TITLE
fix: correct G-Battle replay recording and playback

### DIFF
--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -2119,7 +2119,6 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 
 	oldSpeedMultiplier = gp->freqSpeedMultiplier;
 
-	//TOFIX : seed is not putted into replaydata, when use ghostbattle. (retry puts seed) (see also ProcS_Play())
 	//TOFIX: 0 is a valid seed. Note that LR2IR also returned randomseed=0 on missing ghosts.
 	if (gp->randomseed != 0) {
 		ErrorLogFmtAdd("RANDSEEDを引き継ぎます\n");
@@ -2140,9 +2139,9 @@ int ParseBmsFile(gameplay *gp, CSTR filename, AUDIO *aud, ConfigStruct* cfg, BMS
 		if (gp->randomseed == 0xFFFF) {
 			gp->randomseed = GetRand(0x7ffe);
 		}
-		if (gp->replay.status == 1) {
-			AddReplayData(&gp->replay, 0, 200, (short)gp->randomseed);
-		}
+	}
+	if (gp->replay.status == 1) {
+		AddReplayData(&gp->replay, 0, 200, static_cast<short>(gp->randomseed));
 	}
 	ErrorLogFmtAdd("RANDOMSEEDは%dです。\n", gp->randomseed);
 	SRand(gp->randomseed);

--- a/LR2/LR2_customir.cpp
+++ b/LR2/LR2_customir.cpp
@@ -526,7 +526,8 @@ IRScoreInternal::IRScoreInternal(game& game, sqlite3* sql, int _player, std::str
 		song.courseType = curSong.courseType;
 		songPlayLevel = curSong.level;
 	}
-	CONFIG_PLAY& cfg = game.config.play;
+	gameplay& gameplay = game.gameplay;
+	const CONFIG_PLAY& cfg = gameplay.actualPlayConfigCopyForResultIr ? *gameplay.actualPlayConfigCopyForResultIr : game.config.play;
 	settings.gaugeType = cfg.gaugeType[_player];
 	settings.random[PLAYER_1] = cfg.random[PLAYER_1];
 	settings.random[PLAYER_2] = cfg.random[PLAYER_2];
@@ -563,7 +564,6 @@ IRScoreInternal::IRScoreInternal(game& game, sqlite3* sql, int _player, std::str
 	settings.gomiscore = cfg.gomiscore;
 	settings.disableCurSpeedChange = cfg.disableCurSpeedChange;
 
-	gameplay& gameplay = game.gameplay;
 	state.player = _player;
 	state.keymode = gameplay.keymode;
 	state.randomseed = gameplay.randomseed;
@@ -675,12 +675,14 @@ static std::optional<openlr2::IRRankResult> ResultIrAsync(std::shared_ptr<Custom
 }
 void CUSTOMIR_MANAGER::BeginResultIr(game& game, sqlite3* sql, int player, std::string ghost) {
 	if (mModules.empty()) {
+		game.gameplay.actualPlayConfigCopyForResultIr.reset();
 		return;
 	}
 
 	IRScoreInternal internal{ game, sql, player, std::move(ghost) };
 	IRScoreV1 scoreV1;
 	internal.MakeScoreV1(scoreV1);
+	game.gameplay.actualPlayConfigCopyForResultIr.reset();
 
 	SendScoreMultiplexed(
 			mSendThreads, scoreV1,

--- a/LR2/LR2_statplay.cpp
+++ b/LR2/LR2_statplay.cpp
@@ -575,6 +575,9 @@ int SaveResult(game *g, sqlite3* sql) {
 	g->gameplay.player[PLAYER_1].lastCourseGaugeType = g->gameplay.player[PLAYER_1].gaugeType; // If you finish a course stage with exscore 0, this code won't run and you may start the next stage with same gauge as one displayed on result... First hit note will reset it back to normal.
 
 	if (g->gameplay.isAutoplay) return -1;
+	if (g->gameplay.ghostBattle) {
+		g->gameplay.actualPlayConfigCopyForResultIr = g->config.play;
+	}
 
 	if (g->config.play.m_gas && g->gameplay.replay.status != 2) {
 		g->gameplay.player[PLAYER_1].gaugeType = GetBestClearedGauge(g->gameplay, 0, g->config.play, g->gameplay.courseStageNow != 0);

--- a/LR2/Main.cpp
+++ b/LR2/Main.cpp
@@ -1174,7 +1174,6 @@ int main(int argc, char** argv) {
 					if (gs.gameplay.replay.status == 2 || gs.config.play.replay == 0) {
 						if (gs.gameplay.replay.status == 1) {
 							AllocReplayBuffer(&gs.gameplay.replay);
-							//TOFIX : replay option mismatch, when use ghostbattle. ProcS_Play()->GetTargetInfo() changes option (gauge, random)
 							AddReplayDataHeader(&gs.config.play, &gs.gameplay.replay, &gs.audio, &gs.gameplay);
 						}
 						else if (gs.gameplay.replay.status == 2) {
@@ -1192,7 +1191,6 @@ int main(int argc, char** argv) {
 					else {
 						gs.gameplay.replay.status = 1;
 						AllocReplayBuffer(&gs.gameplay.replay);
-						//TOFIX : replay option mismatch, when use ghostbattle. ProcS_Play()->GetTargetInfo() changes option (gauge, random)
 						AddReplayDataHeader(&gs.config.play, &gs.gameplay.replay, &gs.audio, &gs.gameplay);
 					}
 					if (gs.gameplay.ghostBattle == 1) {

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1853,7 +1853,7 @@ int ProcS_Play(game *g, sqlite3* sql) {
 			g->config.play.gaugeType[PLAYER_2] = g->config.play.gaugeType[PLAYER_1];
 			g->config.play.random[PLAYER_2] = g->config.play.random[PLAYER_1];
 
-			if (g->config.play.m_gas && !g->gameplay.isAutoplay) {
+			if (!g->gameplay.isAutoplay) {
 				g->config.play.gaugeType[PLAYER_1] = origGauge;
 			}
 		}

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -1841,7 +1841,6 @@ int ProcS_Play(game *g, sqlite3* sql) {
 		}
 		else {
 			int origGauge = g->config.play.gaugeType[PLAYER_1];
-			//TOFIX : seed is not putted into replaydata, when use ghostbattle. (retry puts seed) (see also ParseBmsFile())
 			if(g->sSelect.bmsList[g->sSelect.cur_song].keymode > 9) {
 				int iDpFlipTemp{};
 				// TODO: make GetTargetInfo take a bool for dp flip
@@ -1857,6 +1856,12 @@ int ProcS_Play(game *g, sqlite3* sql) {
 			if (g->config.play.m_gas && !g->gameplay.isAutoplay) {
 				g->config.play.gaugeType[PLAYER_1] = origGauge;
 			}
+		}
+		 // if g-battle is on, target_id is valid and replay is "recording", save the options to player 1
+		if (g->gameplay.ghostBattle && g->gameplay.replay.status == 1) {
+			OverwriteReplayData(&g->gameplay.replay, 0, 0x65, static_cast<short>(g->config.play.gaugeType[PLAYER_1]));
+			OverwriteReplayData(&g->gameplay.replay, 0, 0x67, static_cast<short>(g->config.play.random[PLAYER_1]));
+			OverwriteReplayData(&g->gameplay.replay, 0, 0xc9, static_cast<short>(OPTION_BATTLE_OFF));
 		}
 	}
 

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1477,6 +1477,8 @@ struct gameplay {
 	int bpmChangedBmstime; /* bpm change timing */
 	char ghostBattle;
 	std::optional<CONFIG_PLAY> playConfigBackupBeforeTargetSomething;
+	// Play config including temporary options such as those for g-battle
+	std::optional<CONFIG_PLAY> actualPlayConfigCopyForResultIr;
 	int delayDetectedCount;
 	int delayCheckCount;
 	char isCourse; 


### PR DESCRIPTION
## Summary

Related to #219 

G-Battle replays are intended to capture the current player's gameplay as a solo play, using the target chart's seed.

## Known problems

Previously, the replay could store an incorrect seed (the known one), ghost input, and `G-BATTLE` in its header (shown on the video below), causing incorrect notes during playback or the gameplay to initialize twice.

Video showing the actual problem (video is too big): https://gofile.io/d/DCED359x

## What does this fix

- Preserves the generated RANDSEED in recorded replays.
- Records only Player 1 input and judgments during G-Battle.
- Saves Player 1's gauge and random options in the replay header.
- Stores `BATTLE_OFF` so new G-Battle replays are played back as solo play.

Tested with regular Battle, G-Battle, retries, and different gauge settings.

Existing replays are still compatible.
