### PR TITLE
Fix DP Fast/Slow and hit offset display

### DIFF
--- a/LR2/LR2_bmsload.cpp
+++ b/LR2/LR2_bmsload.cpp
@@ -454,6 +454,8 @@ int PlayerCheckAndSwap(gameplay *gp){
 int InitGameplay(gameplay *gp, CONFIG_PLAY *cfg) {
 
 	PlayerCheckAndSwap(gp);
+	gp->lastFastSlowBySide.fill(0);
+	gp->lastHitOffsetBySide.fill(0);
 	gp->bpmt_start = 1;
 	gp->isPreviewLoad = 0;
 	if (gp->bmsobj.count == 0) InitNoteBuffer(&gp->bmsobj, 1000);
@@ -852,6 +854,8 @@ int LoadBmsResource(gameplay *gp, CSTR /*BMSfilepath*/, AUDIO *aud, ConfigStruct
 int InitGameplay_retry(gameplay *gp, AUDIO *snd, game *g) {
 	
 	PlayerCheckAndSwap(gp);
+	gp->lastFastSlowBySide.fill(0);
+	gp->lastHitOffsetBySide.fill(0);
 	if (gp->replay.status != 2 && gp->replay.status == 1) {
 		AddReplayData(&gp->replay, 0, 200, gp->randomseed);
 	}

--- a/LR2/LR2_skinobject.cpp
+++ b/LR2/LR2_skinobject.cpp
@@ -2068,18 +2068,18 @@ uint SetObjectValue_Num(game *g, int op) {
 			return g->net.rankingData.rankingCount;
 		case 201:
 			if (g->procSelecter == 4) { // Extension: fast-slow
-				return g->gameplay.player[PLAYER_1].extendedStats.lastHitOffset;
+				return g->gameplay.lastHitOffsetBySide[PLAYER_1];
 			}
 			return g->net.rankingData.totalPlaycount;
 
 		case 210:
 			if (g->procSelecter == 4) { // Extension: fast-slow
-				return g->gameplay.player[PLAYER_1].extendedStats.lastFastSlow;
+				return g->gameplay.lastFastSlowBySide[PLAYER_1];
 			}
 			return g->net.rankingData.clearPlayers[1];
 		case 211:
 			if (g->procSelecter == 4) { // Extension: fast-slow
-				return g->gameplay.player[PLAYER_2].extendedStats.lastFastSlow;
+				return g->gameplay.lastFastSlowBySide[PLAYER_2];
 			}
 			if (g->net.rankingData.rankingCount != 0) {
 				return (g->net.rankingData.clearPlayers[1] * 100) / g->net.rankingData.rankingCount;
@@ -2095,7 +2095,7 @@ uint SetObjectValue_Num(game *g, int op) {
 			return g->net.rankingData.clearPlayers[2];
 		case 213:
 			if (g->procSelecter == 4) { // Extension: fast-slow
-				return g->gameplay.player[PLAYER_2].extendedStats.lastHitOffset;
+				return g->gameplay.lastHitOffsetBySide[PLAYER_2];
 			}
 			if (g->net.rankingData.rankingCount != 0) {
 				return (g->net.rankingData.clearPlayers[2] * 100) / g->net.rankingData.rankingCount;

--- a/LR2/Scene04_Play.cpp
+++ b/LR2/Scene04_Play.cpp
@@ -738,6 +738,19 @@ int JudgeToScore(int judge, game *g, int player, int lane, char isReplay) {
 	return ApplyJudgeNote(judge, g, player, lane, &g->timer1, isReplay);
 }
 
+
+static void UpdateLastFastSlowBySide(game* g, int player, int lane) {
+	// In DP, both sides belong to PLAYER_1, so use the lane to determine the display side.
+	const int side = (lane >= 10) ? PLAYER_2 : PLAYER_1;
+	g->gameplay.lastFastSlowBySide[side] = g->gameplay.player[player].extendedColumnStats[lane].lastFastSlow;
+}
+
+static void UpdateLastHitOffsetBySide(game* g, int player, int lane) {
+	// In DP, both sides belong to PLAYER_1, so use the lane to determine the display side.
+	const int side = (lane >= 10) ? PLAYER_2 : PLAYER_1;
+	g->gameplay.lastHitOffsetBySide[side] = g->gameplay.player[player].extendedColumnStats[lane].lastHitOffset;
+}
+
 int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 	NoteStruct &note = g->gameplay.bmsobj_note[lane].notes[g->gameplay.bmsobj_note[lane].note_count];
 	EXTENDEDPLAYERSTATS& extendedStats = g->gameplay.player[player].extendedStats;
@@ -786,6 +799,7 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedColumnStats);
 			increment_extended(extendedStatsCourse);
 			increment_extended(extendedColumnStatsCourse);
+			UpdateLastFastSlowBySide(g, player, lane);
 			return 0;
 		}
 		if (keypress != 1) return 0;
@@ -813,6 +827,8 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedColumnStats, isFast, offset);
 			increment_extended(extendedStatsCourse, isFast, offset);
 			increment_extended(extendedColumnStatsCourse, isFast, offset);
+			UpdateLastFastSlowBySide(g, player, lane);
+			UpdateLastHitOffsetBySide(g, player, lane);
 			lastOffsetColumnIdx = lane;
 			return 1;
 		}
@@ -836,6 +852,8 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedColumnStats, isFast, offset);
 			increment_extended(extendedStatsCourse, isFast, offset);
 			increment_extended(extendedColumnStatsCourse, isFast, offset);
+			UpdateLastFastSlowBySide(g, player, lane);
+			UpdateLastHitOffsetBySide(g, player, lane);
 			lastOffsetColumnIdx = lane;
 			return 1;
 		}
@@ -858,6 +876,8 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedColumnStats, isFast, offset);
 			increment_extended(extendedStatsCourse, isFast, offset);
 			increment_extended(extendedColumnStatsCourse, isFast, offset);
+			UpdateLastFastSlowBySide(g, player, lane);
+			UpdateLastHitOffsetBySide(g, player, lane);
 			lastOffsetColumnIdx = lane;
 			return 1;
 		}
@@ -883,6 +903,8 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedColumnStats, isFast, offset);
 			increment_extended(extendedStatsCourse, isFast, offset);
 			increment_extended(extendedColumnStatsCourse, isFast, offset);
+			UpdateLastFastSlowBySide(g, player, lane);
+			UpdateLastHitOffsetBySide(g, player, lane);
 			lastOffsetColumnIdx = lane;
 
 			if (g->gameplay.bmsobj_note[lane].note_count < g->gameplay.bmsobj_note[lane].size && abs(timing - (int)g->gameplay.bmsobj_note[lane].notes[g->gameplay.bmsobj_note[lane].note_count].realTiming) <= g->gameplay.player[player].judgetime[2]) {
@@ -903,6 +925,7 @@ int ProcSinglenote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedColumnStats);
 			increment_extended(extendedStatsCourse);
 			increment_extended(extendedColumnStatsCourse);
+			UpdateLastFastSlowBySide(g, player, lane);
 			return 1;
 		}
 
@@ -937,6 +960,7 @@ int ProcLongnote(game *g, int lane, int keypress, int timing, int player) {
 		increment_extended(extendedColumnStats);
 		increment_extended(extendedStatsCourse);
 		increment_extended(extendedColumnStatsCourse);
+		UpdateLastFastSlowBySide(g, player, lane);
 		return 0;
 	}
 
@@ -958,6 +982,8 @@ int ProcLongnote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedColumnStats, offset);
 			increment_extended(extendedStatsCourse, offset);
 			increment_extended(extendedColumnStatsCourse, offset);
+			UpdateLastFastSlowBySide(g, player, lane);
+			UpdateLastHitOffsetBySide(g, player, lane);
 			lastOffsetColumnIdx = lane;
 
 			SetTimeLapse(70 + lane, &g->timer1);
@@ -977,6 +1003,8 @@ int ProcLongnote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedColumnStats, offset, isFast);
 			increment_extended(extendedStatsCourse, offset, isFast);
 			increment_extended(extendedColumnStatsCourse, offset, isFast);
+			UpdateLastFastSlowBySide(g, player, lane);
+			UpdateLastHitOffsetBySide(g, player, lane);
 			lastOffsetColumnIdx = lane;
 
 			SetTimeLapse(70 + lane, &g->timer1);
@@ -996,6 +1024,8 @@ int ProcLongnote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedColumnStats, offset, isFast);
 			increment_extended(extendedStatsCourse, offset, isFast);
 			increment_extended(extendedColumnStatsCourse, offset, isFast);
+			UpdateLastFastSlowBySide(g, player, lane);
+			UpdateLastHitOffsetBySide(g, player, lane);
 			lastOffsetColumnIdx = lane;
 
 			SetTimeLapse(70 + lane, &g->timer1);
@@ -1015,6 +1045,8 @@ int ProcLongnote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedColumnStats, offset, isFast);
 			increment_extended(extendedStatsCourse, offset, isFast);
 			increment_extended(extendedColumnStatsCourse, offset, isFast);
+			UpdateLastFastSlowBySide(g, player, lane);
+			UpdateLastHitOffsetBySide(g, player, lane);
 			lastOffsetColumnIdx = lane;
 			return 1;
 		}
@@ -1030,6 +1062,7 @@ int ProcLongnote(game *g, int lane, int keypress, int timing, int player) {
 			increment_extended(extendedColumnStats);
 			increment_extended(extendedStatsCourse);
 			increment_extended(extendedColumnStatsCourse);
+			UpdateLastFastSlowBySide(g, player, lane);
 			return 1;
 		}
 

--- a/LR2/structure.h
+++ b/LR2/structure.h
@@ -1503,6 +1503,8 @@ struct gameplay {
 	CSTR previewBMShash;
 	CSTR previewBMSfilepath;
 	std::mutex criticalSection;
+	std::array<int, PLAYER_MAX> lastFastSlowBySide = {};
+	std::array<int, PLAYER_MAX> lastHitOffsetBySide = {};
 };
 
 struct SkinManage {


### PR DESCRIPTION
Fixes #250

Problem

In DP, OpenLR2 stores judgments from both play sides in PLAYER_1 extended stats. Skin numbers 210/201 therefore receive judgments from both sides, while 211/213 do not receive the correct 2P-side values.

Changes

Add separate Fast/Slow display state for each play side.
Add separate hit-offset display state for each play side.
Update the display state according to the judged lane.
Reset the added state when gameplay is initialized or Quick Restart is used.
Keep the existing empty-POOR / missed-POOR hit-offset behavior unchanged.

Tested

5KEY / 7KEY / 9KEY / 10KEY / 14KEY
SP / DP / SP-to-DP / DP-to-SP / PMS-to-SP
D-Battle / Battle
Normal notes / LN / scratch / simultaneous DP inputs
Replay
Quick Restart with random changed and preserved
Song and mode changes

1P and 2P Fast/Slow and hit-offset displays remained independent in all tested DP/Battle cases.